### PR TITLE
Add CSS for responsive video embeds.

### DIFF
--- a/src/main/css/customstyles.css
+++ b/src/main/css/customstyles.css
@@ -1287,11 +1287,32 @@ h4.panel-title {
 }
 
 div.imageblock .content,
+div.videoblock .content,
 div.openblock .content,
 div.literalblock .content,
 div.listingblock .content {
     max-width: 100%
 }
+
+/* BEGIN responsive video size */
+div.videoblock .content {
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 30px;
+  height: 0;
+  overflow: hidden;
+  margin-bottom: 1em;
+}
+.videoblock .content iframe,
+.videoblock .content object,
+.videoblock .content embed {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
+/* END responsive video size */
 
 div.title {
     font-weight: bold!important;


### PR DESCRIPTION
### What does this PR do?

Adds CSS for automatic scaling of embedded (YouTube) videos to width of content column.

### What issues does this PR fix or reference?

Ensures videos using `iframe` for embedding don't use default, tiny size.