### PR TITLE
Update pom.xml to use new Docker image for docs building.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
                                         <!-- build Jekyll docs with docker -->
                                         <exec executable="bash">
                                             <arg value="-c" />
-                                            <arg value="docker run -v $(pwd):/che-docs robkratky/che-docs sh -c 'cd /che-docs/src/main; mkdir -p _site; chown jekyll:jekyll _site; jekyll build --config _config.yml,_config-war.yml'" />
+                                            <arg value="docker run -v $(pwd):/che-docs eclipse/che-docs sh -c 'cd /che-docs/src/main; mkdir -p _site; chown jekyll:jekyll _site; jekyll build --config _config.yml,_config-war.yml'" />
                                         </exec>
                                     </target>
                                 </configuration>


### PR DESCRIPTION
### What does this PR do?

Updates `pom.xml` to use the `eclipse/che-docs` Docker image for docs building (introduced in #562).