### PR TITLE
Fix context attribute conflict.

### DIFF
--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -49,7 +49,7 @@ asciidoctor:
     source-highlighter: coderay
     coderay-css: style
     icons: font
-    context: che
+    project-context: che
     experimental: ''
 
 # library used for syntax highlighting

--- a/src/main/pages/che-6/setup-openshift/openshift-multi-user.adoc
+++ b/src/main/pages/che-6/setup-openshift/openshift-multi-user.adoc
@@ -22,7 +22,7 @@ The deployment script creates three DeploymentConfigs for Che, PostgreSQL, and K
 
 image::diagrams/ocp_multi_user.png[]
 
-ifeval::["{context}" == "che"]
+ifeval::["{project-context}" == "che"]
 [id="using-minishift-to-deploy-che"]
 == Using Minishift to Deploy Che
 
@@ -39,11 +39,11 @@ endif::[]
 [id="using-openshift-container-platform-to-deploy-che"]
 == Using OpenShift Container Platform to deploy Che
 
-ifeval::["{context}" == "che"]
+ifeval::["{project-context}" == "che"]
 :pwd: pages/che-6/setup-openshift/
 endif::[]
 
-include::using-ocp-to-deploy-{context}.adoc[]
+include::using-ocp-to-deploy-{project-context}.adoc[]
 
 
 [id="using-openshift-dedicated-to-deploy-che"]
@@ -64,7 +64,7 @@ The instructions to deploy Che to OpenShift Online Pro are identical to those fo
 Now that you have a running Che multi-user instance, link:user-management.html[create a user, set up oAuth, and log in].
 
 
-ifeval::["{context}" == "che"]
+ifeval::["{project-context}" == "che"]
 [id="additional-resources"]
 == Additional Resources
 

--- a/src/main/pages/che-6/user-management/user-management.adoc
+++ b/src/main/pages/che-6/user-management/user-management.adoc
@@ -24,7 +24,7 @@ If Che is deployed on OpenShift:
 
 * Go to the OpenShift web console and navigate to the *Keycloak* namespace. 
 
-ifeval::["{context}" == "che"]
+ifeval::["{project-context}" == "che"]
 If Che is running on Docker:
 
 * Go to `$CHE_HOST:5050/auth`.


### PR DESCRIPTION
### What does this PR do?

Fixes a conflict in attribute naming: renames the global context attribute to `project-context`, thus allowing the modular `context` attribute to function normally.