### PR TITLE
update installing chectl

### DIFF
--- a/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
+++ b/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
@@ -69,19 +69,11 @@ Install the `chectl` command-line tool to be able to manage the Che Server appli
 
 === Installing chectl on Windows
 
-. Navigate to link:https://github.com/che-incubator/chectl/releases[chectl Releases].
-
-. Download the latest archive suitable for the target architecture.
-
-** Windows 64 bits: `chectl-win32-x64.tar.gz`
-
-** Windows 32 bits: `chectl-win32-x86.tar.gz`
-
-. Extract the archive.
-
-. The files are extracted in a directory called `chectl`. Binaries are in the `bin` subdirectory.
-
-. Add the full path of the `chectl\bin` directory to your `PATH` environment variable.
+. Run the following commands in the powershell terminal:
++
+----
+C:\Users> Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://www.eclipse.org/che/chectl/win/'))
+----
 
 === Installing chectl on Linux or MacOS
 

--- a/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
+++ b/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
@@ -75,6 +75,8 @@ Install the `chectl` command-line tool to be able to manage the Che Server appli
 C:\Users> Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://www.eclipse.org/che/chectl/win/'))
 ----
 
+. The chectl binary is installed in C:\ProgramData\chectl.
+
 === Installing chectl on Linux or MacOS
 
 .Prerequisites

--- a/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
+++ b/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
@@ -69,32 +69,34 @@ Install the `chectl` command-line tool to be able to manage the Che Server appli
 
 === Installing chectl on Windows
 
-. Download link:https://github.com/che-incubator/chectl/releases/download/20190314232124/chectl-win.exe[chectl-win.exe].
+. Navigate to link:https://github.com/che-incubator/chectl/releases[chectl Releases].
 
-. Add the folder of the downloaded binary to your `PATH` environment variable.
+. Download the latest archive suitable for the target architecture.
 
-=== Installing chectl on macOS
+** Windows 64 bits: `chectl-win32-x64.tar.gz`
 
-Run the following commands in the terminal:
+** Windows 32 bits: `chectl-win32-x86.tar.gz`
 
+. Extract the archive.
+
+. The files are extracted in a directory called `chectl`. Binaries are in the `bin` subdirectory.
+
+. Add the full path of the `chectl\bin` directory to your `PATH` environment variable.
+
+=== Installing chectl on Linux or MacOS
+
+.Prerequisites
+
+. `/usr/local/bin` in in your `$PATH`
+
+.Procedure 
+
+. Run the following commands in the terminal:
++
 ----
-$ RELEASE="20190314232124/chectl-macos" && \
-URL=https://github.com/che-incubator/chectl/releases/download/${RELEASE} && \
-sudo curl -sSL ${URL} -o /usr/local/bin/chectl && \
-sudo chmod +x /usr/local/bin/chectl 
+# bash <(curl -sL  https://www.eclipse.org/che/chectl/)
 ----
-
-=== Installing chectl on Linux
-
-Run the following commands in the terminal:
-
-----
-$ RELEASE="20190314232124/chectl-linux" && \
-URL=https://github.com/che-incubator/chectl/releases/download/${RELEASE} && \
-sudo curl -sSL ${URL} -o /usr/local/bin/chectl && \
-sudo chmod +x /usr/local/bin/chectl 
-----
-
+. The `chectl` binary is installed in `/usr/local/bin`.
 
 == Deploying Che using chectl
 


### PR DESCRIPTION
fix https://github.com/eclipse/che/issues/14162

Refresh the documentation Installing the chectl management tool to current reality.

Signed-off-by: Fabrice Flore-Thébault <ffloreth@redhat.com>