### PR TITLE
Update theia-endpoint-runtime image

### DIFF
--- a/src/main/pages/che-7/end-user-guide/ref_che-theia-plug-in-metadata.adoc
+++ b/src/main/pages/che-7/end-user-guide/ref_che-theia-plug-in-metadata.adoc
@@ -43,7 +43,7 @@ When adding a VS Code extension from the oficial marketplace using its ID, the `
 }
 ----
 <1> VS Code extension ID with a `vscode:extension/` prefix
-<2> Points to the container image, in which the extension should run. The image should be based on `wsskeleton/theia-endpoint-runtime` to be able to host VS Code extensions or Che-Theia plug-ins.
+<2> Points to the container image, in which the extension should run. The image should be based on `eclipse/che-theia-endpoint-runtime` to be able to host VS Code extensions or Che-Theia plug-ins.
 
 
 == che-plugin.yaml


### PR DESCRIPTION
In the doc we were still referring to the old wsskeleton image.

The issue was raised in this issue https://github.com/eclipse/che/issues/14099#issuecomment-517643647