### PR TITLE
Add 6.11 release notes regarding rolling update failures

### DIFF
--- a/src/main/pages/release-notes/release-6.11.0.adoc
+++ b/src/main/pages/release-notes/release-6.11.0.adoc
@@ -34,7 +34,7 @@ This error affects workspaces which were in a running state during update to 6.1
 They are possibly lost theirs public/private signature key pairs and therefore their runtime states cannot be recovered during rolling update.
 For more technical details, see https://github.com/eclipse/che/issues/11087
 This release contains fix of DB schema, but it is *strongly* recommended to manually restart workspaces which may me affected by the error.
-If those workspaces will not be restarted, after the automatic DB fix they may remain in undefined state until next restart.
+If those workspaces will not be restarted, after the automatic DB fix they may remain in undefined state that can be fixed by restart.
 To determine lists of affected workspaces, the following query should be run on the Che DB before starting update:
 ----
 SELECT kp.workspace_id FROM che_sign_key_pair kp

--- a/src/main/pages/release-notes/release-6.11.0.adoc
+++ b/src/main/pages/release-notes/release-6.11.0.adoc
@@ -1,0 +1,78 @@
+---
+title: "Release: 6.11.0"
+keywords: release notes
+sidebar: rn_sidebar
+permalink: release-${VERSION}.html
+folder: release_notes
+---
+
+
+[id="release-summary"]
+== Release Summary
+
+Eclipse Che \{version} includes:
+
+* *Feature1*: Quick value description
+* *Feature2*: Quick value description
+* …
+
+[id="upgrade"]
+== Upgrade
+
+Instruction how to upgrade
+
+'''''
+
+[id="release-details"]
+== Release Details
+
+[id="Fix rolling update of version 6.10"]
+=== Fix rolling update of version 6.10 (#11087)
+
+Due to error in DB schema introduced in version 6.10, there is possibility of situation when further rolling updates are failing.
+This error affects workspaces which were in a running state during update to 6.10 version.
+They are possibly lost theirs public/private signature key pairs and therefore their runtime states cannot be recovered during rolling update.
+This release contains fix of DB schema, but it is *strongly* recommended to manually restart workspaces which may me affected by the error.
+To determine lists of affected workspaces, the following query should be run on the DB before starting update:
+----
+SELECT kp.workspace_id FROM che_sign_key_pair kp
+WHERE NOT EXISTS (
+   SELECT id
+   FROM   che_sign_key k
+   WHERE  k.id = kp.private_key
+   )
+OR NOT EXISTS (
+   SELECT id
+   FROM   che_sign_key k
+   WHERE  k.id = kp.public_key
+   )
+----
+After workspaces restarted, rolling update may be performed as usual.
+
+
+
+[id="feature2-issue"]
+=== Feature2 (#ISSUE)
+
+\{image / animated gif}
+
+Feature description focusing on value to the user or contributor.
+
+Learn more in the documentation: \{Link to the documentation}
+
+[id="other-notable-enhancements"]
+== Other Notable Enhancements
+
+* Issue title. (#ISSUE)
+
+[id="notable-bug-fixes"]
+== Notable Bug Fixes
+
+* Fixed issue’s title. (#ISSUE)
+
+[id="community-thank-you"]
+== Community Thank You!
+
+We’d like to say a big thank you to everyone who helped to make Che even better:
+
+* \{Contributor Name} – \{Company} – (#PR): PR Title

--- a/src/main/pages/release-notes/release-6.11.0.adoc
+++ b/src/main/pages/release-notes/release-6.11.0.adoc
@@ -32,8 +32,10 @@ Instruction how to upgrade
 Due to error in DB schema introduced in version 6.10, there is possibility of situation when further rolling updates are failing.
 This error affects workspaces which were in a running state during update to 6.10 version.
 They are possibly lost theirs public/private signature key pairs and therefore their runtime states cannot be recovered during rolling update.
+For more technical details, see https://github.com/eclipse/che/issues/11087
 This release contains fix of DB schema, but it is *strongly* recommended to manually restart workspaces which may me affected by the error.
-To determine lists of affected workspaces, the following query should be run on the DB before starting update:
+If those workspaces will not be restarted, after the automatic DB fix they may remain in undefined state until next restart.
+To determine lists of affected workspaces, the following query should be run on the Che DB before starting update:
 ----
 SELECT kp.workspace_id FROM che_sign_key_pair kp
 WHERE NOT EXISTS (
@@ -47,7 +49,8 @@ OR NOT EXISTS (
    WHERE  k.id = kp.public_key
    )
 ----
-After workspaces restarted, rolling update may be performed as usual.
+Empty result means that no workspaces are affected and no more manual actions needed.
+After damaged workspaces restart finish, rolling update may be performed as usual.
 
 
 


### PR DESCRIPTION
### What does this PR do?
Adds 6.11 release notes regarding rolling update failures

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11087