### PR TITLE
Fix doc for che-dir

### DIFF
--- a/src/main/pages/portable-workspaces/chedir-installation.md
+++ b/src/main/pages/portable-workspaces/chedir-installation.md
@@ -23,7 +23,7 @@ Chedir is provided as a Docker container which you can run instead of using the 
 ```shell  
 # Mac / Linux
 docker run -v /var/run/docker.sock:/var/run/docker.sock \
-           -v "$PWD":"$PWD" --rm eclipse/che-file \
+           -v "$PWD":"$PWD" --rm eclipse/che \ # should this be che-dir? che-file doesn't exist
            $PWD <init|up>
 
 # Windows
@@ -38,7 +38,8 @@ You can build Chedir Docker Container by using the following commands:
 ```shell  
 git clone http://github.com/eclipse/che-dockerfiles
 cd che-dockerfiles
-./lib/typescript/compile.sh && ./che-dir/build.sh\
+# ./lib/typescript/compile.sh # what does this do, and where is the script? it's not in the repo...
+./che-dir/build.sh
 ```
 
 ## Uninstallation  

--- a/src/main/pages/portable-workspaces/chedir-installation.md
+++ b/src/main/pages/portable-workspaces/chedir-installation.md
@@ -23,7 +23,7 @@ Chedir is provided as a Docker container which you can run instead of using the 
 ```shell  
 # Mac / Linux
 docker run -v /var/run/docker.sock:/var/run/docker.sock \
-           -v "$PWD":"$PWD" --rm eclipse/che \ # should this be che-dir? che-file doesn't exist
+           -v "$PWD":"$PWD" --rm eclipse/che-dir \
            $PWD <init|up>
 
 # Windows
@@ -36,10 +36,9 @@ docker run -v /var/run/docker.sock:/var/run/docker.sock \
 
 You can build Chedir Docker Container by using the following commands:
 ```shell  
-git clone http://github.com/eclipse/che-dockerfiles
-cd che-dockerfiles
-# ./lib/typescript/compile.sh # what does this do, and where is the script? it's not in the repo...
-./che-dir/build.sh
+git clone http://github.com/eclipse/che
+cd che/dockerfiles/dir
+./build.sh
 ```
 
 ## Uninstallation  


### PR DESCRIPTION
tweak portable-workspaces/chedir-installation.md - che-file doesn't exist, nor does the typescript/compile.sh script

Change-Id: I7ece549fd6515776ce76ca40dc0bb084ea9543c4
Signed-off-by: nickboldt <nboldt@redhat.com>