### PR TITLE
Updated docs for jdt.ls integration

### DIFF
--- a/src/main/pages/overview/introduction.adoc
+++ b/src/main/pages/overview/introduction.adoc
@@ -106,7 +106,7 @@ Che is a workspace server that runs on top of an application server like Tomcat.
 
 As a user interacts with the Web application, they will create workspaces, projects, environments, machines, and other artifacts necessary to code and debug a project. The IDE communicates with Che over RESTful APIs that manage and interact with a Workspace Master.
 
-The Che server controls the lifecycle of workspaces. Workspaces are isolated spaces where developers can work. Che injects various services into each workspace, including the projects, source code, Che plug-ins, SSH daemon, and language services such as JDT core Intellisense to provide refactoring for Java language projects. The workspace also contains a synchronizer which, depending upon whether the workspace is running locally or remotely, is responsible for synchronizing project files from within the machine with Che long term storage.
+The Che server controls the lifecycle of workspaces. Workspaces are isolated spaces where developers can work. Che injects various services into each workspace, including the projects, source code, Che plug-ins, SSH daemon, and language services such as Eclipse JDT.LS Intellisense to provide refactoring for Java language projects. The workspace also contains a synchronizer which, depending upon whether the workspace is running locally or remotely, is responsible for synchronizing project files from within the machine with Che long term storage.
 
 [id="extensibility"]
 == Extensibility
@@ -117,10 +117,10 @@ There are a number of aspects that can be modified within Che.
 
 [width="100%",cols="50%,50%",options="header",]
 |===
-|Type |Description
-|IDE Extension |Modify the look-and-feel, panels, editors, wizards, menus, toolbars, and pop-up boxes of the client. IDE extensions are authored in Java and transpiled into a JavaScript Web application that is hosted on the Che server as a WAR file.
-|Che Server Extension (aka, Worskspace Master) |Add or modify the core APIs that run within the Che server for managing workspaces, environments and machines. Workspace extensions are authored in Java and packaged as JAR files.
-|Workspace Extension (aka, Workspace Agent) |Create or modify project-specific extensions that run within a workspace machine and have local access to project files. Define machine behaviors, code templates, command instructions, scaffolding commands, and intellisense. The Che Java extension is authored as a workspace agent extension, deployed into the machine, and runs JDT core services from Eclipse to do local intellisense operations against the remote workspace.
+| Type   | Description
+| IDE Extension   | Modify the look-and-feel, panels, editors, wizards, menus, toolbars, and pop-up boxes of the client. IDE extensions are authored in Java and transpiled into a JavaScript Web application that is hosted on the Che server as a WAR file.
+| Che Server Extension  (aka, Worskspace Master)   | Add or modify the core APIs that run within the Che server for managing workspaces, environments and machines. Workspace extensions are authored in Java and packaged as JAR files.
+| Workspace Extension  (aka, Workspace Agent)   | Create or modify project-specific extensions that run within a workspace machine and have local access to project files. Define machine behaviors, code templates, command instructions, scaffolding commands, and intellisense. The Che Java extension is authored as a workspace agent extension, deployed into the machine, and runs Eclipse JDT.LS services to do local intellisense operations against the remote workspace.
 |===
 
 Each extension type is packaged separately because they are deployed differently into the assembly. IDE extensions are transpiled using GWT to generate a cross-browser JavaScript. This application is packaged as a WAR file and hosted on the Che server.

--- a/src/main/pages/user-guide/dependency-management.md
+++ b/src/main/pages/user-guide/dependency-management.md
@@ -1,0 +1,25 @@
+---
+title: "Dependency Management"
+keywords: workspace, runtime, project, projects, dependency management, maven, gradle
+tags: [workspace, runtime]
+sidebar: user_sidebar
+permalink: dependency-management.html
+folder: user-guide
+---
+
+{% include links.html %}
+
+
+## Maven
+
+Maven is natively supported by JDT.LS
+
+You can forcefully update dependencies for a Maven project by calling context menu > **Maven > Reimport**.
+
+## Gradle
+
+Gradle is natively supported by JDT.LS.
+
+## NPM
+
+There's no plugin for Che that will automatically run npm install for JS projects. You can, however, author a [custom command][commands-ide-macro] to install dependencies.

--- a/src/main/pages/user-guide/editor_code_assistance.adoc
+++ b/src/main/pages/user-guide/editor_code_assistance.adoc
@@ -23,14 +23,14 @@ Syntax highlighting is provided by Orion editor out of the box. For some file ty
 
 At this moment, code assistance (including error marking, quick fixes, refactoring, go to definition, javadoc etc) for *Java* is provided by Java plugin that wraps JDT. This will change though, once https://github.com/eclipse/che/issues/6157[JDT.LS] implementation is finalized.
 
-Code assistance for *JavaScript* is provided by Orion editor itself.
+Code assistance for **JavaScript** is provided by Orion editor itself.
 
-Code assistance for other languages is provided by link:language-servers.html[Language Servers]. Eclipse Che supports code assistance for C#, PHP, Python, TypeScript, YAML and JSON. There are plans to add a language servers for Golang.
+Code assistance for other languages is provided by [Language Servers][language-servers]. Eclipse Che supports code assistance for Java, C#, PHP, Python, TypeScript, YAML and JSON. There are plans to add a language servers for Golang.
 
 [id="editor-settings"]
 == Editor Settings
 
-Editor settings can be configured in the Che IDE under `Profile > Preferences > IDE > Editor`. Preferences can change key bindings, tabbing rules, language tools, whitespace and ruler preferences. All the preferences are saved per user. Note that in some cases the editor will need to be refreshed for the new settings to be applied.
+Editor settings can be configured in the Che IDE under `Profile > Preferences > IDE > Editor`. Preferences can change key bindings, tabbing rules, language tools, whitespace and ruler preferences. Note that in some cases the editor will need to be refreshed for the new settings to be applied.
 
 You can edit your files as you would in any other editor (you can even switch to vi or emacs keybindings in `Profile > Preferences`).
 


### PR DESCRIPTION
Signed-off-by: jpinkney <josh.pinkney@mail.utoronto.ca>

Updated documentation for jdt.ls integration in all applicable places (that I could find)

*Shouldn't be merged until 5730_java_ls_poc branch is merged in master to avoid confusion*
Compantion PR: https://github.com/eclipse/che/pull/10863