### PR TITLE
Update Release Notes template

### DIFF
--- a/release-notes/rn-template.md
+++ b/release-notes/rn-template.md
@@ -1,40 +1,92 @@
-## Release summary
+# Eclipse Che $VERSION Release Notes
 
-Eclipse Che <VERSION> includes:
+////
 
-* **Feature1**: Quick value description
-* **Feature2**: Quick value description
-* …
+Heading for blog post
 
-## Upgrading
+## $HIGHLIGHT1 $HIGHLIGHT2 $HIGHLIGHT3
 
-Instructions on how to upgrade.
+////
 
+The Eclipse Che $VERSION release contains the following notable features:
+ 
+* $HIGHLIGHT1
+* $HIGHLIGHT2
+* $HIGHLIGHT3
 
-## Release details
+---
 
-### Feature 1 (#ISSUE)
+Intro paragraph
 
-Feature description focusing on value to the user or contributor.
+---
 
-Learn more in the documentation: [Link to the documentation](<URL>).
+## Quick Start
 
-### Feature 2 (#ISSUE)
+Che is a cloud IDE and containerized workspace server - get started on:
 
-Feature description focusing on value to the user or contributor.
+* Kubernetes ([single-user](https://www.eclipse.org/che/docs/kubernetes-single-user.html) or [multi-user](https://www.eclipse.org/che/docs/kubernetes-multi-user.html))
+* OpenShift ([single-user](https://www.eclipse.org/che/docs/openshift-single-user.html) or [multi-user](https://www.eclipse.org/che/docs/openshift-multi-user.html))
+* Docker ([single-user](https://www.eclipse.org/che/docs/docker-single-user.html) or [multi-user](https://www.eclipse.org/che/docs/docker-multi-user.html))
+* Try Eclipse Che live at [https://che.openshift.io](https://che.openshift.io)
 
-Learn more in the documentation: [Link to the documentation](<URL>).
+Learn more in our [documentation](https://www.eclipse.org/che/docs/infra-support.html) and start using a shared Che server or local instance today.
 
-## Other notable enhancements
+---
 
-* Issue title. (#ISSUE)
+## $HIGHLIGHT1
 
-## Notable bug fixes
+Screenshot/illustration
 
-* Fixed issue’s title. (#ISSUE)
+Description
+
+Links to PRs
+
+---
+
+## $HIGHLIGHT2
+
+Screenshot/illustration
+
+Description
+
+Links to PRs
+
+---
+
+## $HIGHLIGHT3
+
+Screenshot/illustration
+
+Description
+
+Links to PRs
+
+---
+
+## N Improvements
+
+The Che team has made over 130 changes in the $RELEASE release, touching every part of the project. It is difficult to do them justice here, you can read [the full ChangeLog](https://github.com/eclipse/che/blob/master/CHANGELOG.md#6130-2018-10-24) in the project's source code repository.
+
+---
 
 ## Community, Thank You!
 
 We’d like to say a big thank you to everyone who helped to make Che even better:
 
 * [Contributor Name](<PROFILE_URL>) – [Company Name](<COMPANY_URL>) – (#PR): [PR Title](<PR_URL>)
+
+---
+
+## Contributing
+
+The Eclipse Che project is always looking for user feedback and new contributors! [Find out how you can get involved and help make Che even better](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md).
+
+## Getting involved
+
+You can reach the Eclipse Che community in a number of ways:
+
+* Create an issue in the [Eclipse Che GitHub repository](https://github.com/eclipse/che/)
+* Send an email to the [che-dev mailing list](https://accounts.eclipse.org/mailing-list/che-dev) at eclipse.org
+* Join us on [the eclipse-che channel on mattermost.eclipse.org](https://mattermost.eclipse.org/eclipse/channels/eclipse-che) to chat in real-time
+* Follow us on Twitter [@eclipse_che](https://twitter.com/eclipse_che)
+


### PR DESCRIPTION
Updated Release Notes template to include boilerplate we use for the recurring blog post.

Release notes will be collected here after publication of the blog posts in the future.

### What does this PR do?

Update release notes template to include boilerplate we have been using for Che release notes blog posts 

### What issues does this PR fix or reference?
