### PR TITLE
Removing Docker, adding Kubernetes links

### DIFF
--- a/src/main/pages/che-7/overview/overview.adoc
+++ b/src/main/pages/che-7/overview/overview.adoc
@@ -27,7 +27,7 @@ Eclipse Che provides:
 You can get started with Che by:
 
 * link:quick-start.html[Quick start guide]
-* Installing it on Docker: link:docker-single-user.html[Single-user] or link:docker-multi-user.html[Multi-user]
+* Installing it on Kubernetes: link:kubernetes-single-user.html[Single-user] or link:kubernetes-multi-user.html[Multi-user]
 * Installing it on OpenShift: link:openshift-single-user.html[Single-user] or link:openshift-multi-user.html[Multi-user]
 * https://www.eclipse.org/che/docs/setup/getting-started-saas-cloud/index.html[Creating a hosted SaaS account]
 


### PR DESCRIPTION
Docker is not supported in Che 7 AFAIK - we should focus on K8s.

### What does this PR do?

Removes links to Docker getting started, and adds links for Kubernetes getting started

