### PR TITLE
Create page about Che Databases

### DIFF
--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -41,18 +41,25 @@ As in Java code, and TCK it is expected, a custom ExceptionHandler implementaion
 For example, in H2 and PostgreSQL, an exception may occur, when data couldn't be updated/stored due to unique constrain violation.
 But as it will a vendor specific exception with different code, there are Custom `H2ExceptionHandler`/`PostgreSqlExceptionHandler` that will catch it, and throw instead a `DuplicateKeyException`, which is used across the codebase.
 
+*persistence.xml*
+//TODO add notes about persistence.xml and how properties can be dynamicaly added to it in WsMasterModule (depending on DB)
 
 [id="test-compatibility-kit"]
 == Test Compatibility Kit (TCK)
-Test Compatibility kit is a set of integration tests that covers uses of essential DAO components
+Test Compatibility kit is a set of integration tests that covers uses of essential DAO components, that are being run against real database.
 //TODO list with all TCK tests?
 
-*Creating own TCK module*
-//TODO describe creation and execution of TCK tests with DB in image (MySQL?)
+*Running TCK on a custom DB*
 
-- A module during which integration test will be executed
-module must provide all test dependencies 
-- A database provided in an Image and prepared to be used for TCK
+In order to run TCK for a custom database, a maven module should be created with following components:
+
+- a Guice module that extends `TckModule` which will be responsible for establishing connection with DataSource, binding all required implementations of JPA entities and repositories.
+- a file in src/test/resources/META-INF/services named `org.eclipse.che.commons.test.tck.TckModule`. In it, there must be defined a name of the mentioned TckModule implementaion.
+- include all dependency artifacts with TCK tests
+- include artifact with DB Driver
+- add persistence.xml file or use PersistTestModuleBuilder helper class to create one programmatically in `TckModule` implementation
+
+Use `maven-docker-plugin` to run database as a docker container with preconfigured database settings like DB username, password, port, etc.
 
 [id="cascade-removal-tests"]
 == JPA Cascade Removal Tests

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -30,10 +30,10 @@ These properties can be overriden with Che configuration Environment Variables:
 |CHE_JDBC_USERNAME |username
 |CHE_JDBC_PASSWORD	|password
 |CHE_JDBC_URL	|url
-|CHE_JDBC_DRIVER__CLASS__NAME	|driverClassName
+|CHE_JDBC_DRIVER\__CLASS__NAME	|driverClassName
 |CHE_JDBC_MAX__TOTAL	|maxTotal
 |CHE_JDBC_MAX__IDLE	|maxIdle
-|CHE_JDBC_MAX__WAIT__MILLIS
+|CHE_JDBC_MAX\__WAIT__MILLIS| maxWaitMillis
 |===
 
 (More about JDBC configuration properties at https://tomcat.apache.org/tomcat-8.5-doc/jndi-datasource-examples-howto.html)

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -158,5 +158,6 @@ In order to run TCK for a custom database, a maven module should be created with
 - a file in src/test/resources/META-INF/services named `org.eclipse.che.commons.test.tck.TckModule`. In it, there must be defined a name of the mentioned TckModule implementaion.
 - include all dependency artifacts with TCK tests (see list of Che modules above)
 - include artifact with DB Driver
-- include artifact with Che SQL schema. Note, that your database may not be fully compatible with existing Che SQL schema, so you might gonna have to add additional vendor specific scripts ( See "Flyway Migration" for the information on how to add such scripts).
+- include artifact with Che SQL schema. Note, that your database may not be fully compatible with existing Che SQL schema, so you might gonna have to create a separate maven module to add additional vendor specific scripts ( See "Flyway Migration" for the information on how to add such scripts).
 - add persistence.xml file or use PersistTestModuleBuilder helper class to create one programmatically in `TckModule` implementation
+

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -9,8 +9,9 @@ folder: developer-guide
 [id="currently-supported-dbs"]
 == Currently Supported Databases
 As of version 6.10, Eclipse Che currently supports following databases:
-- H2 (version 1.4.196)
-- PostgreSQL (version 9.6)
+
+* H2 (version 1.4.196)
+* PostgreSQL (version 9.6)
 
 H2 database is used by default in Single-User Che, whereas postgresql is used for Multi-user installation.
 Both of these have been tested with Selenium Integration tests, as well as TCK integration tests.
@@ -152,6 +153,7 @@ CREATE INDEX index_user_lower_name ON usr USING GIN (LOWER(name) gin_trgm_ops);
 
 In order to run TCK for a custom database, a maven module should be created with following components:
 
+- configure `docker-maven-plugin` to run an image with database
 - a Guice module that extends `TckModule` which will be responsible for establishing connection with DataSource, binding all required implementations of JPA entities and repositories.
 - a file in src/test/resources/META-INF/services named `org.eclipse.che.commons.test.tck.TckModule`. In it, there must be defined a name of the mentioned TckModule implementaion.
 - include all dependency artifacts with TCK tests (see list of Che modules above)

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -1,0 +1,131 @@
+---
+title: "Databases"
+keywords: database,
+tags: [dev-docs]
+sidebar: user_sidebar
+permalink: database.html
+folder: developer-guide
+---
+
+As of version 6.10, Eclipse Che currently supports following databases:
+- H2 (version 1.4.196)
+- PostgreSQL (version 9.4.1201-jdbc41)
+
+
+ 
+
+
+[id="datasource-components"]
+ Datasource components
+*DataSource factory*
+To Configuring Che to use custom DataSource, a new implementation of `JNDIDataSourceFactory` must be defined.
+It will configure JDBC Pool properties such as
+- DB username
+- DB password
+- DB URL
+- Driver class name
+- Max Total
+- Max Idle
+- Max Wait milliseconds
+
+(More about JDBC configuration properties at https://tomcat.apache.org/tomcat-8.5-doc/jndi-datasource-examples-howto.html)
+
+
+*ExceptionHandler*
+Database may sometimes produce different SQL exception, depending on the vendor.
+As in Java code, and TCK it is expected, a custom ExceptionHandler implementaion may be created, that will allow to rethrow more common exception.
+For example, in H2 and PostgreSQL, an exception may occur, when data couldn't be updated/stored due to unique constrain violation.
+But as it will a vendor specific exception with different code, there are Custom `H2ExceptionHandler`/`PostgreSqlExceptionHandler` that will catch it, and throw instead a `DuplicateKeyException`, which is used across the codebase.
+
+
+[id="test-compatibility-kit"]
+== Test Compatibility Kit (TCK)
+//TODO
+Test Compatibility kit is a set of integration tests that covers uses of essential DAO components
+
+*Creating own TCK module*
+
+To run Test Compatibility Kit against a new database, a new module must be created  
+
+- A module during which integration test will be executed
+module must provide all test dependencies 
+- A database provided in an Image and prepared to be used for TCK
+
+[id="cascade-removal-tests"]
+== JPA Cascade Removal Tests
+//TODO
+JPA Cascade removal tests are designed to test cases related to cascade operations
+An object, that can be depended on another object, for example `Workpace`, that belongs to another `User`
+
+[id="flyway-migration"]
+== Flyway migration
+
+Flyway framework is used to facilitate database schema initialization, as well as perform migrations.
+It is configured to pick up scripts and apply them in order, according to versioning.
+Some key configuration values are defined in che.properties:
+
+
+----
+db.schema.flyway.baseline.enabled=true                      #
+db.schema.flyway.baseline.version=5.0.0.8.1                 #
+db.schema.flyway.scripts.prefix=                            #
+db.schema.flyway.scripts.suffix=.sql                        #
+db.schema.flyway.scripts.version_separator=__               #
+db.schema.flyway.scripts.locations=classpath:che-schema     #
+----
+Also ability to place
+
+Taking a look at the sample structure:
+
+----
+che-schema/
+    5.0.0-M1/
+        1__init.sql
+    5.0.0-M2
+        1__rename_tables.sql
+        2__insert_predefined_data.sql
+        postgresql/
+            2__insert_predefined_data.sql
+subproject-schema/
+    5.0.0-M1/
+        1.1__init_subproject.sql
+    5.0.0-M2
+        2.1__create_additional_tables.sql
+----
+
+Location directory
+The main root directory for scripts (in this example, `che-schema` and `subproject-schema` is used as location names for Flyway.
+There can be multiple locations (artifacts) with scripts, and Flyway can be configured with property to search for such locations in classpath
+
+db.schema.flyway.scripts.locations=classpath:che-schema,classpath:subproject-schema
+
+
+* Version directory*
+There are version directories under the `che-schema` like 5.0.0 or 5.0.0-M1 these directories contain
+scripts for specific versions
+SQL scripts will be placeunder project version directories line 1.init.sql or 1.rename_fields.sql
+The naming of scripts is pretty simple: the first digit in the name is a script version in a project versions (it's `1` in `1__init.sql`)
+then description of changes (if necessary) init in 1__init.sql and then the file extension .sql in 1__init.sql
+
+*Vendor specific script*
+
+There is a directory in 5.0.0-M2 called `postresql` if current database provider is posgresql then
+the script from 5.0.0-M1/posgresql/2.add_workspace_constraint.sql will be used instead of 5.0.0-M1/2.add_workspace_constraint.sql, so basically if the same script name is provided in provider-specific directory then this script will be used instead
+
+So, the order of applyting scripts be as following
+[width="100%",cols="50%,50%",options="header",]
+|===
+|db version |script name	|location	|picked vendor specific
+|5.0.0.1.1 |1__init.sql	|che-schema	|no
+|5.0.0.1.1.1	|1.1__init_subproject.sql	|subproject-schema	|no
+|5.0.0.2.1	|1__rename_tables.sql	|che-schema	|no
+|5.0.0.2.2	|2__insert_predefined_data.sql	|che-schema	|yes
+|5.0.0.2.2.1	|2.1__create_new_tables.sql	|subproject-schema	|no
+|===
+
+[id="pg-trgm"]
+== pg_trgm
+//TODO
+
+Postgres Trigram extension is used for more optimised search of similar string, that is used for example, when searching for user name and email.
+It is enabled with a vendor specific migration script.

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -125,8 +125,8 @@ There can be multiple locations (artifacts) with scripts, and Flyway can be conf
 
 db.schema.flyway.scripts.locations=classpath:che-schema,classpath:subproject-schema
 
-
 * Version directory*
+
 There are version directories under the `che-schema` like 5.0.0 or 5.0.0-M1 these directories contain
 scripts for specific versions
 SQL scripts will be placed under project version directories line 1.init.sql or 1.rename_fields.sql
@@ -135,6 +135,7 @@ then description of changes (if necessary) init in 1__init.sql and then the file
 
 Note, that in this example, as well as in current Che schema, scripts numbers start from 1, but it is possible to use 0.
 This can be useful when script has to be run before the first script in superschema.
+
 *Vendor specific script*
 
 There is a directory in 5.0.0-M2 called `postresql` if current database provider is posgresql then

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -15,6 +15,8 @@ As of version 6.10, Eclipse Che currently supports following databases:
 H2 database is used by default in Single-User Che, whereas postgresql is used for Multi-user installation.
 Both of these have been tested with Selenium Integration tests, as well as TCK integration tests.
 
+MySQL is currently not officially supported because of Driver's GPL License.
+
 It is possible to connect own DB to datasource, and have TCK tests run on it, to ensure that DB can be used with Che's JPA code.
 
 [id="datasource-components"]

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -22,16 +22,16 @@ It is possible to connect own DB to datasource, and have TCK tests run on it, to
 *DataSource factory*
 To Configuring Che to use custom DataSource, a new implementation of `JNDIDataSourceFactory` must be defined.
 It will configure JDBC Pool properties such as
-- DB username
-- DB password
-- DB URL
-- Driver class name
-- Max Total
-- Max Idle
-- Max Wait milliseconds
+
+* DB username
+* DB password
+* DB URL
+* Driver class name
+* Max Total
+* Max Idle
+* Max Wait milliseconds
 
 (More about JDBC configuration properties at https://tomcat.apache.org/tomcat-8.5-doc/jndi-datasource-examples-howto.html)
-
 
 *ExceptionHandler*
 Database may sometimes produce different SQL exception, depending on the vendor.
@@ -39,34 +39,35 @@ As in Java code, and TCK it is expected, a custom ExceptionHandler implementaion
 For example, in H2 and PostgreSQL, an exception may occur, when data couldn't be updated/stored due to unique constrain violation.
 But as it will a vendor specific exception with different code, there are Custom `H2ExceptionHandler`/`PostgreSqlExceptionHandler` that will catch it, and throw instead a `DuplicateKeyException`, which is used across the codebase.
 
-*persistence.xml*
-Persistence XML
+Exception handler has to be defined in persistence XML.
 
 [id="test-compatibility-kit"]
 == Test Compatibility Kit (TCK)
 Test Compatibility kit is a set of integration tests that covers uses of essential DAO components, that are being run against real database.
 
+List of Che modules that have TCK tests:
 
-*Running TCK on a custom DB*
+* che-core-api-user
+* che-multiuser-machine-authentication
+* che-core-api-account
+* che-core-api-installer
+* che-core-api-ssh
+* che-core-api-workspace
+* che-core-api-workspace-activity
 
-In order to run TCK for a custom database, a maven module should be created with following components:
+Tests in these modules are executed on H2 Database during build. But also, tests themselves are packaged into separate artifact with `tests` classifier, which are meant to be used for their re-usage against other DBs.
 
-- a Guice module that extends `TckModule` which will be responsible for establishing connection with DataSource, binding all required implementations of JPA entities and repositories.
-- a file in src/test/resources/META-INF/services named `org.eclipse.che.commons.test.tck.TckModule`. In it, there must be defined a name of the mentioned TckModule implementaion.
-- include all dependency artifacts with TCK tests
-- include artifact with DB Driver
-- add persistence.xml file or use PersistTestModuleBuilder helper class to create one programmatically in `TckModule` implementation
+As an example of that, there are `postgresql-tck` and `che-multiuser-postgresql-tck` modules for running TCK tests on Postgres DB.
 
-Use `maven-docker-plugin` to run database as a docker container with preconfigured database settings like DB username, password, port, etc.
-
-Use `wsmaster/integration-tests/postgresql-tck`module in Che, as an example of TCK execution
 [id="cascade-removal-tests"]
 == JPA Cascade Removal Tests
 
-JPA Cascade removal tests are designed to test cases related to cascade operations
-An object, that can be depended on another object, for example `Workpace`, that belongs to another `User`
+JPA Cascade removal tests are designed to test cases related to cascaded removal of objects with it's depended objects. object, that can be depended on another object, for example `Profile`, that belongs to another `User`.
+For example, if object `User` has a dependent object `Profile`. Removal of `User` should invoke a removal of it's `Profile` as well.
+However, if exception occurs during `User` removal, then transaction would get rolled back and all entities should remain in place.
+Cascade removal tests cover these usecases.
 
-//TODO Descibe JPA tests structure
+JPA tests are being run against H2 database, in modules `cascade-removal` and `che-multiuser-cascade-removal` tests
 
 [id="flyway-migration"]
 == Flyway migration
@@ -124,7 +125,7 @@ There is a directory in 5.0.0-M2 called `postresql` if current database provider
 the script from 5.0.0-M1/posgresql/2.add_workspace_constraint.sql will be used instead of 5.0.0-M1/2.add_workspace_constraint.sql, so basically if the same script name is provided in provider-specific directory then this script will be used instead
 
 So, the order of applyting scripts be as following
-[width="100%",cols="50%,50%",options="header",]
+[width="100%",options="header",]
 |===
 |db version |script name	|location	|picked vendor specific
 |5.0.0.1.1 |1__init.sql	|che-schema	|no
@@ -136,11 +137,24 @@ So, the order of applyting scripts be as following
 
 [id="pg-trgm"]
 == pg_trgm
-//TODO
+Postgres Trigram extension is used for more optimised search of similar string https://www.postgresql.org/docs/9.6/static/pgtrgm.html
 
-Postgres Trigram extension is used for more optimised search of similar string, that is used for example, when searching for user name and email.
-It is enabled with a vendor specific migration script.
+in Che it is used for a faster search for similar email and names, and enabled with a vendor specific migration script:
+```
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX index_user_lower_email ON usr USING GIN (LOWER(email) gin_trgm_ops);
+CREATE INDEX index_user_lower_name ON usr USING GIN (LOWER(name) gin_trgm_ops);
+```
 
-[id="datasource-components"]
+[id="contributor-guidelines"]
 == Contributor guidelines
-//TODO
+*Creating a module to run TCK on a custom DB*
+
+In order to run TCK for a custom database, a maven module should be created with following components:
+
+- a Guice module that extends `TckModule` which will be responsible for establishing connection with DataSource, binding all required implementations of JPA entities and repositories.
+- a file in src/test/resources/META-INF/services named `org.eclipse.che.commons.test.tck.TckModule`. In it, there must be defined a name of the mentioned TckModule implementaion.
+- include all dependency artifacts with TCK tests (see list of Che modules above)
+- include artifact with DB Driver
+- include artifact with Che SQL schema. Note, that your database may not be fully compatible with existing Che SQL schema, so you might gonna have to add additional vendor specific scripts ( See "Flyway Migration" for the information on how to add such scripts).
+- add persistence.xml file or use PersistTestModuleBuilder helper class to create one programmatically in `TckModule` implementation

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -73,6 +73,7 @@ Objects in Database, upon removal, sometimes may need to be removed with other r
 E.g. when Account is removed from DB, all associated Workspaces must be removed as well.
 This is achieved by Account DAO throwing a custom type of `CascadeEvent`, and Workspace DAO have a `CascadeEventSubscriber` that would listen to that event.
 Should removal of Account perform unsuccessfully, the whole transaction would be rolled back and none of the Workspaces would be deleted.
+
 All that functionality is covered by "Cascade Removal Tests", that are located in `cascade-removal` and `che-multiuser-cascade-removal` modules.
 
 [id="flyway-migration"]

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -49,12 +49,13 @@ Test Compatibility kit is a set of integration tests that covers uses of essenti
 List of Che modules that have TCK tests:
 
 * che-core-api-user
-* che-multiuser-machine-authentication
 * che-core-api-account
 * che-core-api-installer
 * che-core-api-ssh
 * che-core-api-workspace
 * che-core-api-workspace-activity
+* infrastructure-kubernetes
+* che-multiuser-machine-authentication (Multi User Che
 * che-multiuser-api-organization (Multi User Che)
 * che-multiuser-api-permission (Multi User Che)
 * che-multiuser-api-resource (Multi User Che)
@@ -68,12 +69,11 @@ As an example of that, there are `postgresql-tck` and `che-multiuser-postgresql-
 [id="cascade-removal-tests"]
 == JPA Cascade Removal Tests
 
-JPA Cascade removal tests are designed to test cases related to cascaded removal of objects with it's depended objects. object, that can be depended on another object, for example `Profile`, that belongs to another `User`.
-For example, if object `User` has a dependent object `Profile`. Removal of `User` should invoke a removal of it's `Profile` as well.
-However, if exception occurs during `User` removal, then transaction would get rolled back and all entities should remain in place.
-Cascade removal tests cover these usecases.
-
-JPA tests are being run against H2 database, in modules `cascade-removal` and `che-multiuser-cascade-removal` tests
+Objects in Database, upon removal, sometimes may need to be removed with other related objects.
+E.g. when Account is removed from DB, all associated Workspaces must be removed as well.
+This is achieved by Account DAO throwing a custom type of `CascadeEvent`, and Workspace DAO have a `CascadeEventSubscriber` that would listen to that event.
+Should removal of Account perform unsuccessfully, the whole transaction would be rolled back and none of the Workspaces would be deleted.
+All that functionality is covered by "Cascade Removal Tests", that are located in `cascade-removal` and `che-multiuser-cascade-removal` modules.
 
 [id="flyway-migration"]
 == Flyway migration

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -10,12 +10,10 @@ folder: developer-guide
 == Currently Supported Databases
 As of version 6.10, Eclipse Che currently supports following databases:
 - H2 (version 1.4.196)
-- PostgreSQL (version 9.4.1201-jdbc41)
+- PostgreSQL (version 9.6)
 
 H2 database is used by default in Single-User Che, whereas postgresql is used for Multi-user installation.
 Both of these have been tested with Selenium Integration tests, as well as TCK integration tests.
-
-MySQL is currently not officially supported because of Driver's GPL License.
 
 It is possible to connect own DB to datasource, and have TCK tests run on it, to ensure that DB can be used with Che's JPA code.
 
@@ -42,12 +40,12 @@ For example, in H2 and PostgreSQL, an exception may occur, when data couldn't be
 But as it will a vendor specific exception with different code, there are Custom `H2ExceptionHandler`/`PostgreSqlExceptionHandler` that will catch it, and throw instead a `DuplicateKeyException`, which is used across the codebase.
 
 *persistence.xml*
-//TODO add notes about persistence.xml and how properties can be dynamicaly added to it in WsMasterModule (depending on DB)
+Persistence XML
 
 [id="test-compatibility-kit"]
 == Test Compatibility Kit (TCK)
 Test Compatibility kit is a set of integration tests that covers uses of essential DAO components, that are being run against real database.
-//TODO list with all TCK tests?
+
 
 *Running TCK on a custom DB*
 
@@ -61,6 +59,7 @@ In order to run TCK for a custom database, a maven module should be created with
 
 Use `maven-docker-plugin` to run database as a docker container with preconfigured database settings like DB username, password, port, etc.
 
+Use `wsmaster/integration-tests/postgresql-tck`module in Che, as an example of TCK execution
 [id="cascade-removal-tests"]
 == JPA Cascade Removal Tests
 

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -132,6 +132,8 @@ SQL scripts will be placed under project version directories line 1.init.sql or 
 The naming of scripts is pretty simple: the first digit in the name is a script version in a project versions (it's `1` in `1__init.sql`)
 then description of changes (if necessary) init in 1__init.sql and then the file extension .sql in 1__init.sql
 
+Note, that in this example, as well as in current Che schema, scripts numbers start from 1, but it is possible to use 0.
+This can be useful when script has to be run before the first script in superschema.
 *Vendor specific script*
 
 There is a directory in 5.0.0-M2 called `postresql` if current database provider is posgresql then

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -66,7 +66,7 @@ List of Che modules that have TCK tests:
 * che-multiuser-permission-workspace (Multi-User Che)
 
 Tests in these modules are executed on H2 Database during the build.
-Also, tests themselves are packaged into separate artifact with `tests` classifier, which are meant to be used for their re-usage against other DBs.
+Also, each module packages tests into separate artifacts with `tests` classifier, which are meant to be used for their re-usage in other TCK tests running modules.
 
 As an example of that, there are `postgresql-tck` and `che-multiuser-postgresql-tck` modules for running TCK tests on Postgres DB.
 

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -20,17 +20,21 @@ It is possible to connect own DB to datasource, and have TCK tests run on it, to
 
 [id="datasource-components"]
 == Datasource components
-*DataSource factory*
-To Configuring Che to use custom DataSource, a new implementation of `JNDIDataSourceFactory` must be defined.
-It will configure JDBC Pool properties such as
+*JDBC Pool configuration*
+Depending on Database used by Che, `JNDIDataSourceFactory` implementation will provide all the required JDBC pool connection configuration.
+These properties can be overriden with Che configuration Environment Variables:
 
-* DB username
-* DB password
-* DB URL
-* Driver class name
-* Max Total
-* Max Idle
-* Max Wait milliseconds
+[width="100%",options="header",]
+|===
+|Che Environment Variable name |JDBC property name
+|CHE_JDBC_USERNAME |username
+|CHE_JDBC_PASSWORD	|password
+|CHE_JDBC_URL	|url
+|CHE_JDBC_DRIVER__CLASS__NAME	|driverClassName
+|CHE_JDBC_MAX__TOTAL	|maxTotal
+|CHE_JDBC_MAX__IDLE	|maxIdle
+|CHE_JDBC_MAX__WAIT__MILLIS
+|===
 
 (More about JDBC configuration properties at https://tomcat.apache.org/tomcat-8.5-doc/jndi-datasource-examples-howto.html)
 
@@ -69,10 +73,11 @@ As an example of that, there are `postgresql-tck` and `che-multiuser-postgresql-
 [id="cascade-removal-tests"]
 == JPA Cascade Removal Tests
 
-Objects in Database, upon removal, sometimes may need to be removed with other related objects.
-E.g. when Account is removed from DB, all associated Workspaces must be removed as well.
-This is achieved by Account DAO throwing a custom type of `CascadeEvent`, and Workspace DAO have a `CascadeEventSubscriber` that would listen to that event.
-Should removal of Account perform unsuccessfully, the whole transaction would be rolled back and none of the Workspaces would be deleted.
+In Eclipse Che database schema, some objects have foreign keys reference on other objects.
+Example: Account and workspaces, Permissions and Workspaces. To be able to correctly
+remove such objects and avoid referential integrity problems Eclipse Che are using events mechanism.
+For example, when Account DAO wants to remove account it sends CascadeEvent, and Workspace DAO has a CascadeEventSubscriber that would listen to that event
+and remove workspace at that time. In case if removal of workspace failed the whole transaction would be rolled back.
 
 All that functionality is covered by "Cascade Removal Tests", that are located in `cascade-removal` and `che-multiuser-cascade-removal` modules.
 

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -6,17 +6,19 @@ sidebar: user_sidebar
 permalink: database.html
 folder: developer-guide
 ---
-
+[id="currently-supported-dbs"]
+== Currently Supported Databases
 As of version 6.10, Eclipse Che currently supports following databases:
 - H2 (version 1.4.196)
 - PostgreSQL (version 9.4.1201-jdbc41)
 
+H2 database is used by default in Single-User Che, whereas postgresql is used for Multi-user installation.
+Both of these have been tested with Selenium Integration tests, as well as TCK integration tests.
 
- 
-
+It is possible to connect own DB to datasource, and have TCK tests run on it, to ensure that DB can be used with Che's JPA code.
 
 [id="datasource-components"]
- Datasource components
+== Datasource components
 *DataSource factory*
 To Configuring Che to use custom DataSource, a new implementation of `JNDIDataSourceFactory` must be defined.
 It will configure JDBC Pool properties such as
@@ -40,12 +42,11 @@ But as it will a vendor specific exception with different code, there are Custom
 
 [id="test-compatibility-kit"]
 == Test Compatibility Kit (TCK)
-//TODO
 Test Compatibility kit is a set of integration tests that covers uses of essential DAO components
+//TODO list with all TCK tests?
 
 *Creating own TCK module*
-
-To run Test Compatibility Kit against a new database, a new module must be created  
+//TODO describe creation and execution of TCK tests with DB in image (MySQL?)
 
 - A module during which integration test will be executed
 module must provide all test dependencies 
@@ -53,9 +54,11 @@ module must provide all test dependencies
 
 [id="cascade-removal-tests"]
 == JPA Cascade Removal Tests
-//TODO
+
 JPA Cascade removal tests are designed to test cases related to cascade operations
 An object, that can be depended on another object, for example `Workpace`, that belongs to another `User`
+
+//TODO Descibe JPA tests structure
 
 [id="flyway-migration"]
 == Flyway migration
@@ -129,3 +132,7 @@ So, the order of applyting scripts be as following
 
 Postgres Trigram extension is used for more optimised search of similar string, that is used for example, when searching for user name and email.
 It is enabled with a vendor specific migration script.
+
+[id="datasource-components"]
+== Contributor guidelines
+//TODO

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -55,8 +55,13 @@ List of Che modules that have TCK tests:
 * che-core-api-ssh
 * che-core-api-workspace
 * che-core-api-workspace-activity
+* che-multiuser-api-organization (Multi User Che)
+* che-multiuser-api-permission (Multi User Che)
+* che-multiuser-api-resource (Multi User Che)
+* che-multiuser-permission-workspace (Multi User Che)
 
-Tests in these modules are executed on H2 Database during build. But also, tests themselves are packaged into separate artifact with `tests` classifier, which are meant to be used for their re-usage against other DBs.
+Tests in these modules are executed on H2 Database during the build.
+Also, tests themselves are packaged into separate artifact with `tests` classifier, which are meant to be used for their re-usage against other DBs.
 
 As an example of that, there are `postgresql-tck` and `che-multiuser-postgresql-tck` modules for running TCK tests on Postgres DB.
 

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -113,6 +113,7 @@ che-schema/
             2__insert_predefined_data.sql
 subproject-schema/
     5.0.0-M1/
+        0.1__before_init_main.sql
         1.1__init_subproject.sql
     5.0.0-M2
         2.1__create_additional_tables.sql
@@ -143,6 +144,7 @@ So, the order of applying scripts be as following
 [width="100%",options="header",]
 |===
 |db version |script name	|location	|picked vendor specific
+|5.0.0.1.0.1	|0.1__before_init_main.sql	|subproject-schema	|no
 |5.0.0.1.1 |1__init.sql	|che-schema	|no
 |5.0.0.1.1.1	|1.1__init_subproject.sql	|subproject-schema	|no
 |5.0.0.2.1	|1__rename_tables.sql	|che-schema	|no

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -8,12 +8,12 @@ folder: developer-guide
 ---
 [id="currently-supported-dbs"]
 == Currently Supported Databases
-As of version 6.10, Eclipse Che currently supports following databases:
+As of version 6.11, Eclipse Che currently supports following databases:
 
 * H2 (version 1.4.196)
 * PostgreSQL (version 9.6)
 
-H2 database is used by default in Single-User Che, whereas postgresql is used for Multi-user installation.
+H2 database is used by default in Single-User Che, whereas postgresql is used for Multi-User installation.
 Both of these have been tested with Selenium Integration tests, as well as TCK integration tests.
 
 It is possible to connect own DB to datasource, and have TCK tests run on it, to ensure that DB can be used with Che's JPA code.
@@ -59,11 +59,11 @@ List of Che modules that have TCK tests:
 * che-core-api-workspace
 * che-core-api-workspace-activity
 * infrastructure-kubernetes
-* che-multiuser-machine-authentication (Multi User Che)
-* che-multiuser-api-organization (Multi User Che)
-* che-multiuser-api-permission (Multi User Che)
-* che-multiuser-api-resource (Multi User Che)
-* che-multiuser-permission-workspace (Multi User Che)
+* che-multiuser-machine-authentication (Multi-User Che)
+* che-multiuser-api-organization (Multi-User Che)
+* che-multiuser-api-permission (Multi-User Che)
+* che-multiuser-api-resource (Multi-User Che)
+* che-multiuser-permission-workspace (Multi-User Che)
 
 Tests in these modules are executed on H2 Database during the build.
 Also, tests themselves are packaged into separate artifact with `tests` classifier, which are meant to be used for their re-usage against other DBs.
@@ -76,8 +76,8 @@ As an example of that, there are `postgresql-tck` and `che-multiuser-postgresql-
 In Eclipse Che database schema, some objects have foreign keys reference on other objects.
 Example: Account and workspaces, Permissions and Workspaces. To be able to correctly
 remove such objects and avoid referential integrity problems Eclipse Che are using events mechanism.
-For example, when Account DAO wants to remove account it sends CascadeEvent, and Workspace DAO has a CascadeEventSubscriber that would listen to that event
-and remove workspace at that time. In case if removal of workspace failed the whole transaction would be rolled back.
+For example, method in AccountManager that removes account sends a CascadeEvent, and Workspace DAO has a CascadeEventSubscriber that would listen to that event
+and remove workspace at that time. In case if removal of workspace failed the whole transaction would be rolled back, because AccountManager method had a `@Transactional` annotation.
 
 All that functionality is covered by "Cascade Removal Tests", that are located in `cascade-removal` and `che-multiuser-cascade-removal` modules.
 
@@ -165,13 +165,13 @@ CREATE INDEX index_user_lower_name ON usr USING GIN (LOWER(name) gin_trgm_ops);
 
 In order to run TCK for a custom database, a maven module should be created with following components:
 
-- configure `docker-maven-plugin` to run an image with database
-- a Guice module that extends `TckModule` which will be responsible for establishing connection with DataSource, binding all required implementations of JPA entities and repositories.
-- a file in src/test/resources/META-INF/services named `org.eclipse.che.commons.test.tck.TckModule`. In it, there must be defined a name of the mentioned TckModule implementaion.
-- include all dependency artifacts with TCK tests (see list of Che modules above)
-- include artifact with DB Driver
-- include artifact with Che SQL schema. Note, that your database may not be fully compatible with existing Che SQL schema, so you might gonna have to create a separate maven module to add additional vendor specific scripts ( See "Flyway Migration" for the information on how to add such scripts).
-- add persistence.xml file or use PersistTestModuleBuilder helper class to create one programmatically in `TckModule` implementation
+- configured `docker-maven-plugin` to run an image with database;
+- a Guice module that extends `TckModule` which will be responsible for establishing connection with DataSource, binding all required implementations of JPA entities and repositories;
+- a file in src/test/resources/META-INF/services named `org.eclipse.che.commons.test.tck.TckModule`. In it, there must be defined a name of the mentioned TckModule implementaion;
+- include all dependency artifacts with TCK tests (see list of Che modules above);
+- include artifact with DB Driver;
+- include artifact with Che SQL schema. Note, that your database may not be fully compatible with existing Che SQL schema, so you might gonna have to create a separate maven module to add additional vendor specific scripts ( See "Flyway Migration" for the information on how to add such scripts);
+- add persistence.xml file or use PersistTestModuleBuilder helper class to create one programmatically in `TckModule` implementation;
 
-Note, that to contribute the module to Eclipse repository, one must create an Eclipse CQ for Database, it's drivers and other possible dependencies.
+Note, that to contribute the module to Eclipse repository, one must create an Eclipse CQ for Database, its drivers and other possible dependencies.
 As these artifacts are used only for building and testing purposes, the type of CQ will be "works with". See https://www.eclipse.org/projects/handbook/#ip-third-party-workswith

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -55,7 +55,7 @@ List of Che modules that have TCK tests:
 * che-core-api-workspace
 * che-core-api-workspace-activity
 * infrastructure-kubernetes
-* che-multiuser-machine-authentication (Multi User Che
+* che-multiuser-machine-authentication (Multi User Che)
 * che-multiuser-api-organization (Multi User Che)
 * che-multiuser-api-permission (Multi User Che)
 * che-multiuser-api-resource (Multi User Che)

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -91,7 +91,8 @@ db.schema.flyway.scripts.suffix=.sql                        #
 db.schema.flyway.scripts.version_separator=__               #
 db.schema.flyway.scripts.locations=classpath:che-schema     #
 ----
-Also ability to place
+
+Che DB Schema artifacts have
 
 Taking a look at the sample structure:
 
@@ -121,7 +122,7 @@ db.schema.flyway.scripts.locations=classpath:che-schema,classpath:subproject-sch
 * Version directory*
 There are version directories under the `che-schema` like 5.0.0 or 5.0.0-M1 these directories contain
 scripts for specific versions
-SQL scripts will be placeunder project version directories line 1.init.sql or 1.rename_fields.sql
+SQL scripts will be placed under project version directories line 1.init.sql or 1.rename_fields.sql
 The naming of scripts is pretty simple: the first digit in the name is a script version in a project versions (it's `1` in `1__init.sql`)
 then description of changes (if necessary) init in 1__init.sql and then the file extension .sql in 1__init.sql
 
@@ -130,7 +131,7 @@ then description of changes (if necessary) init in 1__init.sql and then the file
 There is a directory in 5.0.0-M2 called `postresql` if current database provider is posgresql then
 the script from 5.0.0-M1/posgresql/2.add_workspace_constraint.sql will be used instead of 5.0.0-M1/2.add_workspace_constraint.sql, so basically if the same script name is provided in provider-specific directory then this script will be used instead
 
-So, the order of applyting scripts be as following
+So, the order of applying scripts be as following
 [width="100%",options="header",]
 |===
 |db version |script name	|location	|picked vendor specific
@@ -166,3 +167,5 @@ In order to run TCK for a custom database, a maven module should be created with
 - include artifact with Che SQL schema. Note, that your database may not be fully compatible with existing Che SQL schema, so you might gonna have to create a separate maven module to add additional vendor specific scripts ( See "Flyway Migration" for the information on how to add such scripts).
 - add persistence.xml file or use PersistTestModuleBuilder helper class to create one programmatically in `TckModule` implementation
 
+Note, that to contribute the module to Eclipse repository, one must create an Eclipse CQ for Database, it's drivers and other possible dependencies.
+As these artifacts are used only for building and testing purposes, the type of CQ will be "works with". See https://www.eclipse.org/projects/handbook/#ip-third-party-workswith

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -26,7 +26,7 @@ These properties can be overriden with Che configuration Environment Variables:
 
 [width="100%",options="header",]
 |===
-|Che Environment Variable name |JDBC property name
+|Che Environment Variable |JDBC Pool configuration property
 |CHE_JDBC_USERNAME |username
 |CHE_JDBC_PASSWORD	|password
 |CHE_JDBC_URL	|url


### PR DESCRIPTION
### What does this PR do?

Create Che database page, which will cover the following topics (ticked when ready)
- [ ] What component and how are uses database
- [ ] What database engines are certified to use with Eclipse Che.
- [ ] Information about pg_trgm. And permissions required to enable it.
- [ ] Describe db TCK process.
- [ ] Describe JPA cascade removal tests.
- [ ] Describe db migration process.
- [ ] Describe jdbc pool configuration.
- [ ] Describe guidelines for external contributors how to add new database support
- [ ] Describe a situation with MySQL and why Eclipse Che doesn't have an official support of this database engine

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10950