### PR TITLE
che #11350: Adding docs for ephemeral workspace configuration via 'emptyDir' volumes

### DIFF
--- a/src/main/pages/setup-openshift/openshift-admin-guide.adoc
+++ b/src/main/pages/setup-openshift/openshift-admin-guide.adoc
@@ -118,6 +118,10 @@ Another restriction is that only pods in the same namespace can use the same PVC
 
 It is a default PVC strategy, i.e. `CHE_INFRA_KUBERNETES_PVC_STRATEGY` is set to `unique`. Every workspace gets its own PVC, which means a workspace PVC is created when a workspace starts for the first time. Workspace PVC is deleted when a corresponding workspace is deleted.
 
+[id="ephemeral workspaces"]
+== Ephemeral Workspaces
+On OpenShift/Kubernetes infrastructure it is possible to configure workspaces to be ephemeral (with no PVC attached). Instructions can be found in the link:volumes.html#empty-dir-volumes['emptyDir' volumes support OpenShift/Kubernetes infrastructure] section.
+
 [id="update"]
 == Update
 

--- a/src/main/pages/workspace-admin/volumes.adoc
+++ b/src/main/pages/workspace-admin/volumes.adoc
@@ -35,3 +35,18 @@ When adding a volume in User Dashboard using UI or config window, volume name an
 * name and path contains special characters, including `-` and `_`
 
 If you want your workspace machines to share volumes, just create volumes for each machine with an identical name. This way, machines will share the same volume.
+
+
+[id="empty-dir-volumes"]
+== 'emptyDir' volumes support OpenShift/Kubernetes infrastructure
+
+On OpenShift/Kubernetes infrastructure it is possible to configure workspaces to be  ephemeral (with no PVC attached) via `persistVolumes` attribute set to 'false' in the workspace config:
+
+[source,json]
+----
+"attributes": {
+  "persistVolumes": "false"
+}
+----
+
+In this case, regardless of the link:openshift-admin-guide.html#che-workspaces-storage[PVC strategy], all volumes would be created as https://kubernetes.io/docs/concepts/storage/volumes/#emptydir[`emptyDir`] for the given workspace. When a workspace Pod is removed for any reason, the data in the `emptyDir` volume is deleted forever.


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
 Adding docs for ephemeral workspace configuration via 'emptyDir' volumes

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11350