### PR TITLE
Added description of per-workspace PVC strategy

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,13 +8,13 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-if [ "$1" == "-prod" ]; then
+if [ "$1" = "-prod" ]; then
   echo "Building for production (publishing on eclipse.org/che/docs/). To preview"
   echo -e "the docs locally, run the script ($0) without the '-prod' option.\n"
   docker run --rm -v $(pwd)/src/main:/che-docs:Z eclipse/che-docs sh -c "cd /che-docs; jekyll build --baseurl '/che/docs/'"
 else
   echo "Building and serving the docs for local preview. To build for production"
   echo "(publishing on eclipse.org/che/docs/), run the script with the '-prod' option:"
-  echo -e "$0 -prod\n"
+  echo "$0 -prod"
   docker run --rm -ti -p 35729:35729 -p 4000:4000 -v $(pwd)/src/main:/che-docs:Z eclipse/che-docs sh -c "cd /che-docs; jekyll serve --incremental --livereload -H 0.0.0.0"
 fi

--- a/src/main/pages/che-6/setup-kubernetes/kubernetes-admin-guide.adoc
+++ b/src/main/pages/che-6/setup-kubernetes/kubernetes-admin-guide.adoc
@@ -10,6 +10,7 @@ folder: setup-kubernetes
 
 :admin-context: Kubernetes
 :ctl-command: kubectl
+:k8s-namespace: Kubernetes Namespace
 :docs-registry-link: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 :che-data-volume-link: https://github.com/eclipse/che/blob/master/deploy/kubernetes/helm/che/templates/deployment.yaml#L57
 :cluster-nodes-link: https://kubernetes.io/docs/concepts/architecture/nodes/#management

--- a/src/main/pages/che-6/setup-kubernetes/kubernetes-or-openshift-admin-guide.adoc
+++ b/src/main/pages/che-6/setup-kubernetes/kubernetes-or-openshift-admin-guide.adoc
@@ -1,17 +1,19 @@
 // This content (file) is included in:
-// 
+//
 // * setup-kubernetes/kubernetes-admin-guide.adoc
 // * setup-openshift/openshift-admin-guide.adoc
-// 
+//
 // The 'admin-context' variable (set in the parent files)
 // is used to determine K8s or OpenShift use.
 
 //  ifeval::[{admin-context} == "OpenShift"]
 //  :ctl-command: oc
+//  :k8s-namespace: OpenShift Project
 //  endif::[]
-//  
+//
 //  ifeval::[{admin-context} == "Kubernetes"]
 //  :ctl-command: kubectl
+//  :k8s-namespace: Kubernetes Namespace
 //  endif::[]
 
 
@@ -114,8 +116,13 @@ The workspace PVC strategy is configurable:
 [width="100%",cols="25%,25%,25%,25%",options="header",]
 |===
 |strategy |details |pros |cons
-|*unique (default)* |one PVC per workspace |Storage isolation |An undefined number of PVs is required
-|*common* | One PVC for all workspaces, Sub-paths pre-created |Easy to manage and control storage |No need to recyle PVs when pod with PVC is deleted |Workspace pods should all be in one namespace
+|*unique (default)* | One PVC per workspace volume |Storage isolation |An undefined number of PVs is required
+|*common* | One PVC for all workspaces in one {k8s-namespace}
+
+Sub-paths pre-created |Easy to manage and control storage |Workspaces must be in a separate {k8s-namespace} if PV does not support ReadWriteMany (RWX) access mode
+|*per-workspace* | One PVC for one workspace
+
+Sub-paths pre-created |Easy to manage and control storage |Workspace containers must all be in one pod if PV does not support ReadWriteMany (RWX) access mode
 |===
 
 [id="unique-pvc-strategy"]
@@ -171,6 +178,17 @@ When a common strategy is used and a workspace PVC access mode is ReadWriteOnce 
 To change the access mode for workspace PVCs, pass the `CHE_INFRA_KUBERNETES_PVC_ACCESS_MODE=ReadWriteMany` environment variable to Che deployment either when initially deploying Che or through the Che deployment update.
 
 Another restriction is that only pods in the same namespace can use the same PVC.  The `CHE_INFRA_KUBERNETES_PROJECT` environment variable should not be empty.  It should be either the Che server namespace where objects can be created with the Che service account (SA) or a dedicated namespace where a token or a username and password need to be used.
+
+[id="per-workspace-pvc-strategy"]
+=== Per workspace PVC strategy
+
+To define the unique strategy, set `CHE_INFRA_KUBERNETES_PVC_STRATEGY` to `per-workspace`.
+
+[id="how-the-per-workspace-pvc-strategy-works"]
+==== How the per workspace PVC strategy works
+
+It works similarly to the common PVC strategy.
+The only difference is that all workspace volumes (but not all workspaces) use the same PVC to store data (projects and workspace logs by default and any additional link:volumes.html[volumes] that a user can define).
 
 [id="updating-your-che-deployment"]
 == Updating your Che deployment

--- a/src/main/pages/che-6/setup-openshift/openshift-admin-guide.adoc
+++ b/src/main/pages/che-6/setup-openshift/openshift-admin-guide.adoc
@@ -10,6 +10,7 @@ folder: setup-openshift
 
 :admin-context: OpenShift
 :ctl-command: oc
+:k8s-namespace: OpenShift Project
 :docs-registry-link: https://docs.okd.io/latest/architecture/infrastructure_components/image_registry.html
 :che-data-volume-link: https://github.com/eclipse/che/blob/master/deploy/openshift/templates/pvc/che-server-pvc.yaml#L14
 :cluster-nodes-link: https://docs.okd.io/latest/admin_guide/manage_nodes.html


### PR DESCRIPTION
### What does this PR do?
Adds a description of per-workspace PVC strategy:
1. Modified PVC Strategies section
![screenshot_20181213_110933](https://user-images.githubusercontent.com/5887312/49928221-5fdc7d80-fec8-11e8-9783-a86171b3e577.png)
Changed to the following
![screenshot_20181213_110919](https://user-images.githubusercontent.com/5887312/49928228-666af500-fec8-11e8-99c2-f16cd4abe0ad.png)

2. Added `PerWorkspace` section:
![screenshot_20181213_111006](https://user-images.githubusercontent.com/5887312/49928259-7be01f00-fec8-11e8-87c1-fecda02887fd.png)

It also contains small fixes for `run.sh` script:
1. `#!/bin/sh` doesn't support `==` and show a warning message
```
./run.sh: 11: [: unexpected operator
```
To avoid this `=` should be used instead of `#!/bin/bash` should be used. 
I replaced `==` with `=`
2. As far as I understand `-e` should set some special behavior for `echo -e "$0 -prod\n"` but actually `-e` is just printed. So, removed it and now the output looks like the following:
```sh
serg@sergpad:~/projects/che-docs$ ./run.sh 
Building and serving the docs for local preview. To build for production
(publishing on eclipse.org/che/docs/), run the script with the '-prod' option:
./run.sh -prod

Configuration file: /che-docs/_config.yml
```
### What issues does this PR fix or reference?
It describes changes in https://github.com/eclipse/che/pull/12176