### PR TITLE
Append / to url, otherwise Che returns a 302

### DIFF
--- a/src/main/pages/developer-guide/rest-api.adoc
+++ b/src/main/pages/developer-guide/rest-api.adoc
@@ -10,7 +10,7 @@ folder: developer-guide
 
 Eclipse Che server side components - both for master and workspace agents - are exposed as REST services which makes it easy to integrate Che in other platforms or use custom clients to create and run workspaces, import and update projects, update/delete workspaces and associated objects etc.
 
-You can make yourself familiar with available APIs in Swagger UI page - all methods have swagger annotations. Che master APIs are available at at `${CHE_HOST}/swagger`. If you use multi-user Che flavor, you will need link:authentication.html[authentication token].
+You can make yourself familiar with available APIs in Swagger UI page - all methods have swagger annotations. Che master APIs are available at at `${CHE_HOST}/swagger/`. If you use multi-user Che flavor, you will need link:authentication.html[authentication token].
 
 Probably, https://github.com/eclipse/che/blob/master/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java[workspace API] is the most interesting one to take a closer look. Workspace API lets you remotely interact with Che master to create developer environments - create, update and delete workspaces, start workspaces by creating and deleting runtime, add, update and delete workspace environments, associate commands with a workspace.
 


### PR DESCRIPTION
Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>

In the current docs when you `curl` the url you get a 302 with the new location back.
Directly adding the `/` to the end prevents that one round-trip. 
