### PR TITLE
Remove pure kubectl Che deployment instructions

### DIFF
--- a/src/main/pages/setup-kubernetes/kubernetes-single-user.adoc
+++ b/src/main/pages/setup-kubernetes/kubernetes-single-user.adoc
@@ -56,7 +56,7 @@ kubectl apply -f ./tiller-rbac.yaml
 helm init --service-account tiller
 ----
 +
-* Ensure that you have an NGINX-based Ingress controller. This is the default Ingress controller on Minikube. To start it, use the `minikube addons enable ingress` command.
+* Ensure that you have an Ingress controller enabled. To start it on Minikube, use the `minikube addons enable ingress` command.
 * DNS discovery should be enabled. It is enabled by default in Minikube.
 
 [id="cluster-ip"]

--- a/src/main/pages/setup-kubernetes/kubernetes-single-user.adoc
+++ b/src/main/pages/setup-kubernetes/kubernetes-single-user.adoc
@@ -7,28 +7,96 @@ permalink: kubernetes-single-user.html
 folder: setup-kubernetes
 ---
 
-[id="supported-kuberentes-flavors-and-versions"]
-== Supported Kubernetes flavors and versions
-
-The single-user deployment of Che to Kubernetes is tested only on Minikube v0.25 with the *VirtualBox* and *kvm2* VM providers.
+This section walks you through single-user deployment of Che on Kubernetes.
 
 *Prerequisites*
 
-* `bash`
-* `Kubernetes` installation with:
-** Enabled DNS discovery.
-** Configured Ingress controller. You can start the Ingress controller on Minikube using the `minikube addons enable ingress` command.
+* A Kubernetes cluster with at least 4 GB RAM and RBAC:
+** For Minikube 0.26.0 and higher, use the following command:
++
+----
+minikube start --cpus 2 --memory 4096 --extra-config=apiserver.authorization-mode=RBAC
+----
++
+** For Minikube 0.25.2 and lower, use the following command:
++
+----
+minikube start --cpus 2 --memory 4096 --extra-config=apiserver.Authorization.Mode=RBAC
+----
++
+* To deploy role binding, use the following command:
++
+----
+kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+----
++
+* Install the https://github.com/kubernetes/helm/blob/master/docs/install.md[Helm] CLI. HELM is the package manager for Kubernetes.
+* Set your default Kubernetes context (this is required to use Helm). In Minikube, this is set automatically. Otherwise, modify the `KUBECONFIG` environment variable and run the following coammnd:
++
+----
+kubectl config use-context <my-context>
+----
++
+* Install tiller, the Helm server, on your cluster.
+.. Create a https://github.com/kubernetes/helm/blob/master/docs/rbac.md[tiller serviceAccount].
++
+----
+kubectl create serviceaccount tiller --namespace kube-system
+----
++
+.. Bind it to the `cluster-admin` role.
++
+----
+kubectl apply -f ./tiller-rbac.yaml
+----
++
+.. Install `tiller`.
++
+----
+helm init --service-account tiller
+----
++
+* Ensure that you have an NGINX-based Ingress controller. This is the default Ingress controller on Minikube. To start it, use the `minikube addons enable ingress` command.
+* DNS discovery should be enabled. It is enabled by default in Minikube.
 
-[id="minikube"]
-== Deploying Minikube with YAML file
+[id="cluster-ip"]
+== Obtaining the cluster IP
 
-You can download the YAML file that contains the default settings and create the Che Server Kubernetes objects. In the YAML file, you must set the actual Minikube IP; you can leave the other configuration parameters as is.
+To obtain the cluster IP:
+
+* To run your cluster on Minikube, type `minikube ip` on the command line.
+* If your cluster is in the cloud, obtain the hostname or IP address from your cloud provider.
+
+In production, you must specify a hostname. For details, see the issue details at https://github.com/eclipse/che/issues/8694[Add an ability to use host-based routing instead of path-based for k8s infras]. To use a host-based configuration when you do not have a hostname, use services such as nip.io or xip.io.
+
+To specify a hostname, pass it as the value of the `ingressDomain` parameter in the deployment syntax in the following section.
+
+To use the IP address, for example, when your corporate policy prevents you from using nip.io, set `isHostBased` to `false`.
+
+[id="deploy-syntax"]
+== Deployment syntax
+
+The context of the commands below is `che/deploy/kubernetes/helm/che`.
+
+[id="deploy-che"]
+=== Deploying Che
+
+To deploy single-user Che:
+
+. Use one of the following two methods to override the default values:
 
 ----
-CHE_KUBERNETES_YAML_URL=https://raw.githubusercontent.com/eclipse/che/master/deploy/kubernetes/kubectl/che-kubernetes.yaml
-curl -fsSL ${CHE_KUBERNETES_YAML_URL} | sed "s/192.168.99.100/$(minikube ip)/" > che-kubernetes.yaml
-kubectl create namespace che
-kubectl --namespace=che apply -f che-kubernetes.yaml
+helm upgrade --install <my-che-installation> --namespace <my-che-namespace> -f ./
 ----
 
-The Che deployment starts and the running Che pod is available at the following URL: `$(minikube ip).nip.io`.
+
+* Master: `https://che-<che-namespace>.domain`
+* Workspaces servers: `https://server-host.domain`
+
+== Deleting Che deployment
+
+To delete a deployment, run the following command:
+
+----
+helm delete <che-release-name>
+----


### PR DESCRIPTION
### What does this PR do?
replace old instructions for deploying single-user Che using pure kubectl https://github.com/eclipse/che/pull/11894 , with approach of using Helm

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11135