### PR TITLE
Remove TODOs from monitoring docs

### DIFF
--- a/src/main/pages/che-7/administration-guide/assembly_monitoring-che.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_monitoring-che.adoc
@@ -17,8 +17,6 @@ summary:
 
 Che can expose certain data as metrics, that can be processed by Prometheus and Grafana stack. Prometheus is a monitoring system, that maintains the collection of metrics - time series key-value data which can represent consumption of resources like CPU and memory, amount of processed HTTP queries and their execution time, and Che specific resources, such as number of users and workspaces, the start and shutdown of workspaces, information about JsonRPC stack.
 
-TODO: NEED LIST OF METRICS REPPORTED BY CHE
-
 Prometheus is powered with a special query language, that allows manipulating the collected data, and perform various binary, vector and aggregation operations with it, to help create a more refined view on data.
 
 While Prometheus is the central piece, responsible for scraping and storing the metrics, while Grafana offers a front-end "facade" with tools to create a various visual representation in the form of dashboards with various panels and graph types.

--- a/src/main/pages/che-7/administration-guide/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_collecting-che-metrics-with-prometheus.adoc
@@ -15,8 +15,7 @@ counter:: the simplest numerical type of metric whose value can be only increase
 
 gauge:: numerical value that can be increased or decreased. Best suited for representing values of objects.
 
-histogram:: TODO
-
+histogram:: a more complex metric that is suited for performing observations. Metrics are collected and grouped in configurable buckets, which allwos to present the results, for instance, in a form of a heatmap.
 
 == Configuring Prometheus
 


### PR DESCRIPTION
### What does this PR do?
Remove TODOs from monitoring docs (as they were handled in comments to this PR https://github.com/eclipse/che-docs/pull/708)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12543