### PR TITLE
[WIP] RHDEVDOCS:874: Edited the CLI-Reference section for language and asci…

### DIFF
--- a/src/main/css/customstyles.css
+++ b/src/main/css/customstyles.css
@@ -1287,6 +1287,7 @@ h4.panel-title {
 }
 
 div.imageblock .content,
+div.openblock .content,
 div.literalblock .content,
 div.listingblock .content {
     max-width: 100%

--- a/src/main/pages/setup-docker/docker-cli.adoc
+++ b/src/main/pages/setup-docker/docker-cli.adoc
@@ -8,142 +8,216 @@ folder: setup-docker
 ---
 
 [id="cli-syntax-and-commands"]
-== CLI Syntax and Commands
+== CLI syntax and commands
 
-The CLI is a Docker image that comes with a collection of commands to configure, interact and start Che. The CLI also contains commands for end users to interact with workspaces such as sync and ssh.
+The CLI is a Docker image that comes with a collection of commands to configure, interact, and start Che. The CLI also contains commands, such as `sync` and `ssh`, for end users to interact with workspaces.
 
+Command:
 ----
-USAGE:
-  docker run -it --rm <DOCKER_PARAMETERS> eclipse/che-cli:<version> [COMMAND]
-
-MANDATORY DOCKER PARAMETERS:
-  -v <LOCAL_PATH>:/data                Where user, instance, and log data saved
-
-OPTIONAL DOCKER PARAMETERS:
-  -e CHE_HOST=<YOUR_HOST>              IP address or hostname where che will serve its users
-  -e CHE_PORT=<YOUR_PORT>              Port where che will bind itself to
-  -e CHE_CONTAINER=<YOUR_NAME>         Prefix name for the che container
-  -v <LOCAL_PATH>:/data/instance       Where instance, user, log data will be saved
-  -v <LOCAL_PATH>:/data/backup         Where backup files will be saved
-  -v <LOCAL_PATH>:/repo                che git repo - uses local binaries and manifests
-  -v <LOCAL_PATH>:/assembly            che assembly - uses local binaries
-  -v <LOCAL_PATH>:/sync                Where remote ws files will be copied with sync command
-  -v <LOCAL_PATH>:/unison              Where unison profile for optimizing sync command resides
-  -v <LOCAL_PATH>:/chedir              Soure repository to convert into workspace with Chedir utility
-
-COMMANDS:
-  action <action-name>                 Start action on che instance
-  backup                               Backups che configuration and data to /data/backup volume mount
-  config                               Generates a che config from vars; run on any start / restart
-  destroy                              Stops services, and deletes che instance data
-  dir <command>                        Use Chedir and Chefile in the directory mounted to :/chedir
-  download                             Pulls Docker images for the current che version
-  help                                 This message
-  info                                 Displays info about che and the CLI
-  init                                 Initializes a directory with a che install
-  offline                              Saves che Docker images into TAR files for offline install
-  restart                              Restart che services
-  restore                              Restores che configuration and data from /data/backup mount
-  rmi                                  Removes the Docker images for <version>, forcing a repull
-  ssh <wksp-name> [machine-name]       SSH to a workspace if SSH agent enabled
-  start                                Starts che services
-  stop                                 Stops che services
-  sync <wksp-name>                     Synchronize workspace with local directory mounted to :/sync
-  test <test-name>                     Start test on che instance
-  upgrade                              Upgrades che from one version to another with migrations and backups
-  version                              Installed version and upgrade paths
-
-GLOBAL COMMAND OPTIONS:
-  --fast                               Skips networking, version, nightly and preflight checks
-  --offline                            Runs CLI in offline mode, loading images from disk
-  --debug                              Enable debugging of che server
-  --trace                              Activates trace output for debugging CLI
+docker run -it --rm <DOCKER_PARAMETERS> eclipse/che-cli:<version> [COMMAND]
 ----
 
-The CLI has three primary phases: initialization, configuration, and start. The initialization phase is executed by `init` and will install version-specific files into the folder mounted to `/data`. This includes the universal configuration file named `che.env`, a version identifier, and a location where configuration files will be saved. The configuration is executed by the `config` command and takes as input your `che.env` configuration file, the OS of your host, and then generates an OS-specific set of configuration files in the `/data/instance` folder that can be used to run an instance of Che. The configuration phase will run an initialization if a folder is not found. Every execution of the `config` command will overwrite the files in `/data/instance` with the latest configuration. This way if an admin modifies any configuration file, the instance’s configuration files will be updated to be guaranteed consistent. The CLI generates a large number of configuration files specific to running Che. The configuration files are sourced from Puppet templates that are stored in our GitHub repository under `/dockerfiles/init`. The start phase is executed by `start` and will use a configuration-generated `docker-compose-container.yml` file to launch Eclipse Che. The start phase always executes a `config` command, so any files that were edited in `/data/instance` will be overwritten with the generated configuration from the CLI.
+Following is the mandatory Docker parameter for the Docker CLI image:
 
-The CLI will hide most error conditions from standard out. Internal stack traces and error output is redirected to `cli.log`, which is saved in the host folder where `:/data` is mounted.
+* `-v <LOCAL_PATH>:/data`: The user, instance, and log data are saved here.
 
-You can override any value in `che.env` for a single execution by passing in `-e NAME=VALUE` on the command line. The CLI will detect the values on the command line and ignore those imported from `che.env`.
+The following tables lists the optional Docker parameters that you can use with the Docker CLI image.
 
-'''''
+[cols="2*", options="header"]
+|===
+|Optional Docker parameter
+|Description
+|`-e CHE_HOST=<YOUR_HOST>`              
+|IP address or hostname where Che serves its users
 
-_action_
+|`-e CHE_PORT=<YOUR_PORT>`            
+|Port on which Che binds itself
 
-Executes some actions on the Eclipse Che instance or on a workspace running inside Che. For example to list all workspaces on Che, the following command can be used `action list-workspaces`. To execute a command on a workspace `action execute-command <workspace-name> <action>` where action can be any bash command.
+|`-e CHE_CONTAINER=<YOUR_NAME>`         
+|Prefix name for the Che container
 
-'''''
+|`-v <LOCAL_PATH>:/data/instance`     
+|The instance, user, log data is saved here
 
-_backup_
+|`-v <LOCAL_PATH>:/data/backup`         
+|Backup files are saved here
 
-TARS your `/instance` into files and places them into `/backup`. These files are restoration-ready.
+|`-v <LOCAL_PATH>:/repo`               
+|Che git repository - uses local binaries and manifests
 
-'''''
+|`-v <LOCAL_PATH>:/assembly`            
+|Che assembly - uses local binaries
 
-_config_
+|`-v <LOCAL_PATH>:/sync`               
+|Where `remote ws` files are copied with the `sync` command
 
-Generates a Che instance configuration thta is placed in `/instance`. This command uses puppet to generate Docker Compose configuration files to run Che and its associated server. Che’s server configuration is generated as a che.properties file that is volume mounted into the Che server when it boots. This command is executed on every `start` or `restart`.
+|`-v <LOCAL_PATH>:/unison`              
+|Where unison profile for optimizing the `sync` command resides
+ 
+|`-v <LOCAL_PATH>:/chedir`              
+|Soure repository to convert into workspace with the `Chedir` utility
+|===
 
-If you are using a `eclipse/che:<version>` image and it does not match the version that is in `/instance/che.ver`, then the configuration will abort to prevent you from running a configuration for a different version than what is currently installed.
 
-This command respects `--no-force`, `--pull`, `--force`, and `--offline`.
+The following table lists the commands that you can use with the Docker CLI image.
 
-'''''
+[cols="2*", options="header"]
+|===
+|Command
+|Description
+|`action <action-name>`      
+|Start action on Che instance
 
-_destroy_
+|`backup`                          
+|Backs up Che configuration and data to the `/data/backup` volume mount
 
-Deletes `/docs`, `che.env` and `/instance`, including destroying all user workspaces, projects, data, and user database. If you pass `--quiet` then the confirmation warning will be skipped. Passing `--cli` will also destroy the `cli.log`. By default this is left behind for traceability.
+|`config`                              
+|Generates a Che configuration from variables; run on any `start/restart` command
 
-'''''
+|`destroy`                              
+|Stops services, and deletes che instance data
 
-_dir_
+|`dir <_command_>`                        
+|Use `Chedir` and `Chefile` in the directory mounted to `:/chedir`
+  
+|`download`                           
+|Pulls Docker images for the current Che version
 
-Boots a new Eclipse Che instance with a workspace for the folder `:/chedir` defined as volume mount in parameter.
+|`help`                                 
+|This message displays information about Che and the CLI
 
-If for example `$HOME/my-project` is given as parameter, a new Che instance will be created, using `$HOME/my-project` as project in the IDE.
+|`info`
+|Displays system state and debugging information
 
-So inside the IDE, `/projects` folder will contain a `my-project` folder with your host folder. Then, any changes inside the IDE will be reflected in your host folder. And the opposite is also true, updating a file on your local computer will update the content of the file inside the IDE.
+|`init`                                
+|Initializes a directory with a Che install
 
-Other commands are `init`,`up`, `down`, `ssh` and `status`
+|`offline`                            
+|Saves Che Docker images into the `TAR` files for offline installation
 
-* `init` : Initialize the directory specified and add a default `Chefile` file if there is none
-* `up` : Boot Eclipse Che with workspace on folder
-* `down` : Stop Eclipse Che and any workspaces
-* `ssh` : Connect to the running workspace by using ssh
-* `status` : Display if an instance of Eclipse Che is running or not for the specified folder.
+|`restart`                           
+|Restarts the Che services
 
-'''''
+|`restore`                              
+|Restores Che configuration and data from the `/data/backup` mount
 
-_download_
+|`rmi`                                  
+|Removes the Docker images for <version>, forcing a repull
 
-Used to download Docker images that will be stored in your Docker images repository. This command downloads images that are used by the CLI as utilities, for Che to do initialization and configuration, and for the runtime images that Che needs when it starts. This command respects `--offline`, `--pull`, `--force`, and `--no-force` (default). This command is invoked by `che init`, `che config`, and `che start`.
+|`ssh <_workspace-name_> [_machine-name_]`       
+|SSH to a workspace if SSH agent enabled
 
-`download` is invoked by `che init` before initialization to download images for the version specified by `eclipse/che:<version>`.
+|`start`                                
+|Starts the Che services
 
-It is possible to override the docker images used by the CLI by setting the following environment variables:
+|`stop`                                 
+|Stops the Che services
+  
+|`sync <_workspace-name_>`                     
+|Synchronizes workspace with local directory mounted to `:/sync`
+ 
+|`test <_test-name_>`                     
+|Starts test on the Che instance
 
-* `IMAGE_INIT` to override the default `eclipse/che-init:<version>` docker image,
+|`upgrade`                             
+|Upgrades Che from one version to another with migrations and backups
+
+|`version`                             
+|Installed version and upgrade paths
+|===
+
+The following table lists the global command options that you can se with the Docker CLI image.
+
+[cols="2*", options="header"]
+|===
+|Command option
+|Description
+|`--fast`                               
+|Skips networking, version, nightly, and preflight checks
+
+|`--offline`                            
+|Runs CLI in the offline mode, loading images from the disk
+
+|`--debug`                              
+|Enable debugging of the Che server
+
+|`--trace`                              
+|Activates trace output for debugging CLI
+|===
+
+The CLI has the following three primary phases:
+
+* The initialization phase is executed by the `init` command. It installs version-specific files into the directory mounted to `/data`. This includes the universal configuration file named `che.env`, a version identifier, and a location where configuration files are saved. The configuration is executed by the `config` command. It takes as input, the `che.env` configuration file, the OS of your host, and then generates an OS-specific set of configuration files in the `/data/instance` directory that can be used to run an instance of Che. 
+
+* The configuration phase runs an initialization if a directory is not found. Every execution of the `config` command overwrites the files in the `/data/instance` directory with the latest configuration. This ensures that if an administrator modifies any configuration file, the instance’s configuration files are updated consistently. The CLI generates a large number of configuration files specific to running Che. The configuration files are sourced from the puppet templates that are stored in the GitHub repository under `/dockerfiles/init`. 
+
+* The start phase is executed by the `start` command and it uses a configuration-generated `docker-compose-container.yml` file to launch Eclipse Che. The start phase always executes a `config` command, so any files that were edited in the `/data/instance` directory are overwritten with the generated configuration from the CLI.
+
+The CLI hides most error conditions from standard out. Internal stack traces and error output are redirected to the `cli.log` file, which is saved in the host directory where `:/data` is mounted.
+
+You can override any value in the `che.env` file for a single execution by passing the `-e NAME=VALUE` argument on the command line. The CLI detects the values on the command line and ignores those imported from the `che.env` file.
+
+Following are some selected commands and their uses.
+
+*_action_*
+
+The `action` command executes some actions on the Eclipse Che instance or on a workspace running inside Che. To list all workspaces on Che, use the `action list-workspaces` command. To execute a command on a workspace, use the  `action execute-command <workspace-name> <action>` command; here, action is a `bash` command.
+
+
+*_backup_*
+
+The `backup` command creates `TAR` files from the `/instance` directory and places them in the `/backup` directory. These files are restoration-ready.
+
+*_config_*
+
+The `config` command generates a Che instance configuration that is placed in the `/instance` directory. It uses Puppet to generate Docker Compose configuration files to run Che and its associated server. Che’s server configuration is generated as a `che.properties` file that is mounted in the Che server when it boots. This command is executed on every `start` or `restart`.
+
+If you are using a `eclipse/che:<version>` image and it does not match the version in the `/instance/che.ver` file, the configuration aborts to prevent you from running a configuration for a different version.
+
+It respects `--no-force`, `--pull`, `--force`, and `--offline` command options.
+
+*_destroy_*
+
+The `destroy` command deletes the `/docs`, `che.env` and `/instance` directories, including user workspaces, projects, data, and user database. To skip the confirmation warning message, pass the `--quiet` argument in the command. To delete the `cli.log` file, pass the `--cli` argument. By default, the `cli-log` file is retained for traceability.
+
+*_dir_*
+
+The `dir` command boots a new Eclipse Che instance with a workspace for the `:/chedir` directory defined as volume mount in the parameter.
+
+For example, if you give `$HOME/my-project` as a parameter, a new Che instance is created using `$HOME/my-project` as a project in the IDE. Inside the IDE, the `/projects` directory contains a `my-project` directory with your host directory. Any changes inside the IDE are reflected in your host directory. And, updating a file on your local computer updates the content of the file inside the IDE.
+
+* `init`: Initializes the directory specified and adds a default `Chefile` file if there is none.
+* `up`: Boots Eclipse Che with workspace on directory.
+* `down`: Stops Eclipse Che and any workspaces.
+* `ssh`: Connects to the running workspace by using the `ssh` command.
+* `status`: Displays if an instance of Eclipse Che is running or not for the specified directory.
+
+*_download_*
+
+The `download` command is used to download Docker images stored in your Docker images repository. This command downloads images that are used by the CLI as utilities, for Che to do initialization and configuration, and for the runtime images that Che needs when it starts. This command respects `--offline`, `--pull`, `--force`, and `--no-force` (default) command options. It is invoked by the `che init`, `che config`, or `che start` commands.
+
+The `download` command is invoked by the `che init` command before initialization to download images for the version specified by `eclipse/che:<version>`.
+
+To override the docker images used by the CLI, set the following environment variables:
+
+* `IMAGE_INIT` to override the default `eclipse/che-init:<version>` docker image.
 * `IMAGE_CHE` to override the default `eclipse/che-server:<version>` docker image.
 
-For example if, for both images, you need to use to use a given tag in you own docker account, you can add the following parameters to the docker command:
+For example if, for both the images, you want to use a given tag in you own docker account, add the following parameters to the docker command:
 
 ----
 -e IMAGE_INIT=myDockerAccount/che-init:givenTag -e IMAGE_CHE=myDockerAccount/che-server:givenTag
 ----
 
-'''''
+*_info_*
 
-_info_
+The `info` command displays system state and debugging information. The `--network` command option runs a test to take the `CHE_HOST` variable value to test network connectivity by simulating the *browser > Che* and *Che > workspace* connectivity. The `--bundle` command option generates a support diagnostic bundle in a `TAR` file, which includes the output of certain commands and the execution logs.
 
-Displays system state and debugging information. `--network` runs a test to take your `CHE_HOST` value to test for networking connectivity simulating browser > Che and Che > workspace connectivity. `--bundle` will generate a support diagnostic bundle in a TAR file which includes the output of certain commands and your execution logs.
+*_init_*
 
-'''''
+The `init` command initializes an empty directory with a Che configuration and instance directory. The user data and runtime configuration are stored in the empty directory. You must provide a `<path>:/data` volume mount for Che to create the `instance` and `backup` sub-directories of `<path>`. Optionally, override the location of the `/instance` directory by mounting an additional local directory to the `/data/instance` directory. Optionally, override the location of where backups are stored by mounting an additional local directory to the `/data/backup` directory. After initialization, a `che.env` file is placed in the root directory of the path that you mounted to `/data`.
 
-_init_
-
-Initializes an empty directory with a Che configuration and instance folder where user data and runtime configuration will be stored. You must provide a `<path>:/data` volume mount, then Che creates a `instance` and `backup` subfolder of `<path>`. You can optionally override the location of `instance` by volume mounting an additional local folder to `/data/instance`. You can optionally override the location of where backups are stored by volume mounting an additional local folder to `/data/backup`. After initialization, a `che.env` file is placed into the root of the path that you mounted to `/data`.
-
-These variables can be set in your local environment shell before running and they will be respected during initialization:
+The following variables can be set in your local environment shell before running. These variables are respected during initialization:
 
 [width="100%",cols="44%,56%",options="header",]
 |===
@@ -152,127 +226,126 @@ These variables can be set in your local environment shell before running and th
 |`CHE_PORT` |The port the Che server will run on and expose in its container for your clients to connect to.
 |===
 
-Che depends upon Docker images. We use Docker images to:
+Che depends on Docker images. Docker images are used to:
 
-1.  Provide cross-platform utilities within the CLI. For example, in scenarios where we need to perform a `curl` operation, we use a small Docker image to perform this function. We do this as a precaution as many operating systems (like Windows) do not have curl installed.
-2.  Look up the master version and upgrade manifest, which is saved within the CLI docker image in the /version subfolder.
-3.  Perform initialization and configuration of Che such as with `eclipse/che-init`. This image contains templates to be installed onto your computer used by the CLI to configure Che for your specific OS.
+* Provide cross-platform utilities within the CLI. For example, to perform a `curl` operation, you use a small Docker image to perform this function. This is done as a precautionary measure because many operating systems (like Windows) do not have curl installed.
 
-You can control how Che downloads these images with command line options. All image downloads are performed with `docker pull`.
+* Look up the master version and upgrade manifest, which is saved within the CLI docker image in the `/version` sub-directory.
+
+* Perform initialization and configuration of Che as done with the `eclipse/che-init` command. This image contains templates to be installed on your computer used by the CLI to configure Che for your specific OS.
+
+You can control how Che downloads these images with command line options. All image downloads are performed using the `docker pull` command.
 
 [width="100%",cols="32%,68%",options="header",]
 |===
-|Mode >>>>>>>>>> |Description
-|`--no-force` |Default behavior. Will download an image if not found locally. A local check of the image will see if an image of a matching name is in your local registry and then skip the pull if it is found. This mode does not check DockerHub for a newer version of the same image.
-|`--pull` |Will always perform a `docker pull` when an image is requested. If there is a newer version of the same tagged image at DockerHub, it will pull it, or use the one in local cache. This keeps your images up to date, but execution is slower.
-|`--force` |Performs a forced removal of the local image using `docker rmi` and then pulls it again (anew) from DockerHub. You can use this as a way to clean your local cache and ensure that all images are new.
-|`--offline` |Loads Docker images from `backup/*.tar` folder during a pre-boot mode of the CLI. Used if you are performing an installation or start while disconnected from the Internet.
+|Mode |Description
+|`--no-force` |Default behavior. Downloads an image if not found locally. A local check of the image inspects if an image of a matching name is present in your local registry and then skips pulling the image if it is found. This mode does not check Docker Hub for a newer version of the same image.
+|`--pull` |Always perform a `docker pull` command when an image is requested. If there is a newer version of the same tagged image at Docker Hub, it pulls it, or uses the one in the local cache. This slows the execution, but keeps your images up-to-date.
+|`--force` |Performs a forced removal of the local image using the `docker rmi` command and then pulls it again from Docker Hub. Use this to clean your local cache and to ensure that all images are new.
+|`--offline` |Loads Docker images from the `backup/*.tar` directory during a pre-boot mode of the CLI. Used if you are performing an installation or start while disconnected from the Internet.
 |===
 
-You can reinstall Che on a folder that is already initialized and preserve your `che.env` values by passing the `--reinit` flag.
+You can reinstall Che on a directory that is already initialized and preserve your `che.env` values by passing the `--reinit` flag.
 
-'''''
+*_offline_*
 
-_offline_
+The `offline` command saves all the Docker images that Che requires in the `/backup/*.tar` files. Each image is saved as its own file. If the `backup` directory is available on a machine that is disconnected from the Internet and you start Che with the `--offline` command option, the CLI pre-boot sequence loads all the Docker images in the `/backup/` directory.
 
-Saves all of the Docker images that Che requires into `/backup/*.tar` files. Each image is saved as its own file. If the `backup` folder is available on a machine that is disconnected from the Internet and you start Che with `--offline`, the CLI pre-boot sequence will load all of the Docker images in the `/backup/` folder.
+The `--list` option lists all the core images and optional stack images that can be downloaded. The core system images and the CLI are always saved if an existing `TAR` file is not found. The `--image:<image-name>` command option downloads a single-stack image and can be used multiple times on the command line. You can use the `--all-stacks` option or the `--no-stacks` option to download all or none of the optional stack images.
 
-`--list` option will list all of the core images and optional stack images that can be downloaded. The core system images and the CLI will always be saved, if an existing TAR file is not found. `--image:<image-name>` will download a single stack image and can be used multiple times on the command line. You can use `--all-stacks` or `--no-stacks` to download all or none of the optional stack images.
+*_restart_
 
-'''''
+The `restart` command performs a `stop` action followed by a `start` action, respecting the `--pull`, `--force`, `--offline`, `--skip:config`, `--skip:preflight`, and `--skip:postflight` command options.
 
-_restart_
+*_restore_*
 
-Performs a `stop` followed by a `start`, respecting `--pull`, `--force`, `--offline`, `--skip:config`, `--skip:preflight`, and `--skip:postflight`.
+The `restore` command restores the `/instance` directory to its previous state. The start/stop/restart cycle ensures that the proper Docker images are available or downloaded, if not found.
 
-'''''
+[IMPORTANT]
+====
+We recommend using this command with caution because it deletes the existing `/instance` directory. As a precautionary measure, set these values to different directories when performing a restore action.
+====
 
-_restore_
+*_rmi_*
 
-Restores `/instance` to its previous state. You do not need to worry about having the right Docker images. The normal start / stop / restart cycle ensures that the proper Docker images are available or downloaded, if not found.
+The `rmi` command deletes the Docker images from the local registry that Che has downloaded for this version.
 
-This command will destroy your existing `/instance` folder, so use with caution, or set these values to different folders when performing a restore.
+*_ssh_*
 
-'''''
+The `ssh` command connects the current terminal where the command is started to the terminal of a machine of the workspace. If no machine is specified in the command, it connects to the default development machine. The syntax is `ssh <workspace-name> [machine-name]`. The ssh connection works only if there is a workspace ssh key setup. A default ssh key is automatically generated when a workspace is created.
 
-_rmi_
+*_sync_*
 
-Deletes the Docker images from the local registry that Che has downloaded for this version.
+The `sync` command synchronizes contents of a workspace with a local directory mounted to `:/sync`. The syntax is `-v <path-on-your-machine>:/sync eclipse/che sync <workspace-name>`.
 
-'''''
+To display a log of the underlying unison tool, use the `--unison-verbose` flag.
 
-_ssh_
+*_start_*
 
-Connects the current terminal where the command is started to the terminal of a machine of the workspace. If no machine is specified in the command, it will connect to the default machine which is the dev machine. The syntax is `ssh <workspace-name> [machine-name]` The ssh connection will work only if there is a workspace ssh key setup. A default ssh key is automatically generated when a workspace is created.
+The `start` command starts Che and its services using the `docker-compose` command. If the system cannot find a valid configuration, it performs an `init` command. Every `start`command and `restart` command runs a `config` command to generate a new configuration set using the latest configuration. The starting sequence tests if any ports required by Che are currently being used by other services and to verify access to key APIs.
 
-'''''
+To skip these checks, use the `--skip:preflight` and `--skip:postflight` command options. The typical Che start sequence includes an invocation of the `config` method, which regenerates configuration files placed into the `/instance` directory. To skip this generation, use the `--skip:config` command option. To automatically print out the server logs to the console during the booting of the server, append the  `--follow` argument to the command. To interrupt the output, press `CTRL-C to`.
 
-_sync_
+*_stop_*
 
-Synchronizes a workspace’s contents with a local folder mounted to :/sync The syntax is `-v <path-on-your-machine>:/sync eclipse/che sync <workspace-name>`
+The default stop is a graceful stop where each workspace is stopped and confirmed shutdown before stopping system services. If workspaces are configured to snap on stop, all snaps are completed before the system service shutdown begins. You can ignore workspace stop behavior and shut down only system services using the `–force` flag.
 
-To get extra information, the flag `--unison-verbose` can be used to display log of the underlying unison tool.
+*_test_*
 
-'''''
+The `test` command performs tests on your local instance of Che. For example, to check the ability to create a workspace, start the workspace by using a custom workspace runtime and then use it. For a list of all the tests available, use the `test` command.
 
-_start_
+*_upgrade_*
 
-Starts Che and its services using `docker-compose`. If the system cannot find a valid configuration it will perform an `init`. Every `start` and `restart` will run a `config` to generate a new configuration set using the latest configuration. The starting sequence will perform pre-flight testing to see if any ports required by Che are currently used by other services and post-flight checks to verify access to key APIs.
+The `upgrade` command manages the sequence of upgrading Che from one version to another. For a list of available versions that you can upgrade to, run the `che version` command.
 
-You can skip pre-flight and post-flight checks with `--skip:preflight` and `--skip:postflight` respectively. The typical Che start sequence includes an invocation of the `config` method, which regenerates configuration files placed into the `/instance` folder. You can skip this generation with `--skip:config`. You can automatically print out the server logs to the console during the booting of the server by appending `--follow`. This flag is blocking and requires you to CTRL-C to interrupt the output.
+The Che upgrade is done by using a `eclipse/che:<version>` image that is newer than the version you currently have installed. For example, if you have 5.0.0-M2 installed and you want to upgrade to 5.0.0-M7:
 
-'''''
-
-_stop_
-
-The default stop is a graceful stop where each workspace is stopped and confirmed shutdown before stopping system services. If workspaces are configured to snap on stop, then all snaps will be completed before system service shutdown begins. You can ignore workspace stop behavior and shut down only system services with –force flag.
-
-'''''
-
-_test_
-
-Performs some tests on your local instance of Che. It can for example check the ability to create a workspace, start the workspace by using a custom Workspace runtime and then use it. The list of all the tests available can be obtained by providing only `test` command.
-
-'''''
-
-_upgrade_
-
-Manages the sequence of upgrading Che from one version to another. Run `che version` to get a list of available versions that you can upgrade to.
-
-Upgrading Che is done by using a `eclipse/che:<version>` that is newer than the version you currently have installed. For example, if you have 5.0.0-M2 installed and want to upgrade to 5.0.0-M7, then:
-
+. To get the new version of Che:
++
 ----
-# Get the new version of Che
 docker pull eclipse/che:5.0.0-M7
-
-# You now have two eclipse/che images (one for each version)
-# Perform an upgrade - use the new image to upgrade old installation
+----
++
+You now have two eclipse/che images (one for each version).
++
+. Use the new image to upgrade the old installation:
++
+----
 docker run <volume-mounts> eclipse/che:5.0.0-M7 upgrade
 ----
 
-The upgrade command has numerous checks to prevent you from upgrading Che if the new image and the old version are not compatiable. In order for the upgrade procedure to proceed, the CLI image must be newer than the value of '/instance/che.ver'.
+The upgrade command has numerous checks to prevent you from upgrading Che if the new image and the old version are not compatiable. For the upgrade procedure to proceed, the CLI image must be newer than the value of '/instance/che.ver'.
 
-The upgrade process: a) performs a version compatibility check, b) downloads new Docker images that are needed to run the new version of Che, c) stops Che if it is currently running triggering a maintenance window, d) backs up your installation, e) initializes the new version, and f) starts Che.
+Following is a list of actions that the upgrade process performs in the background:
 
-You can run `che version` to see the list of available versions that you can upgrade to.
+. Performs a version compatibility check.
 
-`--skip-backup` option allow to skip https://github.com/codenvy/che-docs/blob/master/src/main/_docs/setup/setup-cli.md#backup[backup] during update, that could be useful to speed up upgrade because https://github.com/codenvy/che-docs/blob/master/src/main/_docs/setup/setup-cli.md#backup[backup] can be very expensive operation if `/instace` folder is really big due to many user worksapces and projects.
+. Downloads new Docker images that are needed to run the new version of Che.
 
-'''''
+. Stops Che if it is currently running triggering a maintenance window.
 
-_version_
+. Backs up your installation.
 
-Provides information on the current version and the available versions that are hosted in Che’s repositories. `che upgrade` enforces upgrade sequences and will prevent you from upgrading one version to another version where data migrations cannot be guaranteed.
+. Initializes the new version.
 
-'''''
+. Starts Che.
+
+For a list of available versions that you can upgrade to, run the `che version` command.
+
+The `--skip-backup` option allows you to skip the https://github.com/codenvy/che-docs/blob/master/src/main/_docs/setup/setup-cli.md#backup[backup] operation during the update. Skipping the backup operation speeds up the upgrade because the https://github.com/codenvy/che-docs/blob/master/src/main/_docs/setup/setup-cli.md#backup[backup operation] can be time consuming if the `/instance` directory contains many user worksapces and projects making it a large directory.
+
+*_version_*
+
+The `version` command provides information on the current version and the available versions that are hosted in Che’s repositories. The `che upgrade` command enforces upgrade sequences and prevents you from upgrading one version to another version where data migrations cannot be guaranteed.
+
 
 [id="cli-development"]
-== CLI Development
+== Developing and testing the CLI
 
 You can customize the CLI using a variety of techniques. This section discusses how engineers develop and test the CLI on their local machines.
 
 [id="structure"]
-== Structure
+== Structure of the Che CLI
 
 The Che CLI is constructed of multiple Docker images within the Che source repository.
 
@@ -282,47 +355,49 @@ The Che CLI is constructed of multiple Docker images within the Che source repos
 /dockerfiles/init  # Manifests used to configure Che on a host installation
 ----
 
-The Che CLI is authored in `bash`. The `cli` image depends upon both the `base` image and the `init` image. In the source repository, we have `build.sh` commands which will build these Docker images for you either one at a time or collectively as a group.
+The Che CLI is authored in the `bash` script. The `cli` image depends upon both the `base` image and the `init` image. In the source repository, the `build.sh` commands builds these Docker images either one at a time or collectively as a group.
 
-It can become tedious rebuilding images every time you want to test a small change to a bash script. You can avoid having to rebuild images each time for every change to a bash script by volume mounting the contents during the image execution. You cannot volume mount the `entrypoint.sh` file which is where each container has a launch point, but you can volume mount others:
+Rebuilding images every time you want to test a small change to a bash script can be tedious. To avoid rebuilding the images every time and for every change to a bash script, mount the contents during the image execution. You cannot mount the `entrypoint.sh` file. But, you can mount the following:
 
+* To mount the contents of the base image:
 ----
-# Volume mount the contents of the base image
 -v <path-to-che-repo>/dockerfiles/scripts/base/scripts:/base/scripts
+----
 
-# Volume mount the contents of the init image
+* To mount the contents of the `init` image:
+----
 -v <path-to-che-repo>:/repo
 ----
 
-If you run the Che CLI in this configuration, then any changes made to the bash files or templates in those repositories will be used without having to first rebuild the CLI image.
+If you run the Che CLI in this configuration, any changes made to the `bash` files or templates in those repositories are used without having to first rebuild the CLI image.
 
 [id="custom-cli"]
-== Custom CLI
+== Customizing the Che CLI
 
-The Che CLI was designed to be overridden to allow different CLIs to be created from the same base structure. This is how Codenvy and ARTIK has an identical CLIs to Che. The CLI is created with a few minimal assets:
+The Che CLI was designed to be overridden to allow different CLIs to be created from the same base structure. This is how Codenvy and ARTIK has identical CLIs to Che. The CLI is created with the following minimal assets:
 
 ----
 /dockerfiles/cli/build.sh               # Local file to build the image
-/dockerfiles/cli/Dockerfile             # Image definition, must FROM eclipse/che-base:nightly
-/dockerfiles/cli/scripts                # Contains additional commands in form of cmd_<name>.sh
+/dockerfiles/cli/Dockerfile             # Image definition, must FROM `eclipse/che-base:nightly`
+/dockerfiles/cli/scripts                # Contains additional commands in the form of `cmd_<name>.sh`
 /dockerfiles/cli/scripts/entrypoint.sh  # The entrypoint of the CLI container, with usage() method
 /dockerfiles/cli/scripts/cli.sh         # Defines CLI-specific product names & variables
-/dockerfiles/cli/version                # Contains version-specific data the CLI requires
+/dockerfiles/cli/version                # Contains version-specific data that the CLI requires
 ----
 
-You can add additional commands to the Che CLI beyond the base set of commands that are provided by adding a file of the name `cmd_<name>.sh` into the `scripts` folder. Codenvy is an https://github.com/codenvy/codenvy/tree/master/dockerfiles/cli/scripts[example that adds additional commands].
+You can add additional commands to the Che CLI beyond the base set of commands that are provided by adding a file of the name `cmd_<name>.sh` into the `scripts` directory. Codenvy is an example that adds https://github.com/codenvy/codenvy/tree/master/dockerfiles/cli/scripts[additional commands].
 
-The `version` folder has information that details the latest version and a sub-folder for each version that is available for installation. Each version subfolder has version-specific data that the CLI depends upon to create a manifest of Docker images that must be downloaded to support the product that is going to be run. When we generate a release of the Che CLI, we have our CI systems automatically update the `/version` folder with the version-specific information contained in a release.
+The `version` directory has information about the latest version and a sub-directory for each version that is available for installation. Each version sub-directory has version-specific data that the CLI depends upon to create a manifest of Docker images that must be downloaded to support the product that is going to be run. When a release of the Che CLI is generated, the CI systems automatically update the `/version` directory with the version-specific information contained in the release.
 
 [id="puppet-templates"]
-== Puppet Templates
+== Puppet templates
 
-The Che CLI uses Puppet to generate OS-specific configuration files based upon environment variables set by the user either with `-e <VALUE>` options on the command line, or by modifying their `che.env` file. We pass all of these values into Puppet and then run a puppet configuration utility across the files contained in the `/dockerfiles/init/modules` and `/dockerfiles/init/manifests` folder to take the templates contained within the `/init` module, marry them with user-specific variables, and then generate an instance-specific configuration in `/instance`. Puppet has logic constructs that allow us to generate different kinds of constructs with logic based upon the values provided by end users.
+The Che CLI uses Puppet to generate OS-specific configuration files based on environment variables set by the user either with the `-e <VALUE>` option on the command line, or by modifying their `che.env` file. We pass all of these values into Puppet and then run a Puppet configuration utility across the files contained in the `/dockerfiles/init/modules` and `/dockerfiles/init/manifests` directories to take the templates contained within the `/init` module, marry them with user-specific variables, and then generate an instance-specific configuration in the `/instance` directory. Puppet has logic constructs that allow us to generate different kinds of constructs with logic based upon the values provided by the end users.
 
-This puppet-based approach allow us to simplify the outputs for end users and limit the locations where end users need to configure various parts of the system. One powerful example of this is that we generate two `docker-compose.yml` files from a single Puppet template. In the user’s `/instance` folder is `docker-compose.yml` and `docker-compose-container.yml`. The first one is a configuration file that allows a user to run Docker compose for Che on their host. They can just `docker-compose up` in that folder. The second file is for running Docker compose from within a container, which is what the CLI does. The syntax of Docker compose changes in each of these scenarios as the files being referenced from within the compose syntax are different. In the `init` image, we have a single template for Docker Compose and then apply it in two configurations using Puppet.
+This Puppet-based approach allows us to simplify the outputs for end users and limit the locations where end users need to configure various parts of the system. One powerful example of this is that we generate two `docker-compose.yml` files from a single Puppet template. The `docker-compose.yml` and `docker-compose-container.yml` files are located in the user’s `/instance` directory. The first one is a configuration file that allows a user to run Docker compose for Che on their host. They can run the `docker-compose up` command in that directory. The second file is for running Docker compose from within a container, which is what the CLI does. The syntax of Docker compose changes in each of these scenarios as the files being referenced from within the compose syntax are different. There is a single template for Docker Compose in the `init` image. It is then applied in two configurations using Puppet.
 
 [id="cli-tests"]
-== CLI Tests
+== CLI tests
 
-There are existing https://github.com/sstephenson/bats[bats] tests for the Che CLI, which runs automatically with each execution of a `build.sh` script located in the `dockerfiles/cli` folder. To skip them, pass `--skip-tests` argument when running the build script. If you want to just run tests you can achieve it by running script `test.sh` located in the same folder. Tests utilizes docker image `eclipse/che-bats` which is build from `Dockerfile` placed in `dockerfiles/bats`.
+There are existing https://github.com/sstephenson/bats[bats] tests for the Che CLI, which run automatically with each execution of a `build.sh` script located in the `dockerfiles/cli` directory. To skip them, pass the `--skip-tests` argument when running the build script. If you want to just run tests you can achieve it by running the `test.sh` script located in the same directory. Tests utilizes docker image `eclipse/che-bats` which is build from `Dockerfile` placed in `dockerfiles/bats`.
 

--- a/src/main/pages/setup-docker/docker-cli.adoc
+++ b/src/main/pages/setup-docker/docker-cli.adoc
@@ -10,18 +10,18 @@ folder: setup-docker
 [id="cli-syntax-and-commands"]
 == CLI syntax and commands
 
-The CLI is a Docker-formatted container image that comes with a collection of commands to configure, interact, and start Che. The CLI also contains commands, such as `sync` and `ssh`, for end users to interact with workspaces.
+The CLI is a Docker-formatted container image that comes with a collection of commands to configure, interact with, and start Che. The CLI also contains commands, such as `sync` and `ssh`, for end users to interact with workspaces.
 
 Command:
 ----
-docker run -it --rm <DOCKER_PARAMETERS> eclipse/che-cli:<version> [COMMAND]
+$ docker run -it --rm <DOCKER_PARAMETERS> eclipse/che-cli:<version> [COMMAND]
 ----
 
-Following is the mandatory Docker parameter for the Docker CLI image:
+Following is the mandatory `docker` command parameter for the CLI image:
 
 * `-v <LOCAL_PATH>:/data`: The user, instance, and log data are saved here.
 
-The following tables lists the optional Docker parameters that you can use with the Docker CLI image.
+The following tables lists the optional `docker` command parameters that you can use with the CLI image.
 
 [cols="2*", options="header"]
 |===
@@ -72,12 +72,12 @@ The following table lists the commands that you can use with the Docker CLI imag
 |Backs up Che configuration and data to the `/data/backup` volume mount
 
 |`config`                              
-|Generates a Che configuration from variables; run on any `start/restart` command
+|Generates a Che configuration from variables; run on any `start` or `restart` command
 
 |`destroy`                              
 |Stops services, and deletes che instance data
 
-|`dir <_command_>`                        
+|`dir <command>`                        
 |Use `Chedir` and `Chefile` in the directory mounted to `:/chedir`
   
 |`download`                           
@@ -93,7 +93,7 @@ The following table lists the commands that you can use with the Docker CLI imag
 |Initializes a directory with a Che install
 
 |`offline`                            
-|Saves Che Docker images into the `TAR` files for offline installation
+|Saves Che container images into TAR files for offline installation
 
 |`restart`                           
 |Restarts the Che services
@@ -102,10 +102,10 @@ The following table lists the commands that you can use with the Docker CLI imag
 |Restores Che configuration and data from the `/data/backup` mount
 
 |`rmi`                                  
-|Removes the Docker images for <version>, forcing a repull
+|Removes the container images for `<version>`, forcing a re-pull
 
 |`ssh <_workspace-name_> [_machine-name_]`       
-|SSH to a workspace if SSH agent enabled
+|SSH to a workspace if SSH agent is enabled
 
 |`start`                                
 |Starts the Che services
@@ -147,11 +147,11 @@ The following table lists the global command options that you can use with the D
 
 The CLI has the following three primary phases:
 
-* The initialization phase is executed by the `init` command. It installs version-specific files into the directory mounted to `/data`. This includes the universal configuration file named `che.env`, a version identifier, and a location where configuration files are saved. The configuration is executed by the `config` command. The `config` command takes the `che.env` configuration file and the OS of your host system as input and generates an OS-specific set of configuration files in the `data/instance` directory."
+* The initialization phase is executed by the `init` command. It installs version-specific files into the directory mounted to `/data/`. This includes the universal configuration file named `che.env`, a version identifier, and a location where configuration files are saved. The configuration is executed by the `config` command. The `config` command takes the `che.env` configuration file and the OS of your host system as input and generates an OS-specific set of configuration files in the `data/instance` directory."
 
-* The configuration phase runs an initialization if a directory is not found. Every execution of the `config` command overwrites the files in the `/data/instance` directory with the latest configuration. This ensures that if an administrator modifies any configuration file, the instance’s configuration files are updated consistently. The CLI generates a large number of configuration files specific to running Che. The configuration files are sourced from the Puppet templates that are stored in the GitHub repository under `/dockerfiles/init`. 
+* The configuration phase runs an initialization if a directory is not found. Every execution of the `config` command overwrites the files in the `/data/instance/` directory with the latest configuration. This ensures that if an administrator modifies any configuration file, the instance’s configuration files are updated consistently. The CLI generates a large number of configuration files specific to running Che. The configuration files are sourced from the Puppet templates that are stored in the GitHub repository under `/dockerfiles/init/`. 
 
-* The start phase is executed by the `start` command. It uses a configuration-generated `docker-compose-container.yml` file to launch Eclipse Che. The start phase always executes a `config` command, so any files that were edited in the `/data/instance` directory are overwritten with the generated configuration from the CLI.
+* The start phase is executed by the `start` command. It uses a configuration-generated `docker-compose-container.yml` file to launch Eclipse Che. The start phase always executes a `config` command, so any files that were edited in the `/data/instance/` directory are overwritten with the generated configuration from the CLI.
 
 The CLI hides most error conditions from the standard output. Internal stack traces and error output are redirected to the `cli.log` file, which is saved in the host directory where `:/data` is mounted.
 
@@ -159,27 +159,27 @@ You can override any value in the `che.env` file for a single execution by passi
 
 Following are some selected commands and their uses.
 
-_action_::
-The `action` command executes some actions on the Eclipse Che instance or on a workspace running inside Che. To list all workspaces on Che, use the `action list-workspaces` command. To execute a command on a workspace, use the  `action execute-command <workspace-name> <action>` command; here, the `action` command is interpreted by Bash.
+`action`::
+The `action` command executes some actions on the Eclipse Che instance or on a workspace running inside Che. To list all workspaces on Che, use the `action list-workspaces` command. To execute a command on a workspace, use the  `action execute-command <workspace-name> <action>` command; here, the `<action>` parameter is interpreted by the shell.
 
 
-_backup_::
-The `backup` command creates `TAR` files from the `/instance` directory and places them in the `/backup` directory. These files are restoration-ready.
+`backup`::
+The `backup` command creates TAR files from the `/instance/` directory and places them in the `/backup/` directory. These files are restoration-ready.
 
-_config_::
-The `config` command generates a Che instance configuration that is placed in the `/instance` directory. It uses Puppet to generate Docker Compose configuration files to run Che and its associated server. Che’s server configuration is generated as a `che.properties` file that is mounted in the Che server when it boots. This command is executed on every `start` or `restart`.
+`config`::
+The `config` command generates a Che instance configuration that is placed in the `/instance/` directory. It uses Puppet to generate Docker Compose configuration files to run Che and its associated server. Che server configuration is generated as a `che.properties` file that is mounted in the Che server when it boots. This command is executed on every `start` or `restart`.
 +	
 If you are using a `eclipse/che:<version>` image and it does not match the version in the `/instance/che.ver` file, the configuration aborts to prevent you from running a configuration for a different version.
 +	
 It respects the `--no-force`, `--pull`, `--force`, and `--offline` command options.
 
-_destroy_::
-The `destroy` command deletes the `/docs`, `che.env` and `/instance` directories, including user workspaces, projects, data, and user database. To skip the confirmation warning message, pass the `--quiet` argument in the command. To delete the `cli.log` file, pass the `--cli` argument. By default, the `cli-log` file is retained for traceability.
+`destroy`::
+The `destroy` command deletes the `che.env` file and the `/docs/` and `/instance/` directories, including user workspaces, projects, data, and user database. To skip the confirmation warning message, pass the `--quiet` argument in the command. To delete the `cli.log` file, pass the `--cli` argument. By default, the `cli-log` file is retained for traceability.
 
-_dir_::
+`dir`::
 The `dir` command boots a new Eclipse Che instance with a workspace for the `:/chedir` directory defined as volume mount in the parameter.
 +
-For example, if you give `$HOME/my-project` as a parameter, a new Che instance is created using `$HOME/my-project` as a project in the IDE. Inside the IDE, the `/projects` directory contains a `my-project` directory with your host directory. Any changes inside the IDE are reflected in your host directory. And, updating a file on your local computer updates the content of the file inside the IDE.
+For example, if you give `$HOME/my-project` as a parameter, a new Che instance is created using `$HOME/my-project` as a project in the IDE. Inside the IDE, the `/projects/` directory contains a `my-project/` directory with your host directory. Any changes inside the IDE are reflected in your host directory. Updating a file on your local computer updates the content of the file inside the IDE.
 +
 * `init`: Initializes the directory specified and adds a default `Chefile` if there is none.
 * `up`: Boots Eclipse Che with workspace on directory.
@@ -187,8 +187,8 @@ For example, if you give `$HOME/my-project` as a parameter, a new Che instance i
 * `ssh`: Connects to the running workspace by using the `ssh` command.
 * `status`: Displays if an instance of Eclipse Che is running or not for the specified directory.
 
-_download_::
-The `download` command is used to download Docker images stored in your Docker images repository. This command downloads images that are used by the CLI as utilities, for Che to do initialization and configuration, and for the runtime images that Che needs when it starts. This command respects the `--offline`, `--pull`, `--force`, and `--no-force` (default) command options. It is invoked by the `che init`, `che config`, or `che start` commands.
+`download`::
+The `download` command is used to download container images stored in your image repository. This command downloads images that are used by the CLI as utilities, for Che to do initialization and configuration, and for the runtime images that Che needs when it starts. This command respects the `--offline`, `--pull`, `--force`, and `--no-force` (default) command options. It is invoked by the `che init`, `che config`, or `che start` commands.
 +
 The `download` command is invoked by the `che init` command before initialization to download images for the version specified by `eclipse/che:<version>`.
 +
@@ -203,11 +203,15 @@ For example, if you want to use a given tag in your own Docker account for both 
 -e IMAGE_INIT=myDockerAccount/che-init:givenTag -e IMAGE_CHE=myDockerAccount/che-server:givenTag
 ----
 
-_info_::
-The `info` command displays system state and debugging information. The `--network` command option runs a test to take the `CHE_HOST` variable value to test network connectivity by simulating the *browser > Che* and *Che > workspace* connectivity. The `--bundle` command option generates a support diagnostic bundle in a `TAR` file, which includes the output of certain commands and the execution logs.
+`info`::
+The `info` command displays system state and debugging information. The `--network` command option runs a test to take the `CHE_HOST` variable value to test network connectivity by simulating the *browser > Che* and *Che > workspace* connectivity. The `--bundle` command option generates a support diagnostic bundle in a TAR file, which includes the output of certain commands and the execution logs.
 
-_init_::
-The `init` command initializes an empty directory with a Che configuration and instance directory. The user data and runtime configuration are stored in the empty directory. You must provide a `<path>:/data` volume mount for Che to create the `instance` and `backup` sub-directories of `<path>`. Optionally, override the location of the `/instance` directory by mounting an additional local directory to the `/data/instance` directory. Optionally, override the location of where backups are stored by mounting an additional local directory to the `/data/backup` directory. After initialization, a `che.env` file is placed in the root directory of the path that you mounted to `/data`.
+`init`::
+The `init` command initializes an empty directory with a Che configuration and instance directory. The user data and runtime configuration are stored in the empty directory. You must provide a `<path>:/data` volume mount for Che to create the `instance/` and `backup/` sub-directories of `<path>`. After initialization, a `che.env` file is placed in the root directory of the path that you mounted to `/data/`.
++
+Overriding the location of the `/instance/` directory:: Mount an additional local directory to the `/data/instance/` directory.
+
+Overriding the location of where backups are stored:: Mount an additional local directory to the `/data/backup/` directory.
 +
 The following variables can be set in your local environment shell before running. These variables are respected during initialization:
 +
@@ -218,106 +222,119 @@ The following variables can be set in your local environment shell before runnin
 |`CHE_PORT` |The port the Che server will run on and expose in its container for your clients to connect to.
 |===
 +
-Che depends on Docker images. Docker images are used to:
+Che depends on container images. The images are used to:
 +
-* Provide cross-platform utilities within the CLI. For example, to perform a `curl` operation, you use a small Docker image to perform this function. This is done as a precautionary measure because many operating systems do not have `curl` installed.
+* Provide cross-platform utilities within the CLI. For example, to perform a `curl` operation, you use a small container image to perform this function. This is done as a precautionary measure because many operating systems do not have `curl` installed.
 +
-* Look up the master version and upgrade manifest, which is saved within the CLI docker image in the `/version` sub-directory.
+* Find the master version and upgrade manifest, which is saved within the CLI container image in the `/version/` sub-directory.
 +
 * Perform initialization and configuration of Che as done with the `eclipse/che-init` command. This image contains templates to be installed on your computer used by the CLI to configure Che for your specific OS.
 +
-You can control how Che downloads these images with command line options. All image downloads are performed using the `docker pull` command.
+You can control how Che downloads these images with command-line options. All image downloads are performed using the `docker pull` command.
 +
 [width="100%",cols="32%,68%",options="header",]
 |===
 |Mode |Description
-|`--no-force` |Default behavior. Downloads an image if not found locally. A local check of the image inspects if an image of a matching name is present in your local registry and then skips pulling the image if it is found. This mode does not check Docker Hub for a newer version of the same image.
-|`--pull` |Always perform a `docker pull` command when an image is requested. If there is a newer version of the same tagged image at Docker Hub, it pulls it, or uses the one in the local cache. This slows the execution, but keeps your images up-to-date.
-|`--force` |Performs a forced removal of the local image using the `docker rmi` command and then pulls it again from Docker Hub. Use this to clean your local cache and to ensure that all images are new.
-|`--offline` |Loads `tar-archived` Docker images from the `backup` directory during the pre-boot mode of the CLI. Used if you are performing an installation or start while disconnected from the Internet.
+|`--no-force` |The default behavior. Downloads an image if not found locally. A local check of the image inspects if an image of a matching name is present in your local registry and then skips pulling the image if it is found. This mode does not check DockerHub for a newer version of the same image.
+|`--pull` |Always perform a `docker pull` command when an image is requested. If there is a newer version of the same tagged image at DockerHub, it pulls it, or uses the one in the local cache. This slows the execution but keeps your images up-to-date.
+|`--force` |Performs a forced removal of the local image using the `docker rmi` command and then pulls it again from DockerHub. Use this to clean your local cache and to ensure that all images are new.
+|`--offline` |Loads tar-archived container images from the `backup/` directory during the pre-boot mode of the CLI. Used if you are performing an installation or start while disconnected from the Internet.
 |===
 +
 You can reinstall Che on a directory that is already initialized and preserve your `che.env` values by passing the `--reinit` flag.
 
-_offline_::
-The `offline` command saves all the Docker images that Che requires in the `/backup/*.tar` files. Each image is saved as its own file. If the `backup` directory is available on a machine that is disconnected from the Internet and you start Che with the `--offline` command option, the CLI pre-boot sequence loads all the Docker images in the `/backup/` directory.
+`offline`::
+The `offline` command saves all the container images that Che requires in `/backup/*.tar` files. Each image is saved as its own file. If the `backup/` directory is available on a machine that is disconnected from the Internet and you start Che with the `--offline` command option, the CLI pre-boot sequence loads all the container images in the `backup/` directory.
 +
-The `--list` option lists all the core images and optional stack images that can be downloaded. The core system images and the CLI are always saved if an existing `TAR` file is not found. The `--image:<image-name>` command option downloads a single-stack image and can be used multiple times on the command line. You can use the `--all-stacks` option or the `--no-stacks` option to download all or none of the optional stack images.
+The `--list` option lists all the core images and optional stack images that can be downloaded. The core system images and the CLI are always saved if an existing TAR file is not found. The `--image:<image-name>` command option downloads a single-stack image and can be used multiple times on the command line. You can use the `--all-stacks` option or the `--no-stacks` option to download all or none of the optional stack images.
 
-_restart_::
+`restart`::
 The `restart` command performs a `stop` action followed by a `start` action, respecting the `--pull`, `--force`, `--offline`, `--skip:config`, `--skip:preflight`, and `--skip:postflight` command options.
 
-_restore_::
+`restore`::
 The `restore` command restores the `/instance` directory to its previous state. The start-stop-restart cycle ensures that the proper Docker images are available or downloaded if not found.
 +
 [IMPORTANT]
 ====
-Use this command with caution because it deletes the existing `/instance` directory. As a precautionary measure, set these values to different directories when performing a restore action.
+Use this command with caution because it deletes the existing `/instance/` directory. As a precautionary measure, set these values to different directories when performing a restore action.
 ====
 
-_rmi_::
-The `rmi` command deletes the Docker images from the local registry that Che has downloaded for this version.
+`rmi`::
+The `rmi` command deletes the container images that Che has downloaded for this version from the local registry.
 
-_ssh_::
-The `ssh` command connects the current terminal where the command is started to the terminal of a machine of the workspace. If no machine is specified in the command, it connects to the default development machine. The syntax is `ssh <workspace-name> [machine-name]`. The SSH connection works only if there is a workspace SSH key set up. A default SSH key is automatically generated when a workspace is created.
+`ssh`::
+The `ssh` command connects the current terminal where the command is started to the terminal of a machine of the workspace. If no machine is specified in the command, it connects to the default development machine. The syntax is:
++
+----
+ ssh <workspace-name> [machine-name]
+----
++
+The SSH connection only works with a configured workspace SSH key. A default SSH key is automatically generated when a workspace is created.
 
-_sync_::
-The `sync` command synchronizes contents of a workspace with a local directory mounted to `:/sync`. The syntax is `-v <path-on-your-machine>:/sync eclipse/che sync <workspace-name>`.
+`sync`::
+The `sync` command synchronizes contents of a workspace with a local directory mounted to `:/sync`. The syntax is:
++
+----
+-v <path-on-your-machine>:/sync eclipse/che sync <workspace-name>
+----
 +
 To display a log of the underlying unison tool, use the `--unison-verbose` flag.
 
-_start_::
-The `start` command starts Che and its services using the `docker-compose` command. If the system cannot find a valid configuration, it performs an `init` command. Every `start` command and `restart` command runs a `config` command to generate a new configuration set using the latest configuration. The starting sequence tests if any ports required by Che are currently being used by other services and to verify access to key APIs.
-+
-To skip these checks, use the `--skip:preflight` and `--skip:postflight` command options. The typical Che start sequence includes an invocation of the `config` method, which regenerates configuration files placed into the `/instance` directory. To skip this generation, use the `--skip:config` command option. To automatically print out the server logs to the console during the booting of the server, append the  `--follow` argument to the command. To interrupt the output, press `CTRL-C`. Or, use the shell commands to interrupt the output.
+`start`::
+The `start` command starts Che and its services using the `docker-compose` command. In the absence of valid configuration, it performs an `init` command. Every `start` and `restart` command runs the `config` command to generate a new configuration set using the latest configuration files placed into the `/instance/` directory. The starting sequence also tests if any ports required by Che are currently being used by other services and to verify access to key APIs.
 
-_stop_::
+Skipping the generation of configuration:: Use the `--skip:config` option.
+Skipping checks:: Use the `--skip:preflight` and `--skip:postflight` options.
+Automatically printing server logs during the boot:: Use the `--follow` option. To interrupt the output, press *Ctrl+c*, or use the shell commands to interrupt the output.
++
+
+`stop`::
 The default stop is a graceful stop where each workspace is stopped and confirmed shut down before stopping system services. If workspaces are configured to snap on stop, all snaps are completed before the system service shutdown begins. You can ignore workspace stop behavior and shut down only system services using the `–force` flag.
 
-_test_::
-The `test` command performs tests on your local instance of Che. For example, to check the ability to create a workspace, start the workspace by using a custom workspace runtime and then use it. For a list of all the tests available, use the `test` command.
+`test`::
+The `test` command performs tests on your local instance of Che. For example, to check the ability to create a workspace, start the workspace by using a custom workspace runtime, and then use it. For a list of all tests available, use the `test` command.
 
-_upgrade_::
+`upgrade`::
 The `upgrade` command manages the sequence of upgrading Che from one version to another. For a list of available versions that you can upgrade to, run the `che version` command.
 +
-The Che upgrade is done by using a `eclipse/che:<version>` image that is newer than the version you currently have installed. For example, if you have 5.0.0-M2 installed and you want to upgrade to 5.0.0-M7:
+The Che upgrade is done by using a `eclipse/che:<version>` image that is newer than the version you currently have installed. For example, if you have `<version>` installed and you want to upgrade to `<version+1>`:
 +
 . To get the new version of Che:
 +
 ----
-docker pull eclipse/che:5.0.0-M7
+$ docker pull eclipse/che:<version+1>
 ----
 +
-You now have two eclipse/che images (one for each version).
+You now have two `eclipse/che` images (one for each version).
 +
 . Use the new image to upgrade the old installation:
 +
 ----
-docker run <volume-mounts> eclipse/che:5.0.0-M7 upgrade
+$ docker run <volume-mounts> eclipse/che:<version+1> upgrade
 ----
 +
-The upgrade command has numerous checks to prevent you from upgrading Che if the new image and the old version are not compatible. For the upgrade procedure to proceed, the CLI image must be newer than the value of '/instance/che.ver'.
+The `upgrade` command has numerous checks to prevent you from upgrading Che if the new image and the old version are not compatible. For the upgrade procedure to proceed, the CLI image must be newer than the value of `/instance/che.ver`.
 +
 Following is a list of actions that the upgrade process performs in the background:
 
-a. Performs a version compatibility check.
+.. Performs a version compatibility check.
 
-b. Downloads new Docker images that are needed to run the new version of Che.
+.. Downloads new Docker images that are needed to run the new version of Che.
 
-c. Stops Che if it is currently running and triggers a maintenance window.
+.. Stops Che if it is currently running and triggers a maintenance window.
 
-d. Backs up your installation.
+.. Backs up your installation.
 
-e. Initializes the new version.
+.. Initializes the new version.
 
-f. Starts Che.
+.. Starts Che.
 
 For a list of available versions that you can upgrade to, run the `che version` command.
 
 The `--skip-backup` option allows you to skip the https://github.com/codenvy/che-docs/blob/master/src/main/_docs/setup/setup-cli.md#backup[backup] operation during the update. Skipping the backup operation speeds up the upgrade because the https://github.com/codenvy/che-docs/blob/master/src/main/_docs/setup/setup-cli.md#backup[backup operation] can be time consuming if the `/instance` directory contains many user worksapces and projects making it a large directory.
 
-_version_::
-The `version` command provides information on the current version and the available versions that are hosted in Che’s repositories. The `che upgrade` command enforces upgrade sequences and prevents you from upgrading one version to another version where data migrations cannot be guaranteed.
+`version`::
+The `version` command provides information on the current version and the available versions that are hosted in Che repositories. The `che upgrade` command enforces upgrade sequences and prevents you from upgrading one version to another version where data migrations cannot be guaranteed.
 
 
 [id="cli-development"]
@@ -331,14 +348,18 @@ You can customize the CLI using a variety of techniques. This section discusses 
 The Che CLI is constructed of multiple Docker images within the Che source repository.
 
 ----
-/dockerfiles/base  # Common functions and commands
-/dockerfiles/cli   # CLI entrypoint, overrides, and version information
-/dockerfiles/init  # Manifests used to configure Che on a host installation
+/dockerfiles/base	<1>
+/dockerfiles/cli	<2>
+/dockerfiles/init	<3>
 ----
 
-The Che CLI is written in Bash. The `cli` image depends upon both the `base` image and the `init` image. In the source repository, the `build.sh` command builds these Docker images either one at a time or collectively as a group.
+<1> Common functions and commands
+<2> CLI entrypoint, overrides, and version information
+<3> Manifests used to configure Che on a host installation
 
-Rebuilding images every time you want to test a small change to Bash script can be tedious. To avoid rebuilding the images every time and for every change to a Bash script, mount the contents during the image execution. You cannot mount the `entrypoint.sh` file. But, you can mount the following:
+The Che CLI is written in Bash. The `cli` image depends upon both the `base` image and the `init` image. In the source repository, the `build.sh` script builds these Docker images either one at a time or collectively as a group.
+
+Rebuilding images every time you want to test a small change to Bash script can be tedious. To avoid rebuilding the images every time and for every change to a Bash script, mount the contents during the image execution. You cannot mount the `entrypoint.sh` file, but you can mount the following:
 
 * To mount the contents of the `base` image:
 ----
@@ -355,30 +376,45 @@ If you run the Che CLI in this configuration, any changes made to the Bash files
 [id="custom-cli"]
 == Customizing the Che CLI
 
-The Che CLI was designed to be overridden to allow different CLIs to be created from the same base structure. This is how Codenvy and ARTIK has identical CLIs to Che. The CLI is created with the following minimal assets:
+The Che CLI was designed to be overridden to allow different CLIs to be created from the same base structure. The CLI is created with the following minimal assets:
 
 ----
-/dockerfiles/cli/build.sh               # Local file to build the image
-/dockerfiles/cli/Dockerfile             # Image definition, must FROM `eclipse/che-base:nightly`
-/dockerfiles/cli/scripts                # Contains additional commands in the form of `cmd_<name>.sh`
-/dockerfiles/cli/scripts/entrypoint.sh  # The entrypoint of the CLI container, with usage() method
-/dockerfiles/cli/scripts/cli.sh         # Defines CLI-specific product names & variables
-/dockerfiles/cli/version                # Contains version-specific data that the CLI requires
+/dockerfiles/cli/build.sh		<1>
+/dockerfiles/cli/Dockerfile		<2>
+/dockerfiles/cli/scripts		<3>
+/dockerfiles/cli/scripts/entrypoint.sh	<4>
+/dockerfiles/cli/scripts/cli.sh		<5>
+/dockerfiles/cli/version		<6>
 ----
 
-You can add additional commands to the Che CLI beyond the base set of commands that are provided by adding a file of the name `cmd_<name>.sh` into the `scripts` directory. Codenvy is an example that adds https://github.com/codenvy/codenvy/tree/master/dockerfiles/cli/scripts[additional commands].
+<1> Local file to build the image
+<2> Image definition, must FROM `eclipse/che-base:nightly`
+<3> Contains additional commands in the form of `cmd_<name>.sh`
+<4> The entrypoint of the CLI container, with usage() method
+<5> Defines CLI-specific product names & variables
+<6> Contains version-specific data that the CLI requires
 
-The `version` directory has information about the latest version and a sub-directory for each version that is available for installation. Each version sub-directory has version-specific data that the CLI depends upon to create a manifest of Docker images that must be downloaded to support the product that is going to be run. When a release of the Che CLI is generated, the CI systems automatically update the `/version` directory with the version-specific information contained in the release.
+You can add additional commands to the Che CLI beyond the base set of commands that are provided by adding a file of the name `cmd_<name>.sh` into the `scripts/` directory.
+
+The `version/` directory contains information about the latest version and a sub-directory for each version that is available for installation. Each version sub-directory has version-specific data that the CLI depends on to create a manifest of container images that must be downloaded to support the product that is going to be run. When a release of the Che CLI is generated, the CI systems automatically update the `version/` directory with the version-specific information contained in the release.
 
 [id="puppet-templates"]
 == Puppet templates
 
-The Che CLI uses Puppet to generate OS-specific configuration files based on environment variables set by the user either with the `-e <VALUE>` option on the command line, or by modifying their `che.env` file. We pass all of these values into Puppet and then run a Puppet configuration utility across the files contained in the `/dockerfiles/init/modules` and `/dockerfiles/init/manifests` directories to take the templates contained within the `/init` module, marry them with user-specific variables, and then generate an instance-specific configuration in the `/instance` directory. Puppet has logic constructs that allow us to generate different kinds of constructs with logic based upon the values provided by the end users.
+The Che CLI uses Puppet to generate OS-specific configuration files based on environment variables set by the user either with the `-e <VALUE>` option on the command line, or by modifying their `che.env` file. 
 
-This Puppet-based approach allows us to simplify the outputs for end users and limit the locations where end users need to configure various parts of the system. One powerful example of this is that we generate two `docker-compose.yml` files from a single Puppet template. The `docker-compose.yml` and `docker-compose-container.yml` files are located in the user’s `/instance` directory. The first one is a configuration file that allows a user to run Docker Compose for Che on their host. They can run the `docker-compose up` command in that directory. The second file is for running Docker Compose from within a container, which is what the CLI does. The syntax of Docker Compose changes in each of these scenarios as the files being referenced from within the compose syntax are different. There is a single template for Docker Compose in the `init` image. It is then applied in two configurations using Puppet.
+A Puppet configuration utility parses files contained in the `/dockerfiles/init/modules/` and `/dockerfiles/init/manifests/` directories to take the templates contained in the `/init/` directory, matches them with user-specific variables, and generates an instance-specific configuration in the `/instance/` directory. Puppet has logic constructs that allow us to generate different kinds of constructs with logic based on the values provided by the end users.
+
+This Puppet-based approach allows to simplify the outputs for end users and limit the locations where end users need to configure various parts of the system. An example of this is that we generate two `docker-compose.yml` files from a single Puppet template. The `docker-compose.yml` and `docker-compose-container.yml` files are located in the user’s `/instance/` directory.
+
+`docker-compose.yml`:: A configuration file that allows a user to run Docker Compose for Che on their host. They can run the `docker-compose up` command in that directory.
+
+`docker-compose-container.yml`:: A configuration file for running Docker Compose from within a container, which is what the CLI does.
+
+The syntax of Docker Compose changes in each of these scenarios as the files being referenced from within the compose syntax are different. There is a single template for Docker Compose in the `init` image. It is then applied in two configurations using Puppet.
 
 [id="cli-tests"]
 == CLI tests
 
-There are existing https://github.com/sstephenson/bats[bats] tests for the Che CLI, which run automatically with each execution of a `build.sh` script located in the `dockerfiles/cli` directory. To skip them, pass the `--skip-tests` argument when running the build script. To only run the tests, execute the `test.sh` script located in the same directory. The tests utilize the `eclipse/che-bats` docker image, which is built from the `Dockerfile` placed in the `dockerfiles/bats` directory.
+There are existing https://github.com/sstephenson/bats[bats] tests for the Che CLI, which run automatically with each execution of the `build.sh` script located in the `dockerfiles/cli/` directory. To skip them, pass the `--skip-tests` argument when running the build script. To only run the tests, execute the `test.sh` script located in the same directory. The tests utilize the `eclipse/che-bats` docker image, which is built from the `Dockerfile` placed in the `dockerfiles/bats/` directory.
 

--- a/src/main/pages/setup-docker/docker-cli.adoc
+++ b/src/main/pages/setup-docker/docker-cli.adoc
@@ -19,7 +19,11 @@ $ docker run -it --rm <DOCKER_PARAMETERS> eclipse/che-cli:<version> [COMMAND]
 
 Following is the mandatory `docker` command parameter for the CLI image:
 
-* `-v <LOCAL_PATH>:/data`: The user, instance, and log data are saved here.
+----
+-v <LOCAL_PATH>:/data
+----
+
+The user, instance, and log data are saved here.
 
 The following tables lists the optional `docker` command parameters that you can use with the CLI image.
 
@@ -27,34 +31,34 @@ The following tables lists the optional `docker` command parameters that you can
 |===
 |Optional Docker parameter
 |Description
-|`-e CHE_HOST=<YOUR_HOST>`              
+|`-e CHE_HOST=<YOUR_HOST>`
 |IP address or hostname where Che serves its users
 
-|`-e CHE_PORT=<YOUR_PORT>`            
+|`-e CHE_PORT=<YOUR_PORT>`
 |Port on which Che binds itself
 
-|`-e CHE_CONTAINER=<YOUR_NAME>`         
+|`-e CHE_CONTAINER=<YOUR_NAME>`
 |Prefix name for the Che container
 
-|`-v <LOCAL_PATH>:/data/instance`     
+|`-v <LOCAL_PATH>:/data/instance`
 |The instance, user, log data is saved here
 
-|`-v <LOCAL_PATH>:/data/backup`         
+|`-v <LOCAL_PATH>:/data/backup`
 |Backup files are saved here
 
-|`-v <LOCAL_PATH>:/repo`               
+|`-v <LOCAL_PATH>:/repo`
 |Che git repository - uses local binaries and manifests
 
-|`-v <LOCAL_PATH>:/assembly`            
+|`-v <LOCAL_PATH>:/assembly`
 |Che assembly - uses local binaries
 
-|`-v <LOCAL_PATH>:/sync`               
+|`-v <LOCAL_PATH>:/sync`
 |Where `remote ws` files are copied with the `sync` command
 
-|`-v <LOCAL_PATH>:/unison`              
+|`-v <LOCAL_PATH>:/unison`
 |Where unison profile for optimizing the `sync` command resides
- 
-|`-v <LOCAL_PATH>:/chedir`              
+
+|`-v <LOCAL_PATH>:/chedir`
 |Source repository to convert into workspace with the `Chedir` utility
 |===
 
@@ -65,64 +69,64 @@ The following table lists the commands that you can use with the Docker CLI imag
 |===
 |Command
 |Description
-|`action <action-name>`      
+|`action <action-name>`
 |Start action on Che instance
 
-|`backup`                          
+|`backup`
 |Backs up Che configuration and data to the `/data/backup` volume mount
 
-|`config`                              
+|`config`
 |Generates a Che configuration from variables; run on any `start` or `restart` command
 
-|`destroy`                              
+|`destroy`
 |Stops services, and deletes che instance data
 
-|`dir <command>`                        
+|`dir <command>`
 |Use `Chedir` and `Chefile` in the directory mounted to `:/chedir`
-  
-|`download`                           
+
+|`download`
 |Pulls Docker images for the current Che version
 
-|`help`                                 
+|`help`
 |Displays information about Che and the CLI
 
 |`info`
 |Displays system state and debugging information
 
-|`init`                                
+|`init`
 |Initializes a directory with a Che install
 
-|`offline`                            
+|`offline`
 |Saves Che container images into TAR files for offline installation
 
-|`restart`                           
+|`restart`
 |Restarts the Che services
 
-|`restore`                              
+|`restore`
 |Restores Che configuration and data from the `/data/backup` mount
 
-|`rmi`                                  
+|`rmi`
 |Removes the container images for `<version>`, forcing a re-pull
 
-|`ssh <_workspace-name_> [_machine-name_]`       
+|`ssh <__workspace-name__> [_machine-name_]`
 |SSH to a workspace if SSH agent is enabled
 
-|`start`                                
+|`start`
 |Starts the Che services
 
-|`stop`                                 
+|`stop`
 |Stops the Che services
-  
-|`sync <_workspace-name_>`                     
+
+|`sync <__workspace-name__>`
 |Synchronizes workspace with local directory mounted to `:/sync`
- 
-|`test <_test-name_>`                     
+
+|`test <__test-name__>`
 |Starts test on the Che instance
 
-|`upgrade`                             
+|`upgrade`
 |Upgrades Che from one version to another with migrations and backups
 
-|`version`                             
+|`version`
 |Installed version and upgrade paths
 |===
 
@@ -132,16 +136,16 @@ The following table lists the global command options that you can use with the D
 |===
 |Command option
 |Description
-|`--fast`                               
+|`--fast`
 |Skips networking, version, nightly, and preflight checks
 
-|`--offline`                            
+|`--offline`
 |Runs CLI in offline mode, loading images from the disk
 
-|`--debug`                              
+|`--debug`
 |Enable debugging of the Che server
 
-|`--trace`                              
+|`--trace`
 |Activates trace output for debugging the CLI
 |===
 
@@ -149,7 +153,7 @@ The CLI has the following three primary phases:
 
 * The initialization phase is executed by the `init` command. It installs version-specific files into the directory mounted to `/data/`. This includes the universal configuration file named `che.env`, a version identifier, and a location where configuration files are saved. The configuration is executed by the `config` command. The `config` command takes the `che.env` configuration file and the OS of your host system as input and generates an OS-specific set of configuration files in the `data/instance` directory."
 
-* The configuration phase runs an initialization if a directory is not found. Every execution of the `config` command overwrites the files in the `/data/instance/` directory with the latest configuration. This ensures that if an administrator modifies any configuration file, the instance’s configuration files are updated consistently. The CLI generates a large number of configuration files specific to running Che. The configuration files are sourced from the Puppet templates that are stored in the GitHub repository under `/dockerfiles/init/`. 
+* The configuration phase runs an initialization if a directory is not found. Every execution of the `config` command overwrites the files in the `/data/instance/` directory with the latest configuration. This ensures that if an administrator modifies any configuration file, the instance’s configuration files are updated consistently. The CLI generates a large number of configuration files specific to running Che. The configuration files are sourced from the Puppet templates that are stored in the GitHub repository under `/dockerfiles/init/`.
 
 * The start phase is executed by the `start` command. It uses a configuration-generated `docker-compose-container.yml` file to launch Eclipse Che. The start phase always executes a `config` command, so any files that were edited in the `/data/instance/` directory are overwritten with the generated configuration from the CLI.
 
@@ -164,28 +168,31 @@ The `action` command executes some actions on the Eclipse Che instance or on a w
 
 
 `backup`::
-The `backup` command creates TAR files from the `/instance/` directory and places them in the `/backup/` directory. These files are restoration-ready.
+The `backup` command creates TAR files from the `instance/` directory and places them in the `/backup/` directory. These files are restoration-ready.
 
 `config`::
-The `config` command generates a Che instance configuration that is placed in the `/instance/` directory. It uses Puppet to generate Docker Compose configuration files to run Che and its associated server. Che server configuration is generated as a `che.properties` file that is mounted in the Che server when it boots. This command is executed on every `start` or `restart`.
+The `config` command generates a Che instance configuration that is placed in the `instance/` directory. It uses Puppet to generate Docker Compose configuration files to run Che and its associated server. Che server configuration is generated as a `che.properties` file that is mounted in the Che server when it boots. This command is executed on every `start` or `restart`.
 +	
-If you are using a `eclipse/che:<version>` image and it does not match the version in the `/instance/che.ver` file, the configuration aborts to prevent you from running a configuration for a different version.
+If you are using a `eclipse/che:<version>` image and it does not match the version in the `instance/che.ver` file, the configuration aborts to prevent you from running a configuration for a different version.
 +	
 It respects the `--no-force`, `--pull`, `--force`, and `--offline` command options.
 
 `destroy`::
-The `destroy` command deletes the `che.env` file and the `/docs/` and `/instance/` directories, including user workspaces, projects, data, and user database. To skip the confirmation warning message, pass the `--quiet` argument in the command. To delete the `cli.log` file, pass the `--cli` argument. By default, the `cli-log` file is retained for traceability.
+The `destroy` command deletes the `che.env` file and the `/docs/` and `instance/` directories, including user workspaces, projects, data, and user database. To skip the confirmation warning message, pass the `--quiet` argument in the command. To delete the `cli.log` file, pass the `--cli` argument. By default, the `cli-log` file is retained for traceability.
 
 `dir`::
 The `dir` command boots a new Eclipse Che instance with a workspace for the `:/chedir` directory defined as volume mount in the parameter.
 +
 For example, if you give `$HOME/my-project` as a parameter, a new Che instance is created using `$HOME/my-project` as a project in the IDE. Inside the IDE, the `/projects/` directory contains a `my-project/` directory with your host directory. Any changes inside the IDE are reflected in your host directory. Updating a file on your local computer updates the content of the file inside the IDE.
 +
-* `init`: Initializes the directory specified and adds a default `Chefile` if there is none.
-* `up`: Boots Eclipse Che with workspace on directory.
-* `down`: Stops Eclipse Che and any workspaces.
-* `ssh`: Connects to the running workspace by using the `ssh` command.
-* `status`: Displays if an instance of Eclipse Che is running or not for the specified directory.
+--
+[horizontal]
+`init`:: Initializes the directory specified and adds a default `Chefile` if there is none.
+`up`:: Boots Eclipse Che with workspace on directory.
+`down`:: Stops Eclipse Che and any workspaces.
+`ssh`:: Connects to the running workspace by using the `ssh` command.
+`status`:: Displays if an instance of Eclipse Che is running or not for the specified directory.
+--
 
 `download`::
 The `download` command is used to download container images stored in your image repository. This command downloads images that are used by the CLI as utilities, for Che to do initialization and configuration, and for the runtime images that Che needs when it starts. This command respects the `--offline`, `--pull`, `--force`, and `--no-force` (default) command options. It is invoked by the `che init`, `che config`, or `che start` commands.
@@ -209,9 +216,10 @@ The `info` command displays system state and debugging information. The `--netwo
 `init`::
 The `init` command initializes an empty directory with a Che configuration and instance directory. The user data and runtime configuration are stored in the empty directory. You must provide a `<path>:/data` volume mount for Che to create the `instance/` and `backup/` sub-directories of `<path>`. After initialization, a `che.env` file is placed in the root directory of the path that you mounted to `/data/`.
 +
-Overriding the location of the `/instance/` directory:: Mount an additional local directory to the `/data/instance/` directory.
-
+--
+Overriding the location of the `instance/` directory:: Mount an additional local directory to the `/data/instance/` directory.
 Overriding the location of where backups are stored:: Mount an additional local directory to the `/data/backup/` directory.
+--
 +
 The following variables can be set in your local environment shell before running. These variables are respected during initialization:
 +
@@ -256,7 +264,7 @@ The `restore` command restores the `/instance` directory to its previous state. 
 +
 [IMPORTANT]
 ====
-Use this command with caution because it deletes the existing `/instance/` directory. As a precautionary measure, set these values to different directories when performing a restore action.
+Use this command with caution because it deletes the existing `instance/` directory. As a precautionary measure, set these values to different directories when performing a restore action.
 ====
 
 `rmi`::
@@ -281,12 +289,13 @@ The `sync` command synchronizes contents of a workspace with a local directory m
 To display a log of the underlying unison tool, use the `--unison-verbose` flag.
 
 `start`::
-The `start` command starts Che and its services using the `docker-compose` command. In the absence of valid configuration, it performs an `init` command. Every `start` and `restart` command runs the `config` command to generate a new configuration set using the latest configuration files placed into the `/instance/` directory. The starting sequence also tests if any ports required by Che are currently being used by other services and to verify access to key APIs.
-
+The `start` command starts Che and its services using the `docker-compose` command. In the absence of valid configuration, it performs an `init` command. Every `start` and `restart` command runs the `config` command to generate a new configuration set using the latest configuration files placed into the `instance/` directory. The starting sequence also tests if any ports required by Che are currently being used by other services and to verify access to key APIs.
++
+--
 Skipping the generation of configuration:: Use the `--skip:config` option.
 Skipping checks:: Use the `--skip:preflight` and `--skip:postflight` options.
 Automatically printing server logs during the boot:: Use the `--follow` option. To interrupt the output, press *Ctrl+c*, or use the shell commands to interrupt the output.
-+
+--
 
 `stop`::
 The default stop is a graceful stop where each workspace is stopped and confirmed shut down before stopping system services. If workspaces are configured to snap on stop, all snaps are completed before the system service shutdown begins. You can ignore workspace stop behavior and shut down only system services using the `–force` flag.
@@ -313,7 +322,7 @@ You now have two `eclipse/che` images (one for each version).
 $ docker run <volume-mounts> eclipse/che:<version+1> upgrade
 ----
 +
-The `upgrade` command has numerous checks to prevent you from upgrading Che if the new image and the old version are not compatible. For the upgrade procedure to proceed, the CLI image must be newer than the value of `/instance/che.ver`.
+The `upgrade` command has numerous checks to prevent you from upgrading Che if the new image and the old version are not compatible. For the upgrade procedure to proceed, the CLI image must be newer than the value of `instance/che.ver`.
 +
 Following is a list of actions that the upgrade process performs in the background:
 
@@ -352,7 +361,6 @@ The Che CLI is constructed of multiple Docker images within the Che source repos
 /dockerfiles/cli	<2>
 /dockerfiles/init	<3>
 ----
-
 <1> Common functions and commands
 <2> CLI entrypoint, overrides, and version information
 <3> Manifests used to configure Che on a host installation
@@ -362,11 +370,13 @@ The Che CLI is written in Bash. The `cli` image depends upon both the `base` ima
 Rebuilding images every time you want to test a small change to Bash script can be tedious. To avoid rebuilding the images every time and for every change to a Bash script, mount the contents during the image execution. You cannot mount the `entrypoint.sh` file, but you can mount the following:
 
 * To mount the contents of the `base` image:
++
 ----
 -v <path-to-che-repo>/dockerfiles/scripts/base/scripts:/base/scripts
 ----
 
 * To mount the contents of the `init` image:
++
 ----
 -v <path-to-che-repo>:/repo
 ----
@@ -386,12 +396,11 @@ The Che CLI was designed to be overridden to allow different CLIs to be created 
 /dockerfiles/cli/scripts/cli.sh		<5>
 /dockerfiles/cli/version		<6>
 ----
-
 <1> Local file to build the image
 <2> Image definition, must FROM `eclipse/che-base:nightly`
 <3> Contains additional commands in the form of `cmd_<name>.sh`
-<4> The entrypoint of the CLI container, with usage() method
-<5> Defines CLI-specific product names & variables
+<4> The entrypoint of the CLI container, with the `usage()` method
+<5> Defines CLI-specific product names and variables
 <6> Contains version-specific data that the CLI requires
 
 You can add additional commands to the Che CLI beyond the base set of commands that are provided by adding a file of the name `cmd_<name>.sh` into the `scripts/` directory.
@@ -401,11 +410,11 @@ The `version/` directory contains information about the latest version and a sub
 [id="puppet-templates"]
 == Puppet templates
 
-The Che CLI uses Puppet to generate OS-specific configuration files based on environment variables set by the user either with the `-e <VALUE>` option on the command line, or by modifying their `che.env` file. 
+The Che CLI uses Puppet to generate OS-specific configuration files based on environment variables set by the user either with the `-e <VALUE>` option on the command line, or by modifying their `che.env` file.
 
-A Puppet configuration utility parses files contained in the `/dockerfiles/init/modules/` and `/dockerfiles/init/manifests/` directories to take the templates contained in the `/init/` directory, matches them with user-specific variables, and generates an instance-specific configuration in the `/instance/` directory. Puppet has logic constructs that allow us to generate different kinds of constructs with logic based on the values provided by the end users.
+A Puppet configuration utility parses files contained in the `/dockerfiles/init/modules/` and `/dockerfiles/init/manifests/` directories to take the templates contained in the `/init/` directory, matches them with user-specific variables, and generates an instance-specific configuration in the `instance/` directory. Puppet has logic constructs that allow us to generate different kinds of constructs with logic based on the values provided by the end users.
 
-This Puppet-based approach allows to simplify the outputs for end users and limit the locations where end users need to configure various parts of the system. An example of this is that we generate two `docker-compose.yml` files from a single Puppet template. The `docker-compose.yml` and `docker-compose-container.yml` files are located in the user’s `/instance/` directory.
+This Puppet-based approach allows to simplify the outputs for end users and limit the locations where end users need to configure various parts of the system. An example of this is that we generate two `docker-compose.yml` files from a single Puppet template. The `docker-compose.yml` and `docker-compose-container.yml` files are located in the user’s `instance/` directory.
 
 `docker-compose.yml`:: A configuration file that allows a user to run Docker Compose for Che on their host. They can run the `docker-compose up` command in that directory.
 

--- a/src/main/pages/setup-docker/docker-cli.adoc
+++ b/src/main/pages/setup-docker/docker-cli.adoc
@@ -10,7 +10,7 @@ folder: setup-docker
 [id="cli-syntax-and-commands"]
 == CLI syntax and commands
 
-The CLI is a Docker image that comes with a collection of commands to configure, interact, and start Che. The CLI also contains commands, such as `sync` and `ssh`, for end users to interact with workspaces.
+The CLI is a Docker-formatted container image that comes with a collection of commands to configure, interact, and start Che. The CLI also contains commands, such as `sync` and `ssh`, for end users to interact with workspaces.
 
 Command:
 ----
@@ -55,7 +55,7 @@ The following tables lists the optional Docker parameters that you can use with 
 |Where unison profile for optimizing the `sync` command resides
  
 |`-v <LOCAL_PATH>:/chedir`              
-|Soure repository to convert into workspace with the `Chedir` utility
+|Source repository to convert into workspace with the `Chedir` utility
 |===
 
 
@@ -84,7 +84,7 @@ The following table lists the commands that you can use with the Docker CLI imag
 |Pulls Docker images for the current Che version
 
 |`help`                                 
-|This message displays information about Che and the CLI
+|Displays information about Che and the CLI
 
 |`info`
 |Displays system state and debugging information
@@ -126,7 +126,7 @@ The following table lists the commands that you can use with the Docker CLI imag
 |Installed version and upgrade paths
 |===
 
-The following table lists the global command options that you can se with the Docker CLI image.
+The following table lists the global command options that you can use with the Docker CLI image.
 
 [cols="2*", options="header"]
 |===
@@ -136,170 +136,152 @@ The following table lists the global command options that you can se with the Do
 |Skips networking, version, nightly, and preflight checks
 
 |`--offline`                            
-|Runs CLI in the offline mode, loading images from the disk
+|Runs CLI in offline mode, loading images from the disk
 
 |`--debug`                              
 |Enable debugging of the Che server
 
 |`--trace`                              
-|Activates trace output for debugging CLI
+|Activates trace output for debugging the CLI
 |===
 
 The CLI has the following three primary phases:
 
-* The initialization phase is executed by the `init` command. It installs version-specific files into the directory mounted to `/data`. This includes the universal configuration file named `che.env`, a version identifier, and a location where configuration files are saved. The configuration is executed by the `config` command. It takes as input, the `che.env` configuration file, the OS of your host, and then generates an OS-specific set of configuration files in the `/data/instance` directory that can be used to run an instance of Che. 
+* The initialization phase is executed by the `init` command. It installs version-specific files into the directory mounted to `/data`. This includes the universal configuration file named `che.env`, a version identifier, and a location where configuration files are saved. The configuration is executed by the `config` command. The `config` command takes the `che.env` configuration file and the OS of your host system as input and generates an OS-specific set of configuration files in the `data/instance` directory."
 
-* The configuration phase runs an initialization if a directory is not found. Every execution of the `config` command overwrites the files in the `/data/instance` directory with the latest configuration. This ensures that if an administrator modifies any configuration file, the instance’s configuration files are updated consistently. The CLI generates a large number of configuration files specific to running Che. The configuration files are sourced from the puppet templates that are stored in the GitHub repository under `/dockerfiles/init`. 
+* The configuration phase runs an initialization if a directory is not found. Every execution of the `config` command overwrites the files in the `/data/instance` directory with the latest configuration. This ensures that if an administrator modifies any configuration file, the instance’s configuration files are updated consistently. The CLI generates a large number of configuration files specific to running Che. The configuration files are sourced from the Puppet templates that are stored in the GitHub repository under `/dockerfiles/init`. 
 
-* The start phase is executed by the `start` command and it uses a configuration-generated `docker-compose-container.yml` file to launch Eclipse Che. The start phase always executes a `config` command, so any files that were edited in the `/data/instance` directory are overwritten with the generated configuration from the CLI.
+* The start phase is executed by the `start` command. It uses a configuration-generated `docker-compose-container.yml` file to launch Eclipse Che. The start phase always executes a `config` command, so any files that were edited in the `/data/instance` directory are overwritten with the generated configuration from the CLI.
 
-The CLI hides most error conditions from standard out. Internal stack traces and error output are redirected to the `cli.log` file, which is saved in the host directory where `:/data` is mounted.
+The CLI hides most error conditions from the standard output. Internal stack traces and error output are redirected to the `cli.log` file, which is saved in the host directory where `:/data` is mounted.
 
 You can override any value in the `che.env` file for a single execution by passing the `-e NAME=VALUE` argument on the command line. The CLI detects the values on the command line and ignores those imported from the `che.env` file.
 
 Following are some selected commands and their uses.
 
-*_action_*
+_action_::
+The `action` command executes some actions on the Eclipse Che instance or on a workspace running inside Che. To list all workspaces on Che, use the `action list-workspaces` command. To execute a command on a workspace, use the  `action execute-command <workspace-name> <action>` command; here, the `action` command is interpreted by Bash.
 
-The `action` command executes some actions on the Eclipse Che instance or on a workspace running inside Che. To list all workspaces on Che, use the `action list-workspaces` command. To execute a command on a workspace, use the  `action execute-command <workspace-name> <action>` command; here, action is a `bash` command.
 
-
-*_backup_*
-
+_backup_::
 The `backup` command creates `TAR` files from the `/instance` directory and places them in the `/backup` directory. These files are restoration-ready.
 
-*_config_*
-
+_config_::
 The `config` command generates a Che instance configuration that is placed in the `/instance` directory. It uses Puppet to generate Docker Compose configuration files to run Che and its associated server. Che’s server configuration is generated as a `che.properties` file that is mounted in the Che server when it boots. This command is executed on every `start` or `restart`.
-
++	
 If you are using a `eclipse/che:<version>` image and it does not match the version in the `/instance/che.ver` file, the configuration aborts to prevent you from running a configuration for a different version.
++	
+It respects the `--no-force`, `--pull`, `--force`, and `--offline` command options.
 
-It respects `--no-force`, `--pull`, `--force`, and `--offline` command options.
-
-*_destroy_*
-
+_destroy_::
 The `destroy` command deletes the `/docs`, `che.env` and `/instance` directories, including user workspaces, projects, data, and user database. To skip the confirmation warning message, pass the `--quiet` argument in the command. To delete the `cli.log` file, pass the `--cli` argument. By default, the `cli-log` file is retained for traceability.
 
-*_dir_*
-
+_dir_::
 The `dir` command boots a new Eclipse Che instance with a workspace for the `:/chedir` directory defined as volume mount in the parameter.
-
++
 For example, if you give `$HOME/my-project` as a parameter, a new Che instance is created using `$HOME/my-project` as a project in the IDE. Inside the IDE, the `/projects` directory contains a `my-project` directory with your host directory. Any changes inside the IDE are reflected in your host directory. And, updating a file on your local computer updates the content of the file inside the IDE.
-
-* `init`: Initializes the directory specified and adds a default `Chefile` file if there is none.
++
+* `init`: Initializes the directory specified and adds a default `Chefile` if there is none.
 * `up`: Boots Eclipse Che with workspace on directory.
 * `down`: Stops Eclipse Che and any workspaces.
 * `ssh`: Connects to the running workspace by using the `ssh` command.
 * `status`: Displays if an instance of Eclipse Che is running or not for the specified directory.
 
-*_download_*
-
-The `download` command is used to download Docker images stored in your Docker images repository. This command downloads images that are used by the CLI as utilities, for Che to do initialization and configuration, and for the runtime images that Che needs when it starts. This command respects `--offline`, `--pull`, `--force`, and `--no-force` (default) command options. It is invoked by the `che init`, `che config`, or `che start` commands.
-
+_download_::
+The `download` command is used to download Docker images stored in your Docker images repository. This command downloads images that are used by the CLI as utilities, for Che to do initialization and configuration, and for the runtime images that Che needs when it starts. This command respects the `--offline`, `--pull`, `--force`, and `--no-force` (default) command options. It is invoked by the `che init`, `che config`, or `che start` commands.
++
 The `download` command is invoked by the `che init` command before initialization to download images for the version specified by `eclipse/che:<version>`.
-
-To override the docker images used by the CLI, set the following environment variables:
-
-* `IMAGE_INIT` to override the default `eclipse/che-init:<version>` docker image.
-* `IMAGE_CHE` to override the default `eclipse/che-server:<version>` docker image.
-
-For example if, for both the images, you want to use a given tag in you own docker account, add the following parameters to the docker command:
-
++
+To override the Docker-formatted container images used by the CLI, set the following environment variables:
++
+* `IMAGE_INIT` to override the default `eclipse/che-init:<version>` Docker-formatted container image.
+* `IMAGE_CHE` to override the default `eclipse/che-server:<version>` Docker-formatted container image.
++
+For example, if you want to use a given tag in your own Docker account for both images, add the following parameters to the `docker` command:
++
 ----
 -e IMAGE_INIT=myDockerAccount/che-init:givenTag -e IMAGE_CHE=myDockerAccount/che-server:givenTag
 ----
 
-*_info_*
-
+_info_::
 The `info` command displays system state and debugging information. The `--network` command option runs a test to take the `CHE_HOST` variable value to test network connectivity by simulating the *browser > Che* and *Che > workspace* connectivity. The `--bundle` command option generates a support diagnostic bundle in a `TAR` file, which includes the output of certain commands and the execution logs.
 
-*_init_*
-
+_init_::
 The `init` command initializes an empty directory with a Che configuration and instance directory. The user data and runtime configuration are stored in the empty directory. You must provide a `<path>:/data` volume mount for Che to create the `instance` and `backup` sub-directories of `<path>`. Optionally, override the location of the `/instance` directory by mounting an additional local directory to the `/data/instance` directory. Optionally, override the location of where backups are stored by mounting an additional local directory to the `/data/backup` directory. After initialization, a `che.env` file is placed in the root directory of the path that you mounted to `/data`.
-
++
 The following variables can be set in your local environment shell before running. These variables are respected during initialization:
-
++
 [width="100%",cols="44%,56%",options="header",]
 |===
 |Variable |Description
 |`CHE_HOST` |The IP address or DNS name of the Che service. We use `eclipse/che-ip` to attempt discovery if not set.
 |`CHE_PORT` |The port the Che server will run on and expose in its container for your clients to connect to.
 |===
-
++
 Che depends on Docker images. Docker images are used to:
-
-* Provide cross-platform utilities within the CLI. For example, to perform a `curl` operation, you use a small Docker image to perform this function. This is done as a precautionary measure because many operating systems (like Windows) do not have curl installed.
-
++
+* Provide cross-platform utilities within the CLI. For example, to perform a `curl` operation, you use a small Docker image to perform this function. This is done as a precautionary measure because many operating systems do not have `curl` installed.
++
 * Look up the master version and upgrade manifest, which is saved within the CLI docker image in the `/version` sub-directory.
-
++
 * Perform initialization and configuration of Che as done with the `eclipse/che-init` command. This image contains templates to be installed on your computer used by the CLI to configure Che for your specific OS.
-
++
 You can control how Che downloads these images with command line options. All image downloads are performed using the `docker pull` command.
-
++
 [width="100%",cols="32%,68%",options="header",]
 |===
 |Mode |Description
 |`--no-force` |Default behavior. Downloads an image if not found locally. A local check of the image inspects if an image of a matching name is present in your local registry and then skips pulling the image if it is found. This mode does not check Docker Hub for a newer version of the same image.
 |`--pull` |Always perform a `docker pull` command when an image is requested. If there is a newer version of the same tagged image at Docker Hub, it pulls it, or uses the one in the local cache. This slows the execution, but keeps your images up-to-date.
 |`--force` |Performs a forced removal of the local image using the `docker rmi` command and then pulls it again from Docker Hub. Use this to clean your local cache and to ensure that all images are new.
-|`--offline` |Loads Docker images from the `backup/*.tar` directory during a pre-boot mode of the CLI. Used if you are performing an installation or start while disconnected from the Internet.
+|`--offline` |Loads `tar-archived` Docker images from the `backup` directory during the pre-boot mode of the CLI. Used if you are performing an installation or start while disconnected from the Internet.
 |===
-
++
 You can reinstall Che on a directory that is already initialized and preserve your `che.env` values by passing the `--reinit` flag.
 
-*_offline_*
-
+_offline_::
 The `offline` command saves all the Docker images that Che requires in the `/backup/*.tar` files. Each image is saved as its own file. If the `backup` directory is available on a machine that is disconnected from the Internet and you start Che with the `--offline` command option, the CLI pre-boot sequence loads all the Docker images in the `/backup/` directory.
-
++
 The `--list` option lists all the core images and optional stack images that can be downloaded. The core system images and the CLI are always saved if an existing `TAR` file is not found. The `--image:<image-name>` command option downloads a single-stack image and can be used multiple times on the command line. You can use the `--all-stacks` option or the `--no-stacks` option to download all or none of the optional stack images.
 
-*_restart_
-
+_restart_::
 The `restart` command performs a `stop` action followed by a `start` action, respecting the `--pull`, `--force`, `--offline`, `--skip:config`, `--skip:preflight`, and `--skip:postflight` command options.
 
-*_restore_*
-
-The `restore` command restores the `/instance` directory to its previous state. The start/stop/restart cycle ensures that the proper Docker images are available or downloaded, if not found.
-
+_restore_::
+The `restore` command restores the `/instance` directory to its previous state. The start-stop-restart cycle ensures that the proper Docker images are available or downloaded if not found.
++
 [IMPORTANT]
 ====
-We recommend using this command with caution because it deletes the existing `/instance` directory. As a precautionary measure, set these values to different directories when performing a restore action.
+Use this command with caution because it deletes the existing `/instance` directory. As a precautionary measure, set these values to different directories when performing a restore action.
 ====
 
-*_rmi_*
-
+_rmi_::
 The `rmi` command deletes the Docker images from the local registry that Che has downloaded for this version.
 
-*_ssh_*
+_ssh_::
+The `ssh` command connects the current terminal where the command is started to the terminal of a machine of the workspace. If no machine is specified in the command, it connects to the default development machine. The syntax is `ssh <workspace-name> [machine-name]`. The SSH connection works only if there is a workspace SSH key set up. A default SSH key is automatically generated when a workspace is created.
 
-The `ssh` command connects the current terminal where the command is started to the terminal of a machine of the workspace. If no machine is specified in the command, it connects to the default development machine. The syntax is `ssh <workspace-name> [machine-name]`. The ssh connection works only if there is a workspace ssh key setup. A default ssh key is automatically generated when a workspace is created.
-
-*_sync_*
-
+_sync_::
 The `sync` command synchronizes contents of a workspace with a local directory mounted to `:/sync`. The syntax is `-v <path-on-your-machine>:/sync eclipse/che sync <workspace-name>`.
-
++
 To display a log of the underlying unison tool, use the `--unison-verbose` flag.
 
-*_start_*
+_start_::
+The `start` command starts Che and its services using the `docker-compose` command. If the system cannot find a valid configuration, it performs an `init` command. Every `start` command and `restart` command runs a `config` command to generate a new configuration set using the latest configuration. The starting sequence tests if any ports required by Che are currently being used by other services and to verify access to key APIs.
++
+To skip these checks, use the `--skip:preflight` and `--skip:postflight` command options. The typical Che start sequence includes an invocation of the `config` method, which regenerates configuration files placed into the `/instance` directory. To skip this generation, use the `--skip:config` command option. To automatically print out the server logs to the console during the booting of the server, append the  `--follow` argument to the command. To interrupt the output, press `CTRL-C`. Or, use the shell commands to interrupt the output.
 
-The `start` command starts Che and its services using the `docker-compose` command. If the system cannot find a valid configuration, it performs an `init` command. Every `start`command and `restart` command runs a `config` command to generate a new configuration set using the latest configuration. The starting sequence tests if any ports required by Che are currently being used by other services and to verify access to key APIs.
+_stop_::
+The default stop is a graceful stop where each workspace is stopped and confirmed shut down before stopping system services. If workspaces are configured to snap on stop, all snaps are completed before the system service shutdown begins. You can ignore workspace stop behavior and shut down only system services using the `–force` flag.
 
-To skip these checks, use the `--skip:preflight` and `--skip:postflight` command options. The typical Che start sequence includes an invocation of the `config` method, which regenerates configuration files placed into the `/instance` directory. To skip this generation, use the `--skip:config` command option. To automatically print out the server logs to the console during the booting of the server, append the  `--follow` argument to the command. To interrupt the output, press `CTRL-C to`.
-
-*_stop_*
-
-The default stop is a graceful stop where each workspace is stopped and confirmed shutdown before stopping system services. If workspaces are configured to snap on stop, all snaps are completed before the system service shutdown begins. You can ignore workspace stop behavior and shut down only system services using the `–force` flag.
-
-*_test_*
-
+_test_::
 The `test` command performs tests on your local instance of Che. For example, to check the ability to create a workspace, start the workspace by using a custom workspace runtime and then use it. For a list of all the tests available, use the `test` command.
 
-*_upgrade_*
-
+_upgrade_::
 The `upgrade` command manages the sequence of upgrading Che from one version to another. For a list of available versions that you can upgrade to, run the `che version` command.
-
++
 The Che upgrade is done by using a `eclipse/che:<version>` image that is newer than the version you currently have installed. For example, if you have 5.0.0-M2 installed and you want to upgrade to 5.0.0-M7:
-
++
 . To get the new version of Che:
 +
 ----
@@ -313,29 +295,28 @@ You now have two eclipse/che images (one for each version).
 ----
 docker run <volume-mounts> eclipse/che:5.0.0-M7 upgrade
 ----
-
-The upgrade command has numerous checks to prevent you from upgrading Che if the new image and the old version are not compatiable. For the upgrade procedure to proceed, the CLI image must be newer than the value of '/instance/che.ver'.
-
++
+The upgrade command has numerous checks to prevent you from upgrading Che if the new image and the old version are not compatible. For the upgrade procedure to proceed, the CLI image must be newer than the value of '/instance/che.ver'.
++
 Following is a list of actions that the upgrade process performs in the background:
 
-. Performs a version compatibility check.
+a. Performs a version compatibility check.
 
-. Downloads new Docker images that are needed to run the new version of Che.
+b. Downloads new Docker images that are needed to run the new version of Che.
 
-. Stops Che if it is currently running triggering a maintenance window.
+c. Stops Che if it is currently running and triggers a maintenance window.
 
-. Backs up your installation.
+d. Backs up your installation.
 
-. Initializes the new version.
+e. Initializes the new version.
 
-. Starts Che.
+f. Starts Che.
 
 For a list of available versions that you can upgrade to, run the `che version` command.
 
 The `--skip-backup` option allows you to skip the https://github.com/codenvy/che-docs/blob/master/src/main/_docs/setup/setup-cli.md#backup[backup] operation during the update. Skipping the backup operation speeds up the upgrade because the https://github.com/codenvy/che-docs/blob/master/src/main/_docs/setup/setup-cli.md#backup[backup operation] can be time consuming if the `/instance` directory contains many user worksapces and projects making it a large directory.
 
-*_version_*
-
+_version_::
 The `version` command provides information on the current version and the available versions that are hosted in Che’s repositories. The `che upgrade` command enforces upgrade sequences and prevents you from upgrading one version to another version where data migrations cannot be guaranteed.
 
 
@@ -355,11 +336,11 @@ The Che CLI is constructed of multiple Docker images within the Che source repos
 /dockerfiles/init  # Manifests used to configure Che on a host installation
 ----
 
-The Che CLI is authored in the `bash` script. The `cli` image depends upon both the `base` image and the `init` image. In the source repository, the `build.sh` commands builds these Docker images either one at a time or collectively as a group.
+The Che CLI is written in Bash. The `cli` image depends upon both the `base` image and the `init` image. In the source repository, the `build.sh` command builds these Docker images either one at a time or collectively as a group.
 
-Rebuilding images every time you want to test a small change to a bash script can be tedious. To avoid rebuilding the images every time and for every change to a bash script, mount the contents during the image execution. You cannot mount the `entrypoint.sh` file. But, you can mount the following:
+Rebuilding images every time you want to test a small change to Bash script can be tedious. To avoid rebuilding the images every time and for every change to a Bash script, mount the contents during the image execution. You cannot mount the `entrypoint.sh` file. But, you can mount the following:
 
-* To mount the contents of the base image:
+* To mount the contents of the `base` image:
 ----
 -v <path-to-che-repo>/dockerfiles/scripts/base/scripts:/base/scripts
 ----
@@ -369,7 +350,7 @@ Rebuilding images every time you want to test a small change to a bash script ca
 -v <path-to-che-repo>:/repo
 ----
 
-If you run the Che CLI in this configuration, any changes made to the `bash` files or templates in those repositories are used without having to first rebuild the CLI image.
+If you run the Che CLI in this configuration, any changes made to the Bash files or templates in those repositories are used without having to first rebuild the CLI image.
 
 [id="custom-cli"]
 == Customizing the Che CLI
@@ -394,10 +375,10 @@ The `version` directory has information about the latest version and a sub-direc
 
 The Che CLI uses Puppet to generate OS-specific configuration files based on environment variables set by the user either with the `-e <VALUE>` option on the command line, or by modifying their `che.env` file. We pass all of these values into Puppet and then run a Puppet configuration utility across the files contained in the `/dockerfiles/init/modules` and `/dockerfiles/init/manifests` directories to take the templates contained within the `/init` module, marry them with user-specific variables, and then generate an instance-specific configuration in the `/instance` directory. Puppet has logic constructs that allow us to generate different kinds of constructs with logic based upon the values provided by the end users.
 
-This Puppet-based approach allows us to simplify the outputs for end users and limit the locations where end users need to configure various parts of the system. One powerful example of this is that we generate two `docker-compose.yml` files from a single Puppet template. The `docker-compose.yml` and `docker-compose-container.yml` files are located in the user’s `/instance` directory. The first one is a configuration file that allows a user to run Docker compose for Che on their host. They can run the `docker-compose up` command in that directory. The second file is for running Docker compose from within a container, which is what the CLI does. The syntax of Docker compose changes in each of these scenarios as the files being referenced from within the compose syntax are different. There is a single template for Docker Compose in the `init` image. It is then applied in two configurations using Puppet.
+This Puppet-based approach allows us to simplify the outputs for end users and limit the locations where end users need to configure various parts of the system. One powerful example of this is that we generate two `docker-compose.yml` files from a single Puppet template. The `docker-compose.yml` and `docker-compose-container.yml` files are located in the user’s `/instance` directory. The first one is a configuration file that allows a user to run Docker Compose for Che on their host. They can run the `docker-compose up` command in that directory. The second file is for running Docker Compose from within a container, which is what the CLI does. The syntax of Docker Compose changes in each of these scenarios as the files being referenced from within the compose syntax are different. There is a single template for Docker Compose in the `init` image. It is then applied in two configurations using Puppet.
 
 [id="cli-tests"]
 == CLI tests
 
-There are existing https://github.com/sstephenson/bats[bats] tests for the Che CLI, which run automatically with each execution of a `build.sh` script located in the `dockerfiles/cli` directory. To skip them, pass the `--skip-tests` argument when running the build script. If you want to just run tests you can achieve it by running the `test.sh` script located in the same directory. Tests utilizes docker image `eclipse/che-bats` which is build from `Dockerfile` placed in `dockerfiles/bats`.
+There are existing https://github.com/sstephenson/bats[bats] tests for the Che CLI, which run automatically with each execution of a `build.sh` script located in the `dockerfiles/cli` directory. To skip them, pass the `--skip-tests` argument when running the build script. To only run the tests, execute the `test.sh` script located in the same directory. The tests utilize the `eclipse/che-bats` docker image, which is built from the `Dockerfile` placed in the `dockerfiles/bats` directory.
 


### PR DESCRIPTION
…idoc formatting.

Signed-off-by: Supriya Takkhi <sbharadw@redhat.com>

### What does this PR do?
Fixes language and markup issues in *CLI-reference-> https://www.eclipse.org/che/docs/docker-cli.html*.
File name: `src/main/pages/setup-docker/docker-cli.adoc`

Hi @rkratky , can you please have a look at the PR. I'm especially looking for feedback for sections where I have deleted the "preflight" and "postflight" words in the section for the `start` and `restart` commands. Thanks!
. 
