### PR TITLE
I554 che 7 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In order to add a new page, create an `.adoc` file in `src/main/pages/${subdir}`
 title: "Single-User&#58 Install on Docker"
 keywords: docker, installation
 tags: [installation, docker]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: docker-single-user.html
 folder: setup
 ---

--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -64,7 +64,7 @@ defaults:
       layout: "page"
       comments: true
       search: true
-      sidebar: user_sidebar
+      sidebar: che_6_docs
       topnav: topnav
   -
     scope:
@@ -90,10 +90,9 @@ defaults:
 # these are defaults used for the frontmatter for these file types
 
 sidebars:
-- user_sidebar
-- product1_sidebar
-- dev_sidebar
-- other
+- che_6_docs
+- che_7_docs
+- che_docs_home
 
 description: "Intended as a documentation theme based on Jekyll for technical writers documenting software and other technical products, this theme has all the elements you would need to handle multiple products with both multi-level sidebar navigation, tags, and other documentation features."
 # the description is used in the feed.xml file

--- a/src/main/_data/sidebars/che_6_docs.yml
+++ b/src/main/_data/sidebars/che_6_docs.yml
@@ -25,7 +25,7 @@ entries:
     folderitems:
 
     - title: Introduction
-      url: /index.html
+      url: /index6.html
       output: web, pdf
     - title: Getting Started
       url: /quick-start.html

--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -1,0 +1,45 @@
+# This is your sidebar TOC. The sidebar code loops through sections here and provides the appropriate formatting.
+
+entries:
+- title: sidebar
+  product:
+  version:
+  folders:
+
+# Overview section
+  - title: Overview
+    output: web
+    folderitems:
+    - title: Introduction
+      url: index.html
+      output: web
+
+# Getting Started Section
+  - title: Getting Started
+    output: web
+    folderitems:
+    - title: Introduction Video
+      url: index.html
+      output: web
+    - title: Hosting Eclipse Che
+      url: hosting.html
+      output: web
+    - title: Discover Eclipse Che
+      url: discover.html
+      output: web
+
+# Installation Guidelines
+  - title: Installation Guidelines
+    output: web
+    folderitems:
+    - title: Overview
+      url: installation-overview.html
+      output: web
+
+# Extending Guidelines
+  - title: Extending Eclipse Che
+    output: web
+    folderitems:
+    - title: Overview
+      url: extending-overview.html
+      output: web

--- a/src/main/_data/sidebars/che_docs_home.yml
+++ b/src/main/_data/sidebars/che_docs_home.yml
@@ -1,12 +1,19 @@
-title: Eclipse Che Docs
-url: /index.html
-children:
+entries:
+- title: sidebar
+  product:
+  version:
+  folders:
 
-- title: Che 6
-  url: /index6.html
-  output: web
+  - title: Che 6
+    output: web
+    folderitems:
+    - title: Overview
+      url: /index6.html
+      output: web
 
-- title: Che 7 Beta
-  url: /che-7/index.html
-  output: web
-
+  - title: Che 7
+    output: web
+    folderitems:
+    - title: Overview
+      url: /che-7/index.html
+      output: web

--- a/src/main/_data/sidebars/che_docs_home.yml
+++ b/src/main/_data/sidebars/che_docs_home.yml
@@ -1,0 +1,12 @@
+title: Eclipse Che Docs
+url: /index.html
+children:
+
+- title: Che 6
+  url: /index6.html
+  output: web
+
+- title: Che 7 Beta
+  url: /che-7/index.html
+  output: web
+

--- a/src/main/_data/topnav.yml
+++ b/src/main/_data/topnav.yml
@@ -3,24 +3,26 @@
 topnav:
 - title: Topnav
   items:
-    - title: Blog
-      external_url: https://medium.com/eclipse-che-blog/
-#    - title: Release Notes
-#      url: /release-6.0.0.html
-    - title: Source Code
-      external_url: https://github.com/eclipse/che
-#    - title: Docs 5.x
-#      external_url: https://www.eclipse.org/che/docs/5/che/docs
+  - title: Blog
+    external_url: https://medium.com/eclipse-che-blog/
+  - title: Source Code
+    external_url: https://github.com/eclipse/che
 
 #Topnav dropdowns
 topnav_dropdowns:
 - title: Topnav dropdowns
   folders:
-    - title: Get Support
-      folderitems:
-        - title: Known Bugs
-          external_url: https://github.com/eclipse/che/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Akind%2Fbug
-        - title: File an Issue
-          external_url: https://github.com/eclipse/che/issues/new
-        - title: Che on StackOverflow
-          external_url: https://stackoverflow.com/questions/tagged/eclipse-che
+  - title: Che Version
+    folderitems:
+    - title: Che 6
+      url: /index6.html
+    - title: Che 7 Beta
+      url: /che-7/index.html
+  - title: Get Support
+    folderitems:
+    - title: Known Bugs
+      external_url: https://github.com/eclipse/che/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Akind%2Fbug
+    - title: File an Issue
+      external_url: https://github.com/eclipse/che/issues/new
+    - title: Che on StackOverflow
+      external_url: https://stackoverflow.com/questions/tagged/eclipse-che

--- a/src/main/_includes/head.html
+++ b/src/main/_includes/head.html
@@ -4,16 +4,16 @@
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
 <title>{{ page.title }} | {{ site.site_title }}</title>
-<link rel="stylesheet" href="{{ "css/syntax.css" }}">
+<link rel="stylesheet" href="{{ "/css/syntax.css" }}">
 <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" crossorigin="anonymous">
 <!--<link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">-->
-<link rel="stylesheet" href="css/modern-business.css">
+<link rel="stylesheet" href="/css/modern-business.css">
 <!-- Latest compiled and minified CSS -->
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-<link rel="stylesheet" href="css/customstyles.css">
-<link rel="stylesheet" href="css/boxshadowproperties.css">
+<link rel="stylesheet" href="/css/customstyles.css">
+<link rel="stylesheet" href="/css/boxshadowproperties.css">
 <!-- most color styles are extracted out to here -->
-<link rel="stylesheet" href="css/theme-che.css">
+<link rel="stylesheet" href="/css/theme-che.css">
 {% capture page_ext %}{{ page.path | split: "." | last }}{% endcapture %}
 {% if page_ext == "adoc" %}
     <link rel="stylesheet" href="{{ '/css/coderay.css' | prepend: site.baseurl }}" media="screen" type="text/css">
@@ -22,17 +22,17 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js" crossorigin="anonymous"></script>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js" crossorigin="anonymous"></script>
-<script src="{{ "js/jquery.navgoco.min.js" }}"></script>
+<script src="{{ "/js/jquery.navgoco.min.js" }}"></script>
 
 
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <!-- Anchor.js -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/2.0.0/anchor.min.js" crossorigin="anonymous"></script>
-<script src="{{ "js/toc.js" }}"></script>
-<script src="{{ "js/customscripts.js" }}"></script>
+<script src="{{ "/js/toc.js" }}"></script>
+<script src="{{ "/js/customscripts.js" }}"></script>
 
-<link rel="shortcut icon" href="{{ "images/favicon.ico"  }}">
+<link rel="shortcut icon" href="{{ "/images/favicon.ico"  }}">
 
 <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
 <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->

--- a/src/main/_includes/taglogic.html
+++ b/src/main/_includes/taglogic.html
@@ -6,7 +6,7 @@
     {% for tag in page.tags %}
         {% if tag == thisTag %}
 
-        <tr><td><a href="{{ page.url | remove: "/" }}">{{page.title}}</a></td>
+        <tr><td><a href="{{ /page.url }}">{{page.title}}</a></td>
             <!-- <td><span class="label label-default">Page</span></td> -->
           <td>{% if page.summary %} {{ page.summary | strip_html | strip_newlines | truncate: 160 }} {% else %} {{ page.content | truncatewords: 50 | strip_html }} {% endif %}</td>
         </tr>

--- a/src/main/_includes/topnav.html
+++ b/src/main/_includes/topnav.html
@@ -43,7 +43,7 @@
                         {% elsif page.url contains folderitem.url %}
                         <li class="dropdownActive"><a href="{{folderitem.url |  remove: "/"}}">{{folderitem.title}}</a></li>
                         {% else %}
-                        <li><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+                        <li><a href="{{folderitem.url}}">{{folderitem.title}}</a></li>
                         {% endif %}
                         {% endfor %}
                     </ul>
@@ -60,12 +60,12 @@
                         <input type="text" id="search-input" placeholder="{{site.data.strings.search_placeholder_text}}">
                         <ul id="results-container"></ul>
                     </div>
-                    <script src="{{ "js/jekyll-search.js"}}" type="text/javascript"></script>
+                    <script src="{{ "/js/jekyll-search.js"}}" type="text/javascript"></script>
                     <script type="text/javascript">
                             SimpleJekyllSearch.init({
                                 searchInput: document.getElementById('search-input'),
                                 resultsContainer: document.getElementById('results-container'),
-                                dataSource: '{{ "search.json" }}',
+                                dataSource: '{{ "/search.json" }}',
                                 searchResultTemplate: '<li><a href="{url}" title="{{page.title | escape }}">{title}</a></li>',
                     noResultsText: '{{site.data.strings.search_no_results_text}}',
                             limit: 10,

--- a/src/main/index.adoc
+++ b/src/main/index.adoc
@@ -1,8 +1,9 @@
 ---
 title: Eclipse Che Documentation
 keywords: landing, index, introduction, overview, home
-tags: [overview, getting-started]
-sidebar: che_docs_home
+#sidebar: che_docs_home
+sidebar: none
+toc: false
 permalink: index.html
 folder: 
 summary: Eclipse Che is a developer workspace server and cloud IDE

--- a/src/main/index.adoc
+++ b/src/main/index.adoc
@@ -1,0 +1,15 @@
+---
+title: Eclipse Che Documentation
+keywords: landing, index, introduction, overview, home
+tags: [overview, getting-started]
+sidebar: che_docs_home
+permalink: index.html
+folder: 
+summary: Eclipse Che is a developer workspace server and cloud IDE
+---
+
+[id="documentation-versions"]
+== Documentation versions
+
+* link:/index6.html[Che 6 Documentation]
+* link:/che-7/index.html[Che 7 Beta Documentation]

--- a/src/main/pages/che-7/extending-che/extending-overview.adoc
+++ b/src/main/pages/che-7/extending-che/extending-overview.adoc
@@ -1,0 +1,22 @@
+---
+title: Extending Eclipse Che
+keywords: overview
+tags: [extending, installation]
+sidebar: che_7_docs
+permalink: che-7/extending-overview.html
+folder: che-7/extending-che
+summary: Eclipse Che is a developer workspace server and cloud IDE
+---
+
+[id="overview"]
+
+*Note*: This version of the documentation is currently under construction. You'll find information about version 7 of Eclipse Che.
+
+== Overview
+
+
+== Extend everything in Eclipse Che
+
+
+
+== Features and benefits

--- a/src/main/pages/che-7/get-started/discover-eclipse-che.adoc
+++ b/src/main/pages/che-7/get-started/discover-eclipse-che.adoc
@@ -1,0 +1,16 @@
+---
+title: Discover Eclipse Che
+keywords: overview
+tags: [discover, getting-started]
+sidebar: che_7_docs
+permalink: che-7/discover.html
+folder: overview
+summary: Eclipse Che is a developer workspace server and cloud IDE
+
+---
+
+[id="online-version"]
+
+*Note:* Under construction
+
+

--- a/src/main/pages/che-7/get-started/hosting-eclipse-che.adoc
+++ b/src/main/pages/che-7/get-started/hosting-eclipse-che.adoc
@@ -1,0 +1,16 @@
+---
+title: Hosting Eclipse Che
+keywords: overview
+tags: [overview, getting-started]
+sidebar: che_7_docs
+permalink: che-7/hosting.html
+folder: che-7/get-started
+summary: Eclipse Che is a developer workspace server and cloud IDE
+
+---
+
+[id="online-version"]
+
+*Note:* Under construction
+
+

--- a/src/main/pages/che-7/installation-guidelines/installation-overview.adoc
+++ b/src/main/pages/che-7/installation-guidelines/installation-overview.adoc
@@ -1,0 +1,23 @@
+---
+title: Extending Eclipse Che
+keywords: overview
+tags: [extending., installation]
+sidebar: che_7_docs
+permalink: che-7/installation-overview.html
+folder: che-7/installation-guidelines
+summary: Eclipse Che is a developer workspace server and cloud IDE
+
+---
+
+[id="overview"]
+
+*Note*: This version of the documentation is currently under construction. You'll find information about version 7 of Eclipse Che.
+
+== Overview
+
+
+== Extend everything in Eclipse Che
+
+
+
+== Features and benefits

--- a/src/main/pages/che-7/overview/overview.adoc
+++ b/src/main/pages/che-7/overview/overview.adoc
@@ -1,0 +1,41 @@
+---
+title: Overview of Eclipse Che
+keywords: overview
+tags: [overview, getting-started]
+sidebar: che_7_docs
+permalink: che-7/index.html
+folder: che-7/overview
+summary: Eclipse Che is a developer workspace server and cloud IDE
+---
+
+[id="introduction"]
+== Introduction
+
+*Note*: This version of the documentation is currently under construction. You'll find information about version 7 of Eclipse Che.
+
+Eclipse Che provides:
+
+* Workspaces that include runtimes and IDEs
+* RESTful workspace server
+* A browser IDE, based on Eclipse Theia
+* Plugins for languages, framework, and tools
+* An SDK for creating plugins and assemblies
+
+[id="getting-started"]
+== Getting Started
+
+You can get started with Che by:
+
+* link:quick-start.html[Quick start guide]
+* Installing it on Docker: link:docker-single-user.html[Single-user] or link:docker-multi-user.html[Multi-user]
+* Installing it on OpenShift: link:openshift-single-user.html[Single-user] or link:openshift-multi-user.html[Multi-user]
+* https://www.eclipse.org/che/docs/setup/getting-started-saas-cloud/index.html[Creating a hosted SaaS account]
+
+[id="single-and-multi-user-flavors"]
+
+== What is Eclipse Che
+
+== Architecture
+
+== Features and Benefits
+

--- a/src/main/pages/che-7/tags/assembly.adoc
+++ b/src/main/pages/che-7/tags/assembly.adoc
@@ -1,0 +1,11 @@
+---
+title: "Che Assembly pages"
+tagName: assembly
+search: exclude
+permalink: che-7/tag_assembly.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/chedir.adoc
+++ b/src/main/pages/che-7/tags/chedir.adoc
@@ -1,0 +1,11 @@
+---
+title: "Chedir pages"
+tagName: chedir
+search: exclude
+permalink: che-7/tag_chedir.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/debugger.adoc
+++ b/src/main/pages/che-7/tags/debugger.adoc
@@ -1,0 +1,11 @@
+---
+title: "Debugger pages"
+tagName: debugger
+search: exclude
+permalink: che-7/tag_debugger.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/dev-docs.adoc
+++ b/src/main/pages/che-7/tags/dev-docs.adoc
@@ -1,0 +1,11 @@
+---
+title: "Dev Docs pages"
+tagName: dev-docs
+search: exclude
+permalink: che-7/tag_dev-docs.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/docker.adoc
+++ b/src/main/pages/che-7/tags/docker.adoc
@@ -1,0 +1,11 @@
+---
+title: "Docker pages"
+tagName: docker
+search: exclude
+permalink: che-7/tag_docker.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/extensions.adoc
+++ b/src/main/pages/che-7/tags/extensions.adoc
@@ -1,0 +1,13 @@
+---
+title: "Extensions pages"
+tagName: extensions
+search: exclude
+permalink: che-7/tag_extensions.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++
+
+

--- a/src/main/pages/che-7/tags/factories.adoc
+++ b/src/main/pages/che-7/tags/factories.adoc
@@ -1,0 +1,11 @@
+---
+title: "Factories pages"
+tagName: factories
+search: exclude
+permalink: che-7/tag_factories.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/getting-started.adoc
+++ b/src/main/pages/che-7/tags/getting-started.adoc
@@ -1,0 +1,11 @@
+---
+title: "Getting Started pages"
+tagName: getting-started
+search: exclude
+permalink: che-7/tag_getting-started.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/installation.adoc
+++ b/src/main/pages/che-7/tags/installation.adoc
@@ -1,0 +1,11 @@
+---
+title: "Installation pages"
+tagName: installation
+search: exclude
+permalink: che-7/tag_installation.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/keycloak.adoc
+++ b/src/main/pages/che-7/tags/keycloak.adoc
@@ -1,0 +1,11 @@
+---
+title: "Keycloak Pages"
+tagName: keycloak
+search: exclude
+permalink: che-7/tag_keycloak.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/kubernetes.adoc
+++ b/src/main/pages/che-7/tags/kubernetes.adoc
@@ -1,0 +1,11 @@
+---
+title: "Kubernetes pages"
+tagName: kubernetes
+search: exclude
+permalink: che-7/tag_kubernetes.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/ldap.adoc
+++ b/src/main/pages/che-7/tags/ldap.adoc
@@ -1,0 +1,11 @@
+---
+title: "LDAP Pages"
+tagName: ldap
+search: exclude
+permalink: che-7/tag_ldap.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/networking.adoc
+++ b/src/main/pages/che-7/tags/networking.adoc
@@ -1,0 +1,11 @@
+---
+title: "Networking pages"
+tagName: networking
+search: exclude
+permalink: che-7/tag_networking.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/openshift.adoc
+++ b/src/main/pages/che-7/tags/openshift.adoc
@@ -1,0 +1,11 @@
+---
+title: "OpenShift pages"
+tagName: openshift
+search: exclude
+permalink: che-7/tag_openshift.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/organizations.adoc
+++ b/src/main/pages/che-7/tags/organizations.adoc
@@ -1,0 +1,11 @@
+---
+title: "Organizations pages"
+tagName: organizations
+search: exclude
+permalink: che-7/tag_organizations.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/plugins.adoc
+++ b/src/main/pages/che-7/tags/plugins.adoc
@@ -1,0 +1,11 @@
+---
+title: "Plugins pages"
+tagName: plugins
+search: exclude
+permalink: che-7/tag_plugins.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/runtime.adoc
+++ b/src/main/pages/che-7/tags/runtime.adoc
@@ -1,0 +1,11 @@
+---
+title: "Runtime pages"
+tagName: runtime
+search: exclude
+permalink: che-7/tag_runtime.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/troubleshooting.adoc
+++ b/src/main/pages/che-7/tags/troubleshooting.adoc
@@ -1,0 +1,11 @@
+---
+title: "Troubleshooting pages"
+tagName: troubleshooting
+search: exclude
+permalink: che-7/tag_troubleshooting.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/che-7/tags/workspace.adoc
+++ b/src/main/pages/che-7/tags/workspace.adoc
@@ -1,0 +1,11 @@
+---
+title: "Workspace pages"
+tagName: workspace
+search: exclude
+permalink: che-7/tag_workspace.html
+sidebar: che_7_docs
+---
+
+++++
+{% include taglogic.html %}
+++++

--- a/src/main/pages/dev_essentials/dto.adoc
+++ b/src/main/pages/dev_essentials/dto.adoc
@@ -2,7 +2,7 @@
 title: "DTO"
 keywords: framework, plugin, extension, dto
 tags: [extensions, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: dto.html
 folder: dev_essentials
 ---

--- a/src/main/pages/dev_essentials/guice.adoc
+++ b/src/main/pages/dev_essentials/guice.adoc
@@ -2,7 +2,7 @@
 title: "Dependency Injection"
 keywords: framework, plugin, extension, DI, dependency injection
 tags: [extensions, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: guice.html
 folder: dev_essentials
 ---

--- a/src/main/pages/dev_essentials/handling-projects-in-plugins.adoc
+++ b/src/main/pages/dev_essentials/handling-projects-in-plugins.adoc
@@ -2,7 +2,7 @@
 title: "Handling Projects in Server and Client Side Plugins"
 keywords: framework, plugin, extension, project import, file system
 tags: [extensions, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: handling-projects-in-plugins.html
 folder: dev_essentials
 ---

--- a/src/main/pages/dev_essentials/json-rpc.adoc
+++ b/src/main/pages/dev_essentials/json-rpc.adoc
@@ -2,7 +2,7 @@
 title: "Communication: JSON-RPC"
 keywords: framework, plugin, extension, json rpc, communication, events, subscribe
 tags: [extensions, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: json-rpc.html
 folder: dev_essentials
 ---

--- a/src/main/pages/developer-guide/actions.adoc
+++ b/src/main/pages/developer-guide/actions.adoc
@@ -2,7 +2,7 @@
 title: "IDE UI: Actions"
 keywords: framework, UI, actions
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: actions.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/assemblies.adoc
+++ b/src/main/pages/developer-guide/assemblies.adoc
@@ -1,6 +1,6 @@
 ---
 title: Che Assemblies
-sidebar: user_sidebar
+sidebar: che_6_docs
 keywords: dev docs
 tags: [extensions, assembly]
 permalink: assemblies.html

--- a/src/main/pages/developer-guide/build-reqs.adoc
+++ b/src/main/pages/developer-guide/build-reqs.adoc
@@ -2,7 +2,7 @@
 title: "Build Requirements"
 keywords: java. maven, node, npm
 tags: [dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: build-reqs.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/che-in-che-quickstart.adoc
+++ b/src/main/pages/developer-guide/che-in-che-quickstart.adoc
@@ -1,6 +1,6 @@
 ---
 title: Develop Your First Plugin Usign Che
-sidebar: user_sidebar
+sidebar: che_6_docs
 keywords: dev docs, developer docs, plugins, extensions
 tags: [extensions, dev-docs, assembly]
 permalink: che-in-che-quickstart.html

--- a/src/main/pages/developer-guide/che-master.adoc
+++ b/src/main/pages/developer-guide/che-master.adoc
@@ -2,7 +2,7 @@
 title: "Che Master"
 keywords: framework, overview, master, server, che server
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: che-master.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/custom-installers.adoc
+++ b/src/main/pages/developer-guide/custom-installers.adoc
@@ -2,7 +2,7 @@
 title: "Installers"
 keywords: framework, overview, master, server, che server, framework
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: custom-installers.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/dao.adoc
+++ b/src/main/pages/developer-guide/dao.adoc
@@ -2,7 +2,7 @@
 title: "DAO"
 keywords: framework, overview, master, server, dao, database
 tags: [dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: dao.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/databases.adoc
+++ b/src/main/pages/developer-guide/databases.adoc
@@ -2,7 +2,7 @@
 title: "Databases"
 keywords: database,
 tags: [dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: database.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/editor.adoc
+++ b/src/main/pages/developer-guide/editor.adoc
@@ -2,7 +2,7 @@
 title: "IDE UI: Editor"
 keywords: framework, UI, themes, editor, syntax coloring
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: editor.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/framework-overview.adoc
+++ b/src/main/pages/developer-guide/framework-overview.adoc
@@ -2,7 +2,7 @@
 title: "Extending Che"
 keywords: framework, overview, plugin, extension, language support, language server
 tags: [extensions, assembly]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: framework-overview.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/framework.adoc
+++ b/src/main/pages/developer-guide/framework.adoc
@@ -2,7 +2,7 @@
 title: "Eclipse Che Framework"
 keywords: framework, overview, master, server, che server, framework
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: framework.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/ide-extensions-gwt.adoc
+++ b/src/main/pages/developer-guide/ide-extensions-gwt.adoc
@@ -2,7 +2,7 @@
 title: "IDE Extensions: GWT"
 keywords: framework, extensions, gwt, client side
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: ide-extensions-gwt.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/language-servers.adoc
+++ b/src/main/pages/developer-guide/language-servers.adoc
@@ -2,7 +2,7 @@
 title: "Language Support"
 keywords: framework, language servers, code assistant, language support, code completion, error marking
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: language-servers.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/logging.adoc
+++ b/src/main/pages/developer-guide/logging.adoc
@@ -1,6 +1,6 @@
 ---
 title: Che logging
-sidebar: user_sidebar
+sidebar: che_6_docs
 keywords: dev docs
 tags: [extensions, assembly, logging, log, logs]
 permalink: logging.html

--- a/src/main/pages/developer-guide/parts.adoc
+++ b/src/main/pages/developer-guide/parts.adoc
@@ -2,7 +2,7 @@
 title: "IDE UI: Parts"
 keywords: framework, UI, parts
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: parts.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/project-types.adoc
+++ b/src/main/pages/developer-guide/project-types.adoc
@@ -2,7 +2,7 @@
 title: "Project Types"
 keywords: framework, overview, framework, project, project type, API
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: project-types.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/properties.adoc
+++ b/src/main/pages/developer-guide/properties.adoc
@@ -2,7 +2,7 @@
 title: "Properties in Extensions"
 keywords: framework, UI, properties
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: properties.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/registry.adoc
+++ b/src/main/pages/developer-guide/registry.adoc
@@ -2,7 +2,7 @@
 title: "Registry"
 keywords: framework, overview, master, server, registry
 tags: [dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: registry.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/rest-api.adoc
+++ b/src/main/pages/developer-guide/rest-api.adoc
@@ -2,7 +2,7 @@
 title: "REST API"
 keywords: framework, overview, master, server, REST API
 tags: [extensions, dev-docs, assembly]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: rest-api.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/server-side-extensions.adoc
+++ b/src/main/pages/developer-guide/server-side-extensions.adoc
@@ -2,7 +2,7 @@
 title: "Server Side Extensions"
 keywords: framework, overview, master, server, che server, framework
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: server-side-extensions.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/themes.adoc
+++ b/src/main/pages/developer-guide/themes.adoc
@@ -2,7 +2,7 @@
 title: "IDE UI: Themes"
 keywords: framework, UI, themes, styles, customize
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: themes.html
 folder: developer-guide
 ---

--- a/src/main/pages/developer-guide/workspace-agent.adoc
+++ b/src/main/pages/developer-guide/workspace-agent.adoc
@@ -2,7 +2,7 @@
 title: "Workspace Agent"
 keywords: framework, agent, workspace
 tags: [extensions, assembly, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: workspace-agent.html
 folder: developer-guide
 ---

--- a/src/main/pages/overview/infra-support.adoc
+++ b/src/main/pages/overview/infra-support.adoc
@@ -2,7 +2,7 @@
 title: "Infrastructures supported in Eclipse Che"
 keywords: docker, oepsnhift
 tags: [infrastructure, installation, docker, openshift]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: infra-support.html
 folder: overview
 ---

--- a/src/main/pages/overview/introduction.adoc
+++ b/src/main/pages/overview/introduction.adoc
@@ -2,11 +2,10 @@
 title: Introduction to Eclipse Che
 keywords: overview
 tags: [overview, getting-started]
-sidebar: user_sidebar
-permalink: index.html
+sidebar: che_6_docs
+permalink: index6.html
 folder: overview
 summary: Eclipse Che is a developer workspace server and cloud IDE
-
 ---
 
 [id="introduction"]

--- a/src/main/pages/overview/quick-start.adoc
+++ b/src/main/pages/overview/quick-start.adoc
@@ -2,7 +2,7 @@
 title: "Quick-Start"
 keywords: docker, installation, minishift, openshift
 tags: [installation, docker]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: quick-start.html
 folder: overview
 ---

--- a/src/main/pages/overview/single-multi-user.adoc
+++ b/src/main/pages/overview/single-multi-user.adoc
@@ -2,7 +2,7 @@
 title: "Single and Multi-User Che"
 keywords: single-user, Eclipse Che
 tags: [installation, getting-started]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: single-multi-user.html
 folder: overview
 

--- a/src/main/pages/portable-workspaces/chedir-getting-started.adoc
+++ b/src/main/pages/portable-workspaces/chedir-getting-started.adoc
@@ -2,7 +2,7 @@
 title: "Getting Started"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: chedir-getting-started.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/portable-workspaces/chedir-installation.adoc
+++ b/src/main/pages/portable-workspaces/chedir-installation.adoc
@@ -2,7 +2,7 @@
 title: "Chedir Installation"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: chedir-installation.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/portable-workspaces/chedir-project-setup.adoc
+++ b/src/main/pages/portable-workspaces/chedir-project-setup.adoc
@@ -2,7 +2,7 @@
 title: "Chedir Project Setup"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: chedir-project-setup.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/portable-workspaces/chedir-ssh.adoc
+++ b/src/main/pages/portable-workspaces/chedir-ssh.adoc
@@ -2,7 +2,7 @@
 title: "SSH"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: chedir-ssh.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/portable-workspaces/chedir-up-and-down.adoc
+++ b/src/main/pages/portable-workspaces/chedir-up-and-down.adoc
@@ -2,7 +2,7 @@
 title: "Chedir Up and Down"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: chedir-up-and-down.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/portable-workspaces/chefile.adoc
+++ b/src/main/pages/portable-workspaces/chefile.adoc
@@ -2,7 +2,7 @@
 title: "Chefile"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: chefile.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/portable-workspaces/creating-factories.adoc
+++ b/src/main/pages/portable-workspaces/creating-factories.adoc
@@ -2,7 +2,7 @@
 title: "Creating Factories"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: creating-factories.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/portable-workspaces/factories-getting-started.adoc
+++ b/src/main/pages/portable-workspaces/factories-getting-started.adoc
@@ -2,7 +2,7 @@
 title: "Getting Started With Factories"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: factories-getting-started.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/portable-workspaces/factories.adoc
+++ b/src/main/pages/portable-workspaces/factories.adoc
@@ -2,7 +2,7 @@
 title: "What Are Factories?"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: factories.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/portable-workspaces/factories_json_reference.adoc
+++ b/src/main/pages/portable-workspaces/factories_json_reference.adoc
@@ -2,7 +2,7 @@
 title: "Factories JSON Reference"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: factories_json_reference.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/portable-workspaces/why-chedir.adoc
+++ b/src/main/pages/portable-workspaces/why-chedir.adoc
@@ -2,7 +2,7 @@
 title: "Why Chedir?"
 keywords: chedir, factories
 tags: [chedir, factories]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: why-chedir.html
 folder: portable-workspaces
 ---

--- a/src/main/pages/setup-docker/docker-cli.adoc
+++ b/src/main/pages/setup-docker/docker-cli.adoc
@@ -2,7 +2,7 @@
 title: "CLI Reference"
 keywords: docker, configuration, CLI, cli
 tags: [installation, docker]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: docker-cli.html
 folder: setup-docker
 ---

--- a/src/main/pages/setup-docker/docker-config.adoc
+++ b/src/main/pages/setup-docker/docker-config.adoc
@@ -2,7 +2,7 @@
 title: "Configuration&#58 Docker"
 keywords: docker, configuration
 tags: [installation, docker]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: docker-config.html
 folder: setup-docker
 ---

--- a/src/main/pages/setup-docker/docker-multi-user.adoc
+++ b/src/main/pages/setup-docker/docker-multi-user.adoc
@@ -2,7 +2,7 @@
 title: "Multi-user&#58 Installation on Docker"
 keywords: openshift, installation
 tags: [installation, docker]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: docker-multi-user.html
 folder: setup-docker
 ---

--- a/src/main/pages/setup-docker/docker-single-user.adoc
+++ b/src/main/pages/setup-docker/docker-single-user.adoc
@@ -2,7 +2,7 @@
 title: "Single-User&#58 Installation on Docker"
 keywords: docker, installation
 tags: [installation, docker]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: docker-single-user.html
 folder: setup-docker
 ---

--- a/src/main/pages/setup-kubernetes/kubernetes-config.adoc
+++ b/src/main/pages/setup-kubernetes/kubernetes-config.adoc
@@ -2,7 +2,7 @@
 title: "Configuration: Kuberentes"
 keywords: kubernetes, configuration
 tags: [installation, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: kubernetes-config.html
 folder: setup-kubernetes
 ---

--- a/src/main/pages/setup-kubernetes/kubernetes-multi-user.adoc
+++ b/src/main/pages/setup-kubernetes/kubernetes-multi-user.adoc
@@ -2,7 +2,7 @@
 title: "Deploying multi-user Che to Kubernetes"
 keywords: kubernetes, installation, pvc, deployment
 tags: [installation, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: kubernetes-multi-user.html
 folder: setup-kubernetes
 ---

--- a/src/main/pages/setup-kubernetes/kubernetes-single-user.adoc
+++ b/src/main/pages/setup-kubernetes/kubernetes-single-user.adoc
@@ -2,7 +2,7 @@
 title: "Deploying single-user Che to Kubernetes"
 keywords: kubernetes, installation, pvc, deployment
 tags: [installation, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: kubernetes-single-user.html
 folder: setup-kubernetes
 ---

--- a/src/main/pages/setup-openshift/kubernetes-admin-guide.adoc
+++ b/src/main/pages/setup-openshift/kubernetes-admin-guide.adoc
@@ -2,7 +2,7 @@
 title: "Che on Kuberentes: Admin Guide"
 keywords: kubernetes, configuration, admin guide
 tags: [installation, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: kubernetes-admin-guide.html
 folder: setup-openshift
 ---

--- a/src/main/pages/setup-openshift/openshift-admin-guide.adoc
+++ b/src/main/pages/setup-openshift/openshift-admin-guide.adoc
@@ -2,7 +2,7 @@
 title: "Che on OpenShift: Admin Guide"
 keywords: openshift, configuration, admin guide
 tags: [installation, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: openshift-admin-guide.html
 folder: setup-openshift
 ---

--- a/src/main/pages/setup-openshift/openshift-config.adoc
+++ b/src/main/pages/setup-openshift/openshift-config.adoc
@@ -2,7 +2,7 @@
 title: "Configuration: OpenShift"
 keywords: openshift, configuration
 tags: [installation, openshift]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: openshift-config.html
 folder: setup-openshift
 ---

--- a/src/main/pages/setup-openshift/openshift-multi-user.adoc
+++ b/src/main/pages/setup-openshift/openshift-multi-user.adoc
@@ -2,7 +2,7 @@
 title: "Multi-User&#58 Deploy to OpenShift"
 keywords: openshift, installation, ocp, multi-user, multi user, keycloak, postgres, deployment
 tags: [installation, openshift]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: openshift-multi-user.html
 folder: setup-openshift
 ---

--- a/src/main/pages/setup-openshift/openshift-single-user.adoc
+++ b/src/main/pages/setup-openshift/openshift-single-user.adoc
@@ -2,7 +2,7 @@
 title: "Single-User&#58 Deploy to OpenShift"
 keywords: openshift, installation, pvc, https, deployment
 tags: [installation, openshift]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: openshift-single-user.html
 folder: setup-openshift
 ---

--- a/src/main/pages/spi/spi-implementation.adoc
+++ b/src/main/pages/spi/spi-implementation.adoc
@@ -1,6 +1,6 @@
 ---
 title: SPI&#58 Implementation
-sidebar: user_sidebar
+sidebar: che_6_docs
 keywords: dev docs
 permalink: spi-implementation.html
 folder: spi

--- a/src/main/pages/spi/spi_overview.adoc
+++ b/src/main/pages/spi/spi_overview.adoc
@@ -1,6 +1,6 @@
 ---
 title: SPI&#58 Overview
-sidebar: user_sidebar
+sidebar: che_6_docs
 keywords: dev docs
 permalink: spi_overview.html
 folder: spi

--- a/src/main/pages/tags/assembly.adoc
+++ b/src/main/pages/tags/assembly.adoc
@@ -3,7 +3,9 @@ title: "Che Assembly pages"
 tagName: assembly
 search: exclude
 permalink: tag_assembly.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/chedir.adoc
+++ b/src/main/pages/tags/chedir.adoc
@@ -3,7 +3,9 @@ title: "Chedir pages"
 tagName: chedir
 search: exclude
 permalink: tag_chedir.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/debugger.adoc
+++ b/src/main/pages/tags/debugger.adoc
@@ -3,7 +3,9 @@ title: "Debugger pages"
 tagName: debugger
 search: exclude
 permalink: tag_debugger.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/dev-docs.adoc
+++ b/src/main/pages/tags/dev-docs.adoc
@@ -3,7 +3,9 @@ title: "Dev Docs pages"
 tagName: dev-docs
 search: exclude
 permalink: tag_dev-docs.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/docker.adoc
+++ b/src/main/pages/tags/docker.adoc
@@ -3,7 +3,9 @@ title: "Docker pages"
 tagName: docker
 search: exclude
 permalink: tag_docker.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/extensions.adoc
+++ b/src/main/pages/tags/extensions.adoc
@@ -1,2 +1,13 @@
+---
+title: "Extensions pages"
+tagName: extensions
+search: exclude
+permalink: tag_extensions.html
+sidebar: che_6_docs
+---
+
+++++
+{% include taglogic.html %}
+++++
 
 

--- a/src/main/pages/tags/factories.adoc
+++ b/src/main/pages/tags/factories.adoc
@@ -3,7 +3,9 @@ title: "Factories pages"
 tagName: factories
 search: exclude
 permalink: tag_factories.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/getting-started.adoc
+++ b/src/main/pages/tags/getting-started.adoc
@@ -3,7 +3,9 @@ title: "Getting Started pages"
 tagName: getting-started
 search: exclude
 permalink: tag_getting-started.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/installation.adoc
+++ b/src/main/pages/tags/installation.adoc
@@ -3,7 +3,9 @@ title: "Installation pages"
 tagName: installation
 search: exclude
 permalink: tag_installation.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/keycloak.adoc
+++ b/src/main/pages/tags/keycloak.adoc
@@ -3,7 +3,9 @@ title: "Keycloak Pages"
 tagName: keycloak
 search: exclude
 permalink: tag_keycloak.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/kubernetes.adoc
+++ b/src/main/pages/tags/kubernetes.adoc
@@ -3,7 +3,9 @@ title: "Kubernetes pages"
 tagName: kubernetes
 search: exclude
 permalink: tag_kubernetes.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/ldap.adoc
+++ b/src/main/pages/tags/ldap.adoc
@@ -3,7 +3,9 @@ title: "LDAP Pages"
 tagName: ldap
 search: exclude
 permalink: tag_ldap.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/networking.adoc
+++ b/src/main/pages/tags/networking.adoc
@@ -3,7 +3,9 @@ title: "Networking pages"
 tagName: networking
 search: exclude
 permalink: tag_networking.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/openshift.adoc
+++ b/src/main/pages/tags/openshift.adoc
@@ -3,7 +3,9 @@ title: "OpenShift pages"
 tagName: openshift
 search: exclude
 permalink: tag_openshift.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/organizations.adoc
+++ b/src/main/pages/tags/organizations.adoc
@@ -3,7 +3,9 @@ title: "Organizations pages"
 tagName: organizations
 search: exclude
 permalink: tag_organizations.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/plugins.adoc
+++ b/src/main/pages/tags/plugins.adoc
@@ -3,7 +3,9 @@ title: "Plugins pages"
 tagName: plugins
 search: exclude
 permalink: tag_plugins.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/runtime.adoc
+++ b/src/main/pages/tags/runtime.adoc
@@ -3,7 +3,9 @@ title: "Runtime pages"
 tagName: runtime
 search: exclude
 permalink: tag_runtime.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/troubleshooting.adoc
+++ b/src/main/pages/tags/troubleshooting.adoc
@@ -3,7 +3,9 @@ title: "Troubleshooting pages"
 tagName: troubleshooting
 search: exclude
 permalink: tag_troubleshooting.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/tags/workspace.adoc
+++ b/src/main/pages/tags/workspace.adoc
@@ -3,7 +3,9 @@ title: "Workspace pages"
 tagName: workspace
 search: exclude
 permalink: tag_workspace.html
-sidebar: user_sidebar
+sidebar: che_6_docs
 ---
 
+++++
 {% include taglogic.html %}
+++++

--- a/src/main/pages/user-guide/commands-ide-macro.adoc
+++ b/src/main/pages/user-guide/commands-ide-macro.adoc
@@ -2,7 +2,7 @@
 title: "Commands and IDE Macros"
 keywords: workspace, runtime, commands, build, run, macro, preview, url
 tags: [workspace, runtime]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: commands-ide-macro.html
 folder: user-guide
 ---

--- a/src/main/pages/user-guide/creating-starting-workspaces.adoc
+++ b/src/main/pages/user-guide/creating-starting-workspaces.adoc
@@ -2,7 +2,7 @@
 title: "Workspace Management"
 keywords: workspace, runtime, recipe, docker, yaml, Dockerfile, docker, kubernetes, container, pod
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: creating-starting-workspaces.html
 folder: user-guide
 ---

--- a/src/main/pages/user-guide/debug.adoc
+++ b/src/main/pages/user-guide/debug.adoc
@@ -2,7 +2,7 @@
 title: "Debug"
 keywords: workspace, runtime, project, projects, debugger, debug, debug jar, breakpoint, suspend
 tags: [workspace, runtime, debugger]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: debug.html
 folder: user-guide
 ---

--- a/src/main/pages/user-guide/dependency-management.adoc
+++ b/src/main/pages/user-guide/dependency-management.adoc
@@ -2,7 +2,7 @@
 title: "Dependency Management"
 keywords: workspace, runtime, project, projects, dependency management, maven, gradle
 tags: [workspace, runtime]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: dependency-management.html
 folder: user-guide
 ---

--- a/src/main/pages/user-guide/dependency-management.md
+++ b/src/main/pages/user-guide/dependency-management.md
@@ -2,7 +2,7 @@
 title: "Dependency Management"
 keywords: workspace, runtime, project, projects, dependency management, maven, gradle
 tags: [workspace, runtime]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: dependency-management.html
 folder: user-guide
 ---

--- a/src/main/pages/user-guide/editor_code_assistance.adoc
+++ b/src/main/pages/user-guide/editor_code_assistance.adoc
@@ -2,7 +2,7 @@
 title: "Editor and Code Assistance"
 keywords: workspace, runtime, project, editor, code-completion, code completion, code assistance, intellisense
 tags: [workspace, runtime]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: editor-code-assistance.html
 folder: user-guide
 ---

--- a/src/main/pages/user-guide/ide-projects.adoc
+++ b/src/main/pages/user-guide/ide-projects.adoc
@@ -2,7 +2,7 @@
 title: "Projects and Project Import"
 keywords: workspace, runtime, project, projects
 tags: [workspace, runtime]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: ide-projects.html
 folder: user-guide
 ---

--- a/src/main/pages/user-guide/version-control.adoc
+++ b/src/main/pages/user-guide/version-control.adoc
@@ -2,7 +2,7 @@
 title: "Version Control"
 keywords: workspace, runtime, project, projects, git, subversion, version control, clone, pull, push, ssh key, ssh keys, github, oauth, gitlab, bitbucket
 tags:
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: version-control.html
 folder: user-guide
 ---

--- a/src/main/pages/user-management/authentication.adoc
+++ b/src/main/pages/user-management/authentication.adoc
@@ -2,7 +2,7 @@
 title: "Che Authentication"
 keywords: user management, permissions, authentication
 tags: [keycloak]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: authentication.html
 folder: user-management
 ---

--- a/src/main/pages/user-management/organizations.adoc
+++ b/src/main/pages/user-management/organizations.adoc
@@ -2,7 +2,7 @@
 title: "Organizations"
 keywords: organizations, user management, permissions
 tags: [organizations]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: organizations.html
 folder: user-management
 ---

--- a/src/main/pages/user-management/permissions.adoc
+++ b/src/main/pages/user-management/permissions.adoc
@@ -2,7 +2,7 @@
 title: "Permissions"
 keywords: organizations, user management, permissions
 tags: [organizations]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: permissions.html
 folder: user-management
 ---

--- a/src/main/pages/user-management/resource-management.adoc
+++ b/src/main/pages/user-management/resource-management.adoc
@@ -2,7 +2,7 @@
 title: "Resource Management"
 keywords: organizations, user management, permissions, resource management, RAM allocation
 tags: [ldap, keycloak]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: resource-management.html
 folder: user-management
 ---

--- a/src/main/pages/user-management/user-management.adoc
+++ b/src/main/pages/user-management/user-management.adoc
@@ -2,7 +2,7 @@
 title: "User Management"
 keywords: organizations, user management, permissions
 tags: [ldap, keycloak]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: user-management.html
 folder: user-management
 ---

--- a/src/main/pages/workspace-admin/env-variables.adoc
+++ b/src/main/pages/workspace-admin/env-variables.adoc
@@ -2,7 +2,7 @@
 title: "Environment variables"
 keywords: workspace, runtime, recipe, docker, stack, environment variables, env, envs
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: env-variables.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/environments.adoc
+++ b/src/main/pages/workspace-admin/environments.adoc
@@ -2,7 +2,7 @@
 title: "Workspace Environments"
 keywords: workspace, runtime, recipe, docker, yaml, Dockerfile, docker, kubernetes, container, pod, environment
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: environments.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/installers.adoc
+++ b/src/main/pages/workspace-admin/installers.adoc
@@ -2,7 +2,7 @@
 title: "Installers"
 keywords: workspace, runtime, recipe, docker, stack, installers, agents
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: installers.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/projects.adoc
+++ b/src/main/pages/workspace-admin/projects.adoc
@@ -2,7 +2,7 @@
 title: "Projects"
 keywords: workspace, runtime, project, projects
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: projects.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/recipes.adoc
+++ b/src/main/pages/workspace-admin/recipes.adoc
@@ -2,7 +2,7 @@
 title: "Recipes"
 keywords: workspace, runtime, recipe, docker, stack
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: recipes.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/secure-servers.adoc
+++ b/src/main/pages/workspace-admin/secure-servers.adoc
@@ -2,7 +2,7 @@
 title: "Secure Servers"
 keywords: workspace, runtime, recipe, kubernetes, openshift, stack, servers, server, secure server
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: secure-servers.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/servers.adoc
+++ b/src/main/pages/workspace-admin/servers.adoc
@@ -2,7 +2,7 @@
 title: "Servers"
 keywords: workspace, runtime, recipe, docker, stack, servers, server, port, preview, preview url
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: servers.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/stacks.adoc
+++ b/src/main/pages/workspace-admin/stacks.adoc
@@ -2,7 +2,7 @@
 title: "Stacks"
 keywords: workspace, runtime, recipe, docker, stack
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: stacks.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/volumes.adoc
+++ b/src/main/pages/workspace-admin/volumes.adoc
@@ -2,7 +2,7 @@
 title: "Volumes"
 keywords: workspace, runtime, recipe, docker, stack, volume, volumes
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: volumes.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/what-are-workspaces.adoc
+++ b/src/main/pages/workspace-admin/what-are-workspaces.adoc
@@ -2,7 +2,7 @@
 title: "What Is a Che Workspace?"
 keywords: workspace, runtime, recipe, docker, yaml, Dockerfile, docker, kubernetes, container, pod
 tags: [workspace, runtime, docker, kubernetes]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: what-are-workspaces.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/workspace-data-model.adoc
+++ b/src/main/pages/workspace-admin/workspace-data-model.adoc
@@ -2,7 +2,7 @@
 title: "Workspace Data Model"
 keywords: workspace, runtime, recipe, docker, yaml, Dockerfile, docker, kubernetes, container, pod
 tags: [workspace, runtime, docker, kubernetes, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: workspace-data-model.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/workspace-rest-api.adoc
+++ b/src/main/pages/workspace-admin/workspace-rest-api.adoc
@@ -2,7 +2,7 @@
 title: "Workspace REST API"
 keywords: workspace, runtime, recipe, docker, yaml, Dockerfile, docker, kubernetes, container, pod
 tags: [workspace, runtime, docker, kubernetes, dev-docs]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: workspaces-rest-api.html
 folder: workspace-admin
 ---

--- a/src/main/pages/workspace-admin/workspaces-troubleshooting.adoc
+++ b/src/main/pages/workspace-admin/workspaces-troubleshooting.adoc
@@ -2,7 +2,7 @@
 title: "Troubleshooting Workspace Start Failures"
 keywords: workspace, runtime, recipe, docker, yaml, Dockerfile, docker, kubernetes, container, pod
 tags: [workspace, runtime, docker, kubernetes, troubleshooting]
-sidebar: user_sidebar
+sidebar: che_6_docs
 permalink: workspaces-troubleshooting.html
 folder: workspace-admin
 ---


### PR DESCRIPTION
### What does this PR do?

Adds initial Che 7 content. In particular:

* adds Stevan's new Che 7 WIP pages, incl. new sidebar
* adds new set of Che 7 tags (may need to be revisited)
* adds top nav dropdown menu with docs versions
* adds top-level landing page with links to docs versions
* fixes template logic top allow for multiple docs roots
* unifies sidebar naming for consistency and intuitiveness

TODO:

* move Che 6 content to its own subdirectory from content root (when the overall docs reviews are completed; postponed to avoid tons of merge conflicts)
* figure out either unifiedf tags or ensure complete split between versions

### What issues does this PR fix or reference?

Fixes #554.