### PR TITLE
Add initial set of Che 7 guides + user story templates.

### DIFF
--- a/src/main/pages/che-7/developer-guide/assembly_configuring-workspaces.adoc
+++ b/src/main/pages/che-7/developer-guide/assembly_configuring-workspaces.adoc
@@ -1,0 +1,43 @@
+---
+title: Configuring workspaces
+keywords: overview
+tags: []
+sidebar: che_7_docs
+permalink: che-7/configuring-workspaces.html
+folder: che-7/developer-guid
+summary: 
+---
+
+:parent-context-of-configuring-workspaces: {context}
+
+[id='configuring-workspaces_{context}']
+= Configuring workspaces
+
+:context: configuring-workspaces
+
+This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. Can include more than one paragraph. Consider using the information from the user story.
+
+[id='prerequisites-{context}']
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+include::con_understanding-workspaces.adoc[leveloffset=+1]
+
+include::proc_defining-workspace-runtime-environments.adoc[leveloffset=+1]
+
+include::proc_defining-volumes-docker-volumes-pvcs-and-pvs.adoc[leveloffset=+1]
+
+include::proc_defining-recipes.adoc[leveloffset=+1]
+
+
+[id='related-information-{context}']
+== Related information
+
+* A bulleted list of links to other material closely related to the contents of the concept module.
+* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+
+:context: {parent-context-of-configuring-workspaces}

--- a/src/main/pages/che-7/developer-guide/assembly_creating-workspaces.adoc
+++ b/src/main/pages/che-7/developer-guide/assembly_creating-workspaces.adoc
@@ -1,0 +1,45 @@
+---
+title: Creating workspaces
+keywords: overview
+tags: []
+sidebar: che_7_docs
+permalink: che-7/creating-workspaces.html
+folder: che-7/developer-guid
+summary: 
+---
+
+:parent-context-of-creating-workspaces: {context}
+
+[id='creating-workspaces_{context}']
+= Creating workspaces
+
+:context: creating-workspaces
+
+This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. Can include more than one paragraph. Consider using the information from the user story.
+
+[id='prerequisites-{context}']
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+include::con_understanding-workspaces.adoc[leveloffset=+1]
+
+include::proc_creating-a-workspace-from-a-code-sample.adoc[leveloffset=+1]
+
+include::proc_creating-a-workspace-by-importing-source-code-of-your-project.adoc[leveloffset=+1]
+
+include::proc_creating-a-workspace-using-multi-machine-environments.adoc[leveloffset=+1]
+
+include::proc_creating-a-workspace-from-a-recipe.adoc[leveloffset=+1]
+
+
+[id='related-information-{context}']
+== Related information
+
+* A bulleted list of links to other material closely related to the contents of the concept module.
+* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+
+:context: {parent-context-of-creating-workspaces}

--- a/src/main/pages/che-7/developer-guide/assembly_extending-che.adoc
+++ b/src/main/pages/che-7/developer-guide/assembly_extending-che.adoc
@@ -1,0 +1,48 @@
+---
+title: Extending Che
+keywords: overview
+tags: []
+sidebar: che_7_docs
+permalink: che-7/extending-che.html
+folder: che-7/developer-guid
+summary: 
+---
+
+:parent-context-of-extending-che: {context}
+
+[id='extending-che_{context}']
+= Extending Che
+
+:context: extending-che
+
+This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. Can include more than one paragraph. Consider using the information from the user story.
+
+[id='prerequisites-{context}']
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+include::con_understanding-che-extensibility.adoc[leveloffset=+1]
+
+include::proc_working-with-che-plugin-registries.adoc[leveloffset=+1]
+
+include::proc_packaging-che-plugins.adoc[leveloffset=+1]
+
+include::proc_packaging-theia-plugins.adoc[leveloffset=+1]
+
+include::proc_packaging-visual-studio-code-extensions.adoc[leveloffset=+1]
+
+include::proc_supporting-che-plugin-types-with-plugin-brokers.adoc[leveloffset=+1]
+
+
+[id='related-information-{context}']
+== Related information
+
+* A bulleted list of links to other material closely related to the contents of the concept module.
+* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+
+
+:context: {parent-context-of-extending-che}

--- a/src/main/pages/che-7/developer-guide/con_understanding-che-extensibility.adoc
+++ b/src/main/pages/che-7/developer-guide/con_understanding-che-extensibility.adoc
@@ -1,0 +1,17 @@
+[id="understanding-che-extensibility_{context}"]
+= Understanding Che extensibility
+
+This paragraph is the concept module introduction and is only optional. Include it to provide a short overview of the module.
+
+The contents of a concept module give the user descriptions and explanations needed to understand and use a product.
+
+* Look at nouns and noun phrases in related procedure modules and assemblies to find the concepts to explain to users.
+* Explain only things that are visible to users. Even if a concept is interesting, it probably does not require explanation if it is not visible to users.
+* Do not include any instructions to perform an action, such as executing a command. Action items belong in procedure modules.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the concept module.
+* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/con_understanding-workspaces.adoc
+++ b/src/main/pages/che-7/developer-guide/con_understanding-workspaces.adoc
@@ -1,0 +1,17 @@
+[id="understanding-workspaces_{context}"]
+= Understanding workspaces
+
+This paragraph is the concept module introduction and is only optional. Include it to provide a short overview of the module.
+
+The contents of a concept module give the user descriptions and explanations needed to understand and use a product.
+
+* Look at nouns and noun phrases in related procedure modules and assemblies to find the concepts to explain to users.
+* Explain only things that are visible to users. Even if a concept is interesting, it probably does not require explanation if it is not visible to users.
+* Do not include any instructions to perform an action, such as executing a command. Action items belong in procedure modules.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the concept module.
+* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_creating-a-workspace-by-importing-source-code-of-your-project.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_creating-a-workspace-by-importing-source-code-of-your-project.adoc
@@ -1,0 +1,27 @@
+[id="creating-a-workspace-by-importing-source-code-of-your-project_{context}"]
+= Creating a workspace by importing source code of your project
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_creating-a-workspace-from-a-code-sample.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_creating-a-workspace-from-a-code-sample.adoc
@@ -1,0 +1,27 @@
+[id="creating-a-workspace-from-a-code-sample_{context}"]
+= Creating a workspace from a code sample
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_creating-a-workspace-from-a-recipe.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_creating-a-workspace-from-a-recipe.adoc
@@ -1,0 +1,27 @@
+[id="creating-a-workspace-from-a-recipe_{context}"]
+= Creating a workspace from a recipe
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_creating-a-workspace-using-multi-machine-environments.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_creating-a-workspace-using-multi-machine-environments.adoc
@@ -1,0 +1,27 @@
+[id="creating-a-workspace-using-multi-machine-environments_{context}"]
+= Creating a workspace using multi-machine environments
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_defining-recipes.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_defining-recipes.adoc
@@ -1,0 +1,27 @@
+[id="defining-recipes_{context}"]
+= Defining recipes
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_defining-volumes-docker-volumes-pvcs-and-pvs.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_defining-volumes-docker-volumes-pvcs-and-pvs.adoc
@@ -1,0 +1,27 @@
+[id="defining-volumes-docker-volumes-pvcs-and-pvs_{context}"]
+= Defining volumes (Docker volumes, PVCs, and PVs)
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_defining-workspace-runtime-environments.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_defining-workspace-runtime-environments.adoc
@@ -1,0 +1,27 @@
+[id="defining-workspace-runtime-environments_{context}"]
+= Defining workspace runtime environments
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_packaging-che-plugins.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_packaging-che-plugins.adoc
@@ -1,0 +1,27 @@
+[id="packaging-che-plugins_{context}"]
+= Packaging Che plugins
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_packaging-theia-plugins.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_packaging-theia-plugins.adoc
@@ -1,0 +1,27 @@
+[id="packaging-theia-plugins_{context}"]
+= Packaging Theia plugins
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_packaging-visual-studio-code-extensions.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_packaging-visual-studio-code-extensions.adoc
@@ -1,0 +1,27 @@
+[id="packaging-visual-studio-code-extensions_{context}"]
+= Packaging Visual Studio Code extensions
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_supporting-che-plugin-types-with-plugin-brokers.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_supporting-che-plugin-types-with-plugin-brokers.adoc
@@ -1,0 +1,27 @@
+[id="supporting-che-plugin-types-with-plugin-brokers_{context}"]
+= Supporting Che plugin types with plugin brokers
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/developer-guide/proc_working-with-che-plugin-registries.adoc
+++ b/src/main/pages/che-7/developer-guide/proc_working-with-che-plugin-registries.adoc
@@ -1,0 +1,27 @@
+[id="working-with-che-plugin-registries_{context}"]
+= Working with Che plugin registries
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+[discrete]
+== Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+[discrete]
+== Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/installation-guide/assembly_installing-eclipse-che-quick-start.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_installing-eclipse-che-quick-start.adoc
@@ -1,0 +1,58 @@
+---
+title: Quick start
+keywords: overview
+tags: []
+sidebar: che_7_docs
+permalink: che-7/installing-eclipse-che-quick-start.html
+folder: che-7/installation-guide
+summary: 
+---
+
+:parent-context-of-installing-eclipse-che-quick-start: {context}
+
+[id='installing-eclipse-che-quick-start_{context}']
+= Installing Eclipse Che - quick start
+
+:context: installing-eclipse-che-quick-start
+
+ifdef::internal[]
+[cols="1,4"]
+|===
+| Included in |
+LIST OF ASSEMBLIES
+| User story |
+USER STORY
+| Jira |
+JIRA LINK
+| BZ |
+BUGZILLA LINK
+| SMEs |
+SME NAMES
+| SME Ack |
+YES/NO
+| Peer Ack |
+YES/NO
+|===
+endif::[]
+
+This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. Can include more than one paragraph. Consider using the information from the user story.
+
+[id='prerequisites-{context}']
+== Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+Include modules here.
+
+
+[id='related-information-{context}']
+== Related information
+
+* A bulleted list of links to other material closely related to the contents of the concept module.
+* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+
+:context: {parent-context-of-installing-eclipse-che-quick-start}
+


### PR DESCRIPTION
### What does this PR do?

Adds initial outline for a new structure of Che 7 docs. Specifically, it adds three directories:

* `installation-guide`
* `administration-guide`
* `developer-guide`

and a number of user-story templates.

Existing Che 7 content will now start to be migrated into the new structure (using prepared templates or adding new templates as required).
