### PR TITLE
Update documentation in admin guide for Openshift/Kubernetes

### DIFF
--- a/src/main/pages/overview/single-multi-user.md
+++ b/src/main/pages/overview/single-multi-user.md
@@ -17,7 +17,7 @@ If you plan using Che just on your local machine or just evaluate the platform, 
 **Single User Che Pros:**
 
 * The CLI will pull fewer Images
-* You will faster get to User Dashboard (no login)
+* You will get to the User Dashboard more quickly (no login)
 
 **Multi-User Che Pros**
 

--- a/src/main/pages/setup-openshift/openshift-single-user.md
+++ b/src/main/pages/setup-openshift/openshift-single-user.md
@@ -54,7 +54,6 @@ If Minishift is already started and Che addon is installed, it is possible to de
 ```bash
 $ minishift addons apply \
     --addon-env CHE_DOCKER_IMAGE=eclipse/che-server:nightly \
-    --addon-env OPENSHIFT_TOKEN=$(oc whoami -t) \
     che
 ```
 
@@ -71,7 +70,6 @@ If the local image is based on Che v6:
 ```bash
 $ minishift addons apply \
     --addon-env CHE_DOCKER_IMAGE=eclipse/che-server:local \
-    --addon-env OPENSHIFT_TOKEN=$(oc whoami -t) \
     che
 ```
 
@@ -85,7 +83,6 @@ To customize the deployment of the Che server, the following variables can be ap
 |`CHE_DOCKER_IMAGE`|The docker image to be used for che.|`eclipse/che-server:latest`|
 |`GITHUB_CLIENT_ID`|GitHub client ID to be used in Che workspaces|`changeme`|
 |`GITHUB_CLIENT_SECRET`|GitHub client secred to be used in Che workspaces|`changeme`|
-|`OPENSHIFT_TOKEN`| Token to create workspace resources (pods, services, routes, etc...)|`changeme`|
 
 Variables can be specified by adding `--addon-env <key=value>` when the addon is being invoked (either by `minishift start` or `minishift addons apply`).
 


### PR DESCRIPTION
## What does this PR do?

Update documentation to support changes for issue https://github.com/eclipse/che/issues/9961. In particular, remove references to properties 
- `che.infra.kubernetes.username`
- `che.infra.kubernetes.password`
- `che.infra.kubernetes.oauth_token`

and simplify documentation around setting up Che on Openshift/Kubernetes
