### PR TITLE
Fix dead links in Quick Start page

### DIFF
--- a/src/main/pages/che-6/overview/quick-start.adoc
+++ b/src/main/pages/che-6/overview/quick-start.adoc
@@ -8,7 +8,6 @@ redirect_from: quick-start.html
 folder: che-6/overview
 ---
 
-1
 Eclipse Che is a developer workspace server and cloud IDE. You install, run, and manage Eclipse Che with with different container orchestration engines such as Docker or OpenShift.
 
 Eclipse Che is available in two modes:
@@ -16,7 +15,7 @@ Eclipse Che is available in two modes:
 * *Single-user*: This is suited for personal desktop environments.
 * *Multi-user*: This is an advanced setup for Che and is for organizations and developer teams.
 
-See link:single-multi-user[Single and Multi-User Che] to learn more. The quick starts are for single-user mode.
+See link:single-multi-user.html[Single and Multi-User Che] to learn more. The quick starts are for single-user mode.
 
 [id="docker"]
 == Running single-user Che on Docker
@@ -48,7 +47,7 @@ Note that `/local/path` can be any path on your local machine where you want to 
 
 .Next steps
 
-link:creating-starting-workspaces[Create and start your first workspace], import a link:ide-projects[project], and link:commands-ide-macro[build and run] your project.
+link:creating-starting-workspaces.html[Create and start your first workspace], import a link:ide-projects.html[project], and link:commands-ide-macro.html[build and run] your project.
 
 .Additional resources
 


### PR DESCRIPTION
This may be a widespread occurrence - is there a way to check if the .html extension is missing through the entire site?

Fixes issue #677