### PR TITLE
More Explicit Instructions on Changing /local/path in Che Single User Mode Instructions

### DIFF
--- a/src/main/pages/che-6/overview/quick-start.adoc
+++ b/src/main/pages/che-6/overview/quick-start.adoc
@@ -37,13 +37,13 @@ $ docker run --rm --net host eclipse/che-ip:nightly
 
 .Procedure
 
-To run Che in single-user mode, enter:
+To run Che in single-user mode, run the command below. Note that `/local/path` in the command below needs to be changed and can be any path on your local machine where you want to store Che data and projects.
 
 ----
 $ docker run -ti -v /var/run/docker.sock:/var/run/docker.sock -v /local/path:/data eclipse/che start
 ----
 
-Note that `/local/path` can be any path on your local machine where you want to store Che data and projects. Once Che has started, it can be accessed at `localhost:8080`.
+Once Che has started, it can be accessed at `localhost:8080`.
 
 .Next steps
 


### PR DESCRIPTION
### What does this PR do?

This pull request rearranges the Che single user mode instructions under quick start to more explicitly call out changing the `/local/path` in the `docker run` command to start up Che:

`docker run -ti -v /var/run/docker.sock:/var/run/docker.sock -v` **/local/path**`:/data eclipse/che start`

### What issues does this PR fix or reference?

No issue created for this. This is an issue I ran into when setting up Che. 