### PR TITLE
Fix Che 7 index.html redirect

### DIFF
--- a/src/main/pages/che-7/overview/assembly_introduction-to-eclipse-che.adoc
+++ b/src/main/pages/che-7/overview/assembly_introduction-to-eclipse-che.adoc
@@ -3,8 +3,8 @@ title: Introduction to Eclipse Che
 keywords: 
 tags: [Che]
 sidebar: che_7_docs
-permalink: che-7/introduction-to-eclipse-che.html
-redirect_from: che-7/index.html
+permalink: che-7/index.html
+redirect_from: che-7/introduction-to-eclipse-che.html
 folder: che-7/overview
 summary: 
 ---


### PR DESCRIPTION
### What does this PR do?

Fixes the docs factory (https://github.com/ibuziuk/my-che-devfiles/blob/master/che-docs/factory.json) used by che.openhift.io (a Jekyll redirect was causing the doc URL to end up at 0.0.0.0).

### What issues does this PR fix or reference?

#728 