### PR TITLE
Can't start Che 6.4.1 w/ Docker 17.09, 17.12, or 18.04 from inside Fedora VM (virtual box image)

### DIFF
--- a/src/main/pages/setup-docker/docker-single-user.md
+++ b/src/main/pages/setup-docker/docker-single-user.md
@@ -9,7 +9,11 @@ folder: setup-docker
 
 ## Pre-Requisites
 
-* Docker 17+ recommended, ideally the [latest Docker version](http://docs.docker.com/engine/installation/). Even though Che may not have any issues with Docker 1.13+, all tests use Docker 17+.
+* Docker 17 recommended, ideally the [latest](https://www.docker.com/community-edition#/download) supported Docker version, [17.09](https://docs.docker.com/v17.09/). 
+
+Even though Che may not have any issues with newer versions or v1.13, all tests use Docker 17. 
+
+See also [Docker Install Guide](http://docs.docker.com/engine/installation/).
 
 ```bash
 wget -qO- https://get.docker.com/ | sh


### PR DESCRIPTION
document the fact that Docker 18 is not supported, and 17.09 is the recommended version to use; fix links

Change-Id: Id0bb3dbe07a9cd5a5417123772e6f624d2967866
Signed-off-by: nickboldt <nboldt@redhat.com>