### PR TITLE
fix loopback alias command

### DIFF
--- a/src/main/pages/che-6/overview/quick-start.adoc
+++ b/src/main/pages/che-6/overview/quick-start.adoc
@@ -44,8 +44,7 @@ To run Che in single-user mode, enter:
 $ docker run -ti -v /var/run/docker.sock:/var/run/docker.sock -v /local/path:/data eclipse/che start
 ----
 
-Note that `/local/path` can be any path on your local machine where you want to store Che data and projects.
-Once Che has started it can be accessed at `localhost:8080`.
+Note that `/local/path` can be any path on your local machine where you want to store Che data and projects. Once Che has started, it can be accessed at `localhost:8080`.
 
 .Next steps
 

--- a/src/main/pages/che-6/overview/quick-start.adoc
+++ b/src/main/pages/che-6/overview/quick-start.adoc
@@ -27,7 +27,7 @@ See link:single-multi-user[Single and Multi-User Che] to learn more. The quick s
 * On macOS, create an IP alias. In a terminal, run:
 +
 ----
-# ifconfig la0 alias $IP
+# ifconfig lo0 alias $IP
 ----
 +
 Where `$IP` is found either in *Preferences > Advanced > Docker subnet*, or run
@@ -45,6 +45,7 @@ $ docker run -ti -v /var/run/docker.sock:/var/run/docker.sock -v /local/path:/da
 ----
 
 Note that `/local/path` can be any path on your local machine where you want to store Che data and projects.
+Once Che has started it can be accessed at `localhost:8080`.
 
 .Next steps
 


### PR DESCRIPTION
-  fix loopback alias command (`la0` -> `lo0`)
- add information how to access Che once it has launched


