### PR TITLE
Update minishift addon instructions

### DIFF
--- a/src/main/pages/overview/quick-start.adoc
+++ b/src/main/pages/overview/quick-start.adoc
@@ -54,18 +54,12 @@ Che supports different flavors of OpenShift:
 * *link:%5B[OpenShift Dedicated (OCD)]https://access.redhat.com/products/openshift-dedicated-red-hat/)*: Enterprise public cloud with your own OpenShift cluster managed by Red Hat.
 * *https://www.openshift.org/minishift/[MiniShift]*: OpenShift running on your local environment.
 
-If you want to try Che on OpenShift, we recommand to you to do it with MiniShift and use the https://github.com/minishift/minishift-addons/tree/master/add-ons/che[MiniShift add-on for Che].
+If you want to try Che on OpenShift, we recommend you to do it with MiniShift and use the https://github.com/minishift/minishift/tree/master/addons/che[MiniShift add-on for Che].
 
-On any computer with https://docs.openshift.org/latest/minishift/getting-started/index.html[MiniShift] running:
+On any computer with https://docs.openshift.org/latest/minishift/getting-started/index.html[MiniShift] running (v1.23.0 or greater):
 
 ----
-git clone https://github.com/minishift/minishift-addons
-minishift addons install <path_to_minishift-addons-clone>/add-ons/che
-minishift addons enable che
-minishift addons apply \
-    --addon-env CHE_DOCKER_IMAGE=eclipse/che-server:nightly \
-    --addon-env OPENSHIFT_TOKEN=$(oc whoami -t) \
-    che
+minishift addons enable che && minishift addons apply che
 ----
 
 Installation and configuration docs:

--- a/src/main/pages/setup-openshift/openshift-single-user.adoc
+++ b/src/main/pages/setup-openshift/openshift-single-user.adoc
@@ -42,24 +42,10 @@ The best way of deploying Che to Minishift is using an add-on via the https://do
 
 *Install add-On*
 
-Clone addons repository onto your local machine and then install the add-on via:
+Starting with minishift v1.23.0 Che addon is pre-installed. To start Che we need to `enable` the addon and `apply` it:
 
 ----
-git clone https://github.com/minishift/minishift-addons
-minishift addons install <path_to_minishift-addons>/add-ons/che
-minishift addons enable che
-----
-
-`enable` will setup Eclipse Che when you start Minishift the next time.
-
-*Apply add-on*
-
-If Minishift is already started and Che addon is installed, it is possible to deploy Che without restarting Minishift:
-
-----
-$ minishift addons apply \
-    --addon-env CHE_DOCKER_IMAGE=eclipse/che-server:nightly \
-    che
+$ minishift addons enable che && minishift addons apply che
 ----
 
 *Deploy a local Che server image*


### PR DESCRIPTION
### What does this PR do?

Update the instructions to run Che as a minishift addon. Che addon is now a default minishift addon and source code has been moved to https://github.com/minishift/minishift/tree/master/addons/che

