### PR TITLE
Added section about auto-stopping workspaces without pods

### DIFF
--- a/src/main/pages/che-6/setup-kubernetes/kubernetes-or-openshift-admin-guide.adoc
+++ b/src/main/pages/che-6/setup-kubernetes/kubernetes-or-openshift-admin-guide.adoc
@@ -306,6 +306,25 @@ To increase the grace termination period, use the following environment variable
 If the `terminationGracePeriodSeconds` variable is explicitly set in the {admin-context} recipe, the `pass:[CHE_INFRA_KUBERNETES_POD_TERMINATION__GRACE__PERIOD__SEC]` environment variable does not override the recipe.
 ====
 
+[id="kubernetes-or-openshift-admin-guide-che-workspace-stop-on-pods-removing"]
+== Auto-stopping workspace if its pods are removed
+
+Sometimes it may happen that workspace Pods goes down when Che Server considers it as `RUNNING`.
+For example, the user removed it from {admin-context} console, admin can terminate (miner detection) pod or infrastructure node goes down.
+Che Server has periodical job that will stop such Runtimes without existing pods.
+
+It is disabled by default because there is possible Che Server configuration when Che Server doesn't have an ability to interact with Kubernetes API when operation is not invoked by user.
+It DOES work on the following configurations:
+
+* workspaces objects are created in the same namespace where Che Server is located;
+* cluster-admin service account token is mount to Che Server pod;
+
+It DOES NOT work on the following configurations:
+
+* Che Server communicates with Kubernetes API using token from OAuth provider;
+
+And it may be enabled by configuring `pass:[CHE_INFRA_KUBERNETES_RUNTIMES__CONSISTENCY__CHECK__PERIOD__MIN]` environment variable with value more than `0`.
+
 [id="updating-che-without-stopping-active-workspaces"]
 == Updating Che without stopping active workspaces
 

--- a/src/main/pages/che-6/setup-kubernetes/kubernetes-or-openshift-admin-guide.adoc
+++ b/src/main/pages/che-6/setup-kubernetes/kubernetes-or-openshift-admin-guide.adoc
@@ -306,24 +306,25 @@ To increase the grace termination period, use the following environment variable
 If the `terminationGracePeriodSeconds` variable is explicitly set in the {admin-context} recipe, the `pass:[CHE_INFRA_KUBERNETES_POD_TERMINATION__GRACE__PERIOD__SEC]` environment variable does not override the recipe.
 ====
 
+
 [id="kubernetes-or-openshift-admin-guide-che-workspace-stop-on-pods-removing"]
-== Auto-stopping workspace if its pods are removed
+== Auto-stopping a workspace when its pods are removed
 
-Sometimes it may happen that workspace Pods goes down when Che Server considers it as `RUNNING`.
-For example, the user removed it from {admin-context} console, admin can terminate (miner detection) pod or infrastructure node goes down.
-Che Server has periodical job that will stop such Runtimes without existing pods.
+Che Server includes a job that automatically stops workspace runtimes if their pods have been terminated. Pods are terminated when, for example, users remove them from the {admin-context} console, administrators terminate them to prevent misuse, or an infrastructure node crashes.
 
-It is disabled by default because there is possible Che Server configuration when Che Server doesn't have an ability to interact with Kubernetes API when operation is not invoked by user.
-It DOES work on the following configurations:
+The job is disabled by default to avoid problems in configurations where Che Server cannot interact with the Kubernetes API without user intervention.
 
-* workspaces objects are created in the same namespace where Che Server is located;
-* cluster-admin service account token is mount to Che Server pod;
+The job cannot function with the following Che Server configuration:
 
-It DOES NOT work on the following configurations:
+* Che Server communicates with the Kubernetes API using a token from the OAuth provider.
 
-* Che Server communicates with Kubernetes API using token from OAuth provider;
+The job can function with the following Che Server configurations:
 
-And it may be enabled by configuring `pass:[CHE_INFRA_KUBERNETES_RUNTIMES__CONSISTENCY__CHECK__PERIOD__MIN]` environment variable with value more than `0`.
+* Workspaces objects are created in the same namespace where Che Server is located.
+* The *cluster-admin* service account token is mounted to the Che Server pod.
+
+To enable the job, set the `pass:[CHE_INFRA_KUBERNETES_RUNTIMES__CONSISTENCY__CHECK__PERIOD__MIN]` environment variable to contain a value greater than `0`. The value is the time period in minutes between checks for runtimes without pods.
+
 
 [id="updating-che-without-stopping-active-workspaces"]
 == Updating Che without stopping active workspaces


### PR DESCRIPTION
### What does this PR do?
Adds section about auto-stopping workspaces without pods:
![screenshot_20181226_143927](https://user-images.githubusercontent.com/5887312/50446178-3980fe00-091c-11e9-8d5c-675823730718.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/pull/12257