### PR TITLE
Move factories to che.osio instead of codenvy.io

### DIFF
--- a/src/main/pages/portable-workspaces/creating-factories.adoc
+++ b/src/main/pages/portable-workspaces/creating-factories.adoc
@@ -14,7 +14,7 @@ folder: portable-workspaces
 [cols="1,4"]
 |===
 |Action | In the user dashboard: `Dashboard > Factories > Create Factory`.
-|Sample Factory | https://codenvy.com/f?id=s38eam174ji42vty[https://codenvy.io/f?id=s38eam174ji42vty]
+|Sample Factory | https://che.openshift.io/f?id=factorymtyoro1y0qt8tq2j[https://che.openshift.io/f?id=factorymtyoro1y0qt8tq2j]
 |===
 
 Creating a Factory in the dashboard gives you the most freedom and control. The simplest way is to create a Factory based on an existing workspace, but you can also create Factories based on a template we provide or by pasting in a `factory.json` file and then generating a Factory URL using our CLI or API. Learn more the JSON structure and options in our link:factories_json_reference[Factory JSON reference].
@@ -27,7 +27,7 @@ A Factory created from the dashboard will be persisted into Che database and kep
 [cols="1,4"]
 |===
 |Action | In the IDE: `Workspace > Create Factory`.
-|Sample Factory | https://codenvy.com/f?id=s38eam174ji42vty[https://codenvy.io/f?id=s38eam174ji42vty]
+|Sample Factory | https://che.openshift.io/f?id=factorymtyoro1y0qt8tq2j[https://che.openshift.io/f?id=factorymtyoro1y0qt8tq2j]
 |===
 
 Creating a Factory from inside the IDE in a running workspace will generate a Factory to replicate that workspace including both runtime and project settings.
@@ -40,9 +40,9 @@ A Factory created from the dashboard will be persisted onto {{ site.product_mini
 [cols="1,4"]
 |===
 |Action | Specify the repo URL. In this case the configuration must be stored inside the repository.
-|Sample Factories | http://codenvy.io/f?url=https://github.com/eclipse/che +
- http://codenvy.io/f?url=https://github.com/eclipse/che/tree/language-server +
- http://codenvy.io/f?url=https://gitlab.com/benoitf/simple-project
+|Sample Factories | http://che.openshift.io/f?url=https://github.com/eclipse/che +
+ http://che.openshift.io/f?url=https://github.com/eclipse/che/tree/language-server +
+ http://che.openshift.io/f?url=https://gitlab.com/benoitf/simple-project
 |===
 
 
@@ -154,7 +154,7 @@ If you have projects in GitHub or GitLab, you can help your contributors to get 
 
 [source,markdown]
 ----
-[![Developer Workspace](https://codenvy.io/factory/resources/codenvy-contribute.svg)](your-factory-url)
+[![Developer Workspace](https://che.openshift.io/factory/resources/factory-contribute.svg)](your-factory-url)
 ----
 
 [id="nest-steps"]

--- a/src/main/pages/portable-workspaces/factories-getting-started.adoc
+++ b/src/main/pages/portable-workspaces/factories-getting-started.adoc
@@ -13,14 +13,14 @@ A Factory is a template containing configuration to automate generating new Work
 [id="try-a-factory"]
 == Try a Factory
 
-Clone a public workspace on `codenvy.io` by clicking the button below. http://codenvy.io/f?id=omriatu352kkthua[image:https://codenvy.io/factory/resources/codenvy-contribute.svg[Try a Factory]]
+Clone a public workspace on `che.openshift.io` by clicking the button below. https://che.openshift.io/f?id=factorymtyoro1y0qt8tq2j[image:https://che.openshift.io/factory/resources/factory-contribute.svg[Try a Factory]]
 
 [id="using-factories"]
 == Using Factories
 
-Factories can be invoked from a Factory URL built in multiple ways. You can replace the {% if site.product_mini_cli=="codenvy" %}`codenvy.io` domain with the hostname of any Codenvy on-premises installation.{% else %}`localhost:8080` domain with the hostname of any Che installation.{% endif %}
+Factories can be invoked from a Factory URL built in multiple ways. You can replace the {% if site.product_mini_cli=="codenvy" %}`che.openshift.io` domain with the hostname of any Codenvy on-premises installation.{% else %}`localhost:8080` domain with the hostname of any Che installation.{% endif %}
 
-{% if site.product_mini_cli=="codenvy" %}Using Factories on `codenvy.io` require the user to be authenticated. Users who are not authenticated will be presented a login screen after they click on the Factory URL. Users without an account can create one using the same dialog.{% else %}{% endif %}
+{% if site.product_mini_cli=="codenvy" %}Using Factories on `che.openshift.io` require the user to be authenticated. Users who are not authenticated will be presented a login screen after they click on the Factory URL. Users without an account can create one using the same dialog.{% else %}{% endif %}
 
 [id="invoke-factory-using-its-unique-hashcode"]
 == Invoke Factory using its unique hashcode
@@ -29,7 +29,7 @@ Factories can be invoked from a Factory URL built in multiple ways. You can repl
 |===
 |Format | `/f?id={hashcode}` +
  `/factory?id={hashcode}`
-|Sample | {% if site.product_mini_cli=="codenvy" %} https://codenvy.io/f?id=s38eam174ji42vty{% else %}https://localhost:8080/f?id=s38eam174ji42vty{% endif %}
+|Sample | {% if site.product_mini_cli=="codenvy" %} https://che.openshift.io/f?id=factorymtyoro1y0qt8tq2j{% else %}https://localhost:8080/f?id=factorymtyoro1y0qt8tq2j{% endif %}
 |===
 
 [id="invoke-a-named-factory"]
@@ -39,8 +39,8 @@ Factories can be invoked from a Factory URL built in multiple ways. You can repl
 |===
 |Format | `/f?user={username}&name={factoryname}` +
  `/factory?user={username}&name={factoryname}`
-|Sample | {% if site.product_mini_cli=="codenvy" %} https://codenvy.io/f?user=tylerjewell&name=starwars +
- https://codenvy.io/factory?user=tylerjewell&name=starwars{% else %}https://localhost:8080/f?user=che&name=starwars +
+|Sample | {% if site.product_mini_cli=="codenvy" %} https://che.openshift.io/f?user=tylerjewell&name=starwars +
+ https://che.openshift.io/factory?user=tylerjewell&name=starwars{% else %}https://localhost:8080/f?user=che&name=starwars +
  https://localhost:8080/factory?user=che&name=starwars{% endif %}
 |===
 
@@ -51,9 +51,9 @@ Factories can be invoked from a Factory URL built in multiple ways. You can repl
 [cols="1,5"]
 |===
 |Format | `/f?url={git URL}`
-|Sample | {% if site.product_mini_cli=="codenvy" %} http://codenvy.io/f?url=https://github.com/eclipse/che +
- http://codenvy.io/f?url=https://github.com/eclipse/che/tree/language-server +
- http://codenvy.io/f?url=https://gitlab.com/benoitf/simple-project{% else %}http://localhost:8080/f?url=https://github.com/eclipse/che +
+|Sample | {% if site.product_mini_cli=="codenvy" %} http://che.openshift.io/f?url=https://github.com/eclipse/che +
+ http://che.openshift.io/f?url=https://github.com/eclipse/che/tree/language-server +
+ http://che.openshift.io/f?url=https://gitlab.com/benoitf/simple-project{% else %}http://localhost:8080/f?url=https://github.com/eclipse/che +
  http://localhost:8080/f?url=https://github.com/eclipse/che/tree/language-server +
  http://localhost:8080/f?url=https://gitlab.com/benoitf/simple-project{% endif %}
 |===


### PR DESCRIPTION
Moving factories references to che.openshift.io instead of codenvy.io as che.openshift.io is running latest version of Eclipse Che.