### PR TITLE
Add release notes for the che_workspace_failure_total and che_workspace_status metrics.

### DIFF
--- a/release-notes/release-6.17.0.md
+++ b/release-notes/release-6.17.0.md
@@ -1,0 +1,34 @@
+## Release summary
+
+Eclipse Che 6.17 includes:
+
+* **Workspace failure count metric**: Prometheus metric counting the number of workspace failures
+
+
+## Upgrading
+
+Instructions on how to upgrade.
+
+
+## Release details
+
+### Workspace failure count metric
+
+The Prometheus metrics exposed by the Che server now include the `che_workspace_failure_total` 
+metric which reports the count of workspaces that failed while in different statuses. You can
+distinguish between failures during startup, runtime or shutdown of a workspace using the `while`
+tag of the metric, which recognizes `STARTING`, `RUNNING` or `STOPPING` values respectively.
+ 
+## Other notable enhancements
+
+* Issue title. (#ISSUE)
+
+## Notable bug fixes
+
+* Fixed issue’s title. (#ISSUE)
+
+## Community, Thank You!
+
+We’d like to say a big thank you to everyone who helped to make Che even better:
+
+* [Contributor Name](<PROFILE_URL>) – [Company Name](<COMPANY_URL>) – (#PR): [PR Title](<PR_URL>)

--- a/release-notes/release-6.17.0.md
+++ b/release-notes/release-6.17.0.md
@@ -2,8 +2,8 @@
 
 Eclipse Che 6.17 includes:
 
-* **Keep track of workspace failures**: Added a Prometheus metric to count the number of workspace
-failures
+* **Improvements to workspace monitoring metrics**: Added a Prometheus metric to count the number of
+workspace failures
 
 
 ## Upgrading
@@ -13,13 +13,16 @@ Instructions on how to upgrade.
 
 ## Release details
 
-### Keep track of workspace failures
+### Improvements to workspace monitoring metrics
 
-The Prometheus metrics exposed by the Che server now include the `che_workspace_failure_total` 
-metric which reports the count of workspaces that failed while in different statuses. You can
-distinguish between failures during startup, runtime or shutdown of a workspace using the `while`
-tag of the metric, which recognizes `STARTING`, `RUNNING` or `STOPPING` values respectively.
- 
+As part of the improvements in the monitoring and tracing of workspaces, we have added several new
+metrics in this release. The Prometheus metrics exposed by the Che server now include the 
+`che_workspace_status` and `che_workspace_failure_total` metrics, allowing users to track the count
+of workspaces per status (`STARTING`, `RUNNING` `STOPPING` or `STOPPED`), and the total number of
+failed workspaces. Server operators can see when workspaces are failing by using a `while` tag,
+which recognizes `STARTING`, `RUNNING` or `STOPPING` values respectively. These new metrics enable
+operators to proactively identify when there are issues with workspaces.
+
 ## Other notable enhancements
 
 * Issue title. (#ISSUE)

--- a/release-notes/release-6.17.0.md
+++ b/release-notes/release-6.17.0.md
@@ -2,7 +2,8 @@
 
 Eclipse Che 6.17 includes:
 
-* **Workspace failure count metric**: Prometheus metric counting the number of workspace failures
+* **Keep track of workspace failures**: Added a Prometheus metric to count the number of workspace
+failures
 
 
 ## Upgrading
@@ -12,7 +13,7 @@ Instructions on how to upgrade.
 
 ## Release details
 
-### Workspace failure count metric
+### Keep track of workspace failures
 
 The Prometheus metrics exposed by the Che server now include the `che_workspace_failure_total` 
 metric which reports the count of workspaces that failed while in different statuses. You can


### PR DESCRIPTION
### What does this PR do?

Add release notes for the `che_workspace_failure_total` and `che_workspace_status` metrics.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/12242
https://github.com/eclipse/che/pull/12368
eclipse/che#12092
