### PR TITLE
[docker] Update image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+src/main/images
+src/main/_site

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 #
 FROM ruby:2.5-alpine
 COPY src/main/Gemfile* /tmp/
-RUN apk add --no-cache --virtual build-dependencies build-base \
+RUN apk add --no-cache --virtual build-dependencies build-base libstdc++ \
     && cd /tmp && bundle install \
     && apk del build-dependencies build-base \
     && mkdir /projects \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,19 @@
-FROM eivantsov/jekyll-docs:latest
-
-RUN gem install jekyll-asciidoc
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+FROM ruby:2.5-alpine
+COPY src/main/Gemfile* /tmp/
+RUN apk add --no-cache --virtual build-dependencies build-base \
+    && cd /tmp && bundle install \
+    && apk del build-dependencies build-base \
+    && mkdir /projects \
+    && for f in "/projects"; do \
+           chgrp -R 0 ${f} && \
+           chmod -R g+rwX ${f}; \
+       done
+CMD tail -f /dev/null

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+GREEN='\033[1;32m'
+BLUE='\033[1;34m'
+RED='\033[0;31m'
+NC='\033[0m'
+BOLD='\033[1m'
+
+printf "${BOLD}Building${NC} ${BLUE}eclipse/che-docs${NC} Che documentation ${BLUE}docker image${NC}\n"
+docker build -t eclipse/che-docs .
+if docker build -t eclipse/che-docs .; then
+  printf "${BOLD}Build${NC} ${BLUE}eclipse/che-docs${NC} ${GREEN}[OK]${NC}\n"
+else
+  printf "${BOLD}Build${NC} ${BLUE}eclipse/che-docs${NC} ${RED}[Failure]${NC}\n"
+fi


### PR DESCRIPTION
### What does this PR do?
Use Gemfile when building the docker image and not when running image
It avoids to install all gems dependencies at each start
Also
- introduce docker ignore file to speed up the build
- introduce build script for the image

Update of run.sh will follow when image will be published online

### What issues does this PR fix or reference?
N/A

Change-Id: Ifdb53b725ef4bc493d6781d5c412178d5f2b36f8
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
