### PR TITLE
Fix formatting of yaml files related to TLS certificates

### DIFF
--- a/src/main/pages/che-7/overview/con_persistent-volume-configuration.adoc
+++ b/src/main/pages/che-7/overview/con_persistent-volume-configuration.adoc
@@ -3,6 +3,6 @@
 
 A Kubernetes persistent volume is attached to the Che workspace to persist its data: source code, application logs, and tools configuration. A Che server can be configured to use different strategies:
 
-* *common*: A Che workspace that is provisioned in the same Kubernetes namespace and shares the same `PesistentVolume`. The data of different workspaces are separated using subpaths. The default strategy is *common*.
+* *common*: A Che workspace that is provisioned in the same Kubernetes namespace and shares the same `PersistentVolume`. The data of different workspaces are separated using subpaths. The default strategy is *common*.
 
 * *unique*: Every Che workspace is attached to a distinct persistent volume. This strategy provides better data isolation but requires more resources.

--- a/src/main/pages/che-7/overview/proc_creating-a-service-account-secret-on-google-cloud-platform.adoc
+++ b/src/main/pages/che-7/overview/proc_creating-a-service-account-secret-on-google-cloud-platform.adoc
@@ -30,5 +30,5 @@ IMPORTANT: Keep the key file safe, and do not share it with anyone because it ca
 . Create a Secret from this file.
 +
 ----
-$ kubectl create secret generic clouddns-dns01-solver-svc-acct --from-file=key.json
+$ kubectl create secret generic clouddns-dns01-solver-svc-acct --from-file=key.json --namespace=cert-manager
 ----

--- a/src/main/pages/che-7/overview/proc_installing-cert-manager-on-kubernetes.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-cert-manager-on-kubernetes.adoc
@@ -30,21 +30,21 @@ $ cat <<EOF | kubectl apply -f -
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer
 metadata:
- name: che-certificate-issuer
+  name: che-certificate-issuer
 spec:
- acme:
- dns01:
- providers:
- - clouddns:
- project: eclipse-che-1
- serviceAccountSecretRef:
- key: key.json
- name: clouddns-dns01-solver-svc-acct
- name: clouddns
- email: joe@example.com
- privateKeySecretRef:
- name: letsencrypt
- server: https://acme-v02.api.letsencrypt.org/directory[_https://acme-v02.api.letsencrypt.org/directory_]
+  acme:
+    dns01:
+      providers:
+      - clouddns:
+          project: eclipse-che-1
+          serviceAccountSecretRef:
+            key: key.json
+            name: clouddns-dns01-solver-svc-acct
+        name: clouddns
+    email: joe@example.com
+    privateKeySecretRef:
+      name: letsencrypt
+    server: https://acme-v02.api.letsencrypt.org/directory
 EOF
 ----
 
@@ -60,16 +60,16 @@ metadata:
 spec:
  secretName: che-tls
  issuerRef:
- name: che-certificate-issuer
- kind: ClusterIssuer
+   name: che-certificate-issuer
+   kind: ClusterIssuer
  dnsNames:
- - '*.gcp.my-ide.cloud'
+   - '*.gcp.my-ide.cloud'
  acme:
- config:
- - dns01:
- provider: clouddns
- domains:
- - '*.gcp.my-ide.cloud'
+   config:
+     - dns01:
+         provider: clouddns
+       domains:
+         - '*.gcp.my-ide.cloud'
 EOF
 ----
 
@@ -137,4 +137,3 @@ Status:
  Type: Ready
  Not After: 2019-10-27T12:56:24Z
 ----
- 


### PR DESCRIPTION
### What does this PR do?
Fix formatting of yaml files related to TLS certificates
Fix namespace for Cloud DNS admin secret (I've checked and namespace is specified for AWS and Azure)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14220

:warning:  This PR is not tested
I tried to test it by myself but did not manage to do it quickly. 
`./run.sh` does not take any local changes. It would be appropriate from che-docs team to update README.md with instruction on how to test changes.
