### PR TITLE
Use `millisecond` as the unit for `CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT`.

### DIFF
--- a/src/main/pages/user-management/resource-management.adoc
+++ b/src/main/pages/user-management/resource-management.adoc
@@ -73,7 +73,7 @@ See link:docker-config.html[Docker] and link:openshift-config.html[OpenShift] co
 |`CHE_LIMITS_ORGANIZATION_WORKSPACES_COUNT` |-1 |item |maximum number of workspaces that members of an organization can create
 |`CHE_LIMITS_ORGANIZATION_WORKSPACES_RUN_COUNT` |-1 |item |maximum number of workspaces that members of an organization can simultaneously run
 |`CHE_LIMITS_ORGANIZATION_WORKSPACES_RAM` |-1 |memory |maximum amount of RAM that workspaces from all organizations can simultaneously use 
-|`CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT` |-1 |minute |maxium number of workspaces that can stay inactive before they are idled 
+|`CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT` |-1 |millisecond |maxium number of workspaces that can stay inactive before they are idled 
 |`CHE_LIMITS_WORKSPACE_ENV_RAM` |16gb |memory |maximum amount of RAM that workspace environment can use simultaneously
 |===
 
@@ -100,7 +100,7 @@ Memory uses one of the following suffixes:
 |===
 
 * `item` - An integer describing the number of objects.
-* `minute` - An integer describing the time frame in minutes.
+* `millisecond` - An integer describing the time frame in milliseconds.
 
 [id="resource-free-api"]
 == Resource-free API

--- a/src/main/pages/user-management/resource-management.adoc
+++ b/src/main/pages/user-management/resource-management.adoc
@@ -73,7 +73,7 @@ See link:docker-config.html[Docker] and link:openshift-config.html[OpenShift] co
 |`CHE_LIMITS_ORGANIZATION_WORKSPACES_COUNT` |-1 |item |maximum number of workspaces that members of an organization can create
 |`CHE_LIMITS_ORGANIZATION_WORKSPACES_RUN_COUNT` |-1 |item |maximum number of workspaces that members of an organization can simultaneously run
 |`CHE_LIMITS_ORGANIZATION_WORKSPACES_RAM` |-1 |memory |maximum amount of RAM that workspaces from all organizations can simultaneously use 
-|`CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT` |-1 |minutes |maxium number of workspaces that can stay inactive before they are idled 
+|`CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT` |-1 |minute |maxium number of workspaces that can stay inactive before they are idled 
 |`CHE_LIMITS_WORKSPACE_ENV_RAM` |16gb |memory |maximum amount of RAM that workspace environment can use simultaneously
 |===
 
@@ -100,7 +100,7 @@ Memory uses one of the following suffixes:
 |===
 
 * `item` - An integer describing the number of objects.
-* `minutes` - An integer describing the time frame in minutes.
+* `minute` - An integer describing the time frame in minutes.
 
 [id="resource-free-api"]
 == Resource-free API


### PR DESCRIPTION
### What does this PR do?

Fixing typo. Referring to the output of Swagger, the unit is `minute`.
 
### What issues does this PR fix or reference?

No.