### PR TITLE
Installing chectl as quickstart chapter

### DIFF
--- a/src/main/_config-war.yml
+++ b/src/main/_config-war.yml
@@ -1,5 +1,6 @@
 asciidoctor:
   attributes:
     imagesdir: /che/docs/images
+    site-baseurl: /che/docs/
 
 baseurl: "/che/docs/"

--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -45,6 +45,7 @@ asciidoctor:
   safe: unsafe
   attributes:
     imagesdir: /images
+    site-baseurl: /
     page-liquid: ''
     source-highlighter: coderay
     coderay-css: style

--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -11,6 +11,9 @@ entries:
   - title: Che quick-starts
     output: web
     folderitems:
+    - title: Installing the chectl management tool
+      url: che-7/installing-the-chectl-management-tool
+      output: web
     - title: Running Che locally
       url: che-7/running-che-locally
       output: web

--- a/src/main/pages/che-7/administration-guide/assembly_customizing-the-devfile-and-plug-in-registries.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_customizing-the-devfile-and-plug-in-registries.adoc
@@ -28,8 +28,8 @@ In this document, the following two ways to customize the default registries tha
 . Building a custom image of the registries
 . Running the default images but modifying them at runtime
 
-* link:{{site.baseurl}}che-7/building-and-running-a-custom-registry-image[Building and running a custom registry image]
-* link:{{site.baseurl}}che-7/including-the-plug-in-binaries-in-the-registry-image[Including the plug-in binaries in the registry image]
-* link:{{site.baseurl}}che-7/editing-a-devfile-and-plug-in-at-runtime[Editing a devfile and plug-in at runtime]
+* link:{site-baseurl}che-7/building-and-running-a-custom-registry-image[Building and running a custom registry image]
+* link:{site-baseurl}che-7/including-the-plug-in-binaries-in-the-registry-image[Including the plug-in binaries in the registry image]
+* link:{site-baseurl}che-7/editing-a-devfile-and-plug-in-at-runtime[Editing a devfile and plug-in at runtime]
 
 :context: {parent-context-of-customizing-the-devfile-and-plug-in-registries}

--- a/src/main/pages/che-7/administration-guide/assembly_modifying-the-registries.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_modifying-the-registries.adoc
@@ -1,3 +1,5 @@
+:page-liquid:
+
 :parent-context-of-modifying-the-registries: {context}
 
 [id='modifying-the-registries']
@@ -9,7 +11,7 @@ This section explains how to modify the existing content of the devfile and plug
 
 .Prerequisites
 
-* The registries are cloned following the link:{{site.baseurl}}che-7/customizing-the-devfile-and-plug-in-registries[Cloning the registries] procedure.
+* The registries are cloned following the link:{site-baseurl}che-7/customizing-the-devfile-and-plug-in-registries[Cloning the registries] procedure.
 
 include::proc_adding-a-new-plug-in.adoc[leveloffset=+1]
 

--- a/src/main/pages/che-7/administration-guide/assembly_retrieving-che-logs.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_retrieving-che-logs.adoc
@@ -17,10 +17,10 @@ summary:
 
 This is a catalog of the location and instructions to retrieve application logs (for administrators and for users).
 
-* link:{{site.baseurl}}che-7/viewing-kubernetes-events[Viewing Kubernetes events]
-* link:{{site.baseurl}}che-7/viewing-che-server-logs[Viewing Che server logs]
-* link:{{site.baseurl}}che-7/viewing-external-service-logs[Viewing external service logs]
-* link:{{site.baseurl}}che-7/viewing-che-workspaces-logs[Viewing Che workspaces logs]
+* link:{site-baseurl}che-7/viewing-kubernetes-events[Viewing Kubernetes events]
+* link:{site-baseurl}che-7/viewing-che-server-logs[Viewing Che server logs]
+* link:{site-baseurl}che-7/viewing-external-service-logs[Viewing external service logs]
+* link:{site-baseurl}che-7/viewing-che-workspaces-logs[Viewing Che workspaces logs]
 
 // TODO: include::proc_viewing-che-operator-logs.adoc[leveloffset=+1]
 

--- a/src/main/pages/che-7/administration-guide/assembly_viewing-keycloak-logs.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_viewing-keycloak-logs.adoc
@@ -1,3 +1,5 @@
+:page-liquid:
+
 :parent-context-of-viewing-keycloak-logs: {context}
 
 [id='viewing-keycloak-logs']

--- a/src/main/pages/che-7/administration-guide/proc_adding-a-new-devfile.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_adding-a-new-devfile.adoc
@@ -1,3 +1,5 @@
+:page-liquid:
+
 [id="adding-a-new-devfile_{context}"]
 = Adding a new devfile
 
@@ -30,7 +32,7 @@ $ tree ./che-devfile-registry/devfiles
  └── meta.yaml
 ----
 
-. Add valid content in the `devfile.yaml` file. For a detailed description of the devfile format, see the link:{{site.baseurl}}che-7/making-a-workspace-portable-using-a-devfile[Making a workspace portable using a Devfile] section.
+. Add valid content in the `devfile.yaml` file. For a detailed description of the devfile format, see the link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile[Making a workspace portable using a Devfile] section.
 
 . Ensure that the `meta.yaml` file conforms to the following structure:
 +

--- a/src/main/pages/che-7/administration-guide/proc_viewing-keycloak-server-logs.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_viewing-keycloak-server-logs.adoc
@@ -1,3 +1,5 @@
+:page-liquid:
+
 [id="viewing-keycloak-server-logs_{context}"]
 = Viewing the Keycloak server logs
 
@@ -21,4 +23,4 @@ image::logs/viewing-keycloak-server-logs.png[]
 
 .Additional resources
 
-* Some diagnostics and error messages related to the Keycloak IDE Server can be found in the active Che deployment log. For details to access the active Che deployments logs, see the link:{{site.baseurl}}che-7/viewing-che-server-logs[Viewing the Che server logs] section.
+* Some diagnostics and error messages related to the Keycloak IDE Server can be found in the active Che deployment log. For details to access the active Che deployments logs, see the link:{site-baseurl}che-7/viewing-che-server-logs[Viewing the Che server logs] section.

--- a/src/main/pages/che-7/administration-guide/proc_viewing-postgresql-server-logs.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_viewing-postgresql-server-logs.adoc
@@ -1,3 +1,5 @@
+:page-liquid:
+
 [id="viewing-postgresql-server-logs_{context}"]
 = Viewing the PostgreSQL server logs
 
@@ -20,4 +22,4 @@ image::logs/viewing-postgresql-server-logs.png[]
 
 .Additional resources
 
-* Some diagnostics or error messages related to the PostgreSQL server can be found in the active Che deployment log. For details to access the active Che deployments logs, see the link:{{site.baseurl}}che-7/viewing-che-server-logs[Viewing the Che server logs] section.
+* Some diagnostics or error messages related to the PostgreSQL server can be found in the active Che deployment log. For details to access the active Che deployments logs, see the link:{site-baseurl}che-7/viewing-che-server-logs[Viewing the Che server logs] section.

--- a/src/main/pages/che-7/contributor-guide/proc_adding-support-for-a-new-debugger.adoc
+++ b/src/main/pages/che-7/contributor-guide/proc_adding-support-for-a-new-debugger.adoc
@@ -37,4 +37,4 @@ $ npm install -g yo @theia/generator-plugin
 * link:https://microsoft.github.io/debug-adapter-protocol/[Debug Adapter Protocol]
 * link:https://code.visualstudio.com/api/extension-guides/debugger-extension[VS Code debugger extension documentation]
 * link:https://microsoft.github.io/debug-adapter-protocol/implementors/adapters/[Implementations Debug Adapters]
-* link:{{site.baseurl}}che-7/publishing-che-theia-plug-ins/#adding-a-che-theia-plug-in-to-the-che-plug-in-registry_publishing-che-theia-plug-ins[Adding a Che-Theia plug-in to the Che plug-in registry]
+* link:{site-baseurl}che-7/publishing-che-theia-plug-ins/#adding-a-che-theia-plug-in-to-the-che-plug-in-registry_publishing-che-theia-plug-ins[Adding a Che-Theia plug-in to the Che plug-in registry]

--- a/src/main/pages/che-7/end-user-guide/assembly_customizing-developer-environments.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_customizing-developer-environments.adoc
@@ -40,9 +40,9 @@ Extending Eclipse Che can be done entirely using Eclipse Che. Since version 7, E
 // * Delete the section title and bullets if the assembly has no prerequisites.
 
 
-* link:{{site.baseurl}}che-7/what-is-a-che-theia-plug-in[What is a Che-Theia plug-in]
-* link:{{site.baseurl}}che-7/using-alternative-ides-in-che[Using alternative IDEs in Che]
-* link:{{site.baseurl}}che-7/using-a-visual-studio-code-extension-in-che[Using a Visual Studio Code extension in Che]
+* link:{site-baseurl}che-7/what-is-a-che-theia-plug-in[What is a Che-Theia plug-in]
+* link:{site-baseurl}che-7/using-alternative-ides-in-che[Using alternative IDEs in Che]
+* link:{site-baseurl}che-7/using-a-visual-studio-code-extension-in-che[Using a Visual Studio Code extension in Che]
 
 
 // == Related information

--- a/src/main/pages/che-7/end-user-guide/con_workspaces-overview.adoc
+++ b/src/main/pages/che-7/end-user-guide/con_workspaces-overview.adoc
@@ -8,6 +8,8 @@ folder: che-7/end-user-guide
 summary:
 ---
 
+:page-liquid:
+
 [id="workspaces-overview"]
 = Workspaces overview
 
@@ -55,16 +57,16 @@ Eclipse Che workspaces are managed by Kubernetes pods. Everything running in a C
 
 // TODO: Diagram
 
-* link:{{site.baseurl}}che-7/configuring-a-workspace-using-a-devfile[Configuring a workspace using a devfile]
-* link:{{site.baseurl}}che-7/making-a-workspace-portable-using-a-devfile[Making a workspace portable using a devfile]
-* link:{{site.baseurl}}che-7/converting-a-che-6-workspace-to-a-che-7-devfile[Converting a Che 6 Workspace to a Che 7 devfile]
-* link:{{site.baseurl}}che-7/creating-and-configuring-a-new-che-7-workspace[Creating and configuring a new Che 7 workspace]
-// * link:{{site.baseurl}}che-7/using-and-customizing-a-workspace-template-stack[Using and customizing a workspace template - stack]
-// * link:{{site.baseurl}}che-7/exporting-a-workspace-with-a-che-factory[Exporting a workspace with a Che factory]
-// * link:{{site.baseurl}}che-7/sharing-access-to-a-che-workspace[Sharing access to a Che workspace]
-* link:{{site.baseurl}}che-7/importing-a-kubernetes-application-into-a-che-workspace[Importing a Kubernetes application into a Che workspace]
-* link:{{site.baseurl}}che-7/remotely-accessing-che-workspaces[Remotely accessing workspaces]
-* link:{{site.baseurl}}che-7/creating-a-workspace-from-code-sample[Creating a workspace from code sample]
-* link:{{site.baseurl}}che-7/creating-a-workspace-by-importing-source-code-of-a-project[Creating a workspace by importing source code of a project]
-// * link:{{site.baseurl}}che-7/configuring-vcs-credentials-for-workspaces[Configuring VCS credentials for workspaces]
-// * link:{{site.baseurl}}che-7/use-an-alternative-che-workspace-editor[Using an alternative Che workspace editor]
+* link:{site-baseurl}che-7/configuring-a-workspace-using-a-devfile[Configuring a workspace using a devfile]
+* link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile[Making a workspace portable using a devfile]
+* link:{site-baseurl}che-7/converting-a-che-6-workspace-to-a-che-7-devfile[Converting a Che 6 Workspace to a Che 7 devfile]
+* link:{site-baseurl}che-7/creating-and-configuring-a-new-che-7-workspace[Creating and configuring a new Che 7 workspace]
+// * link:{site-baseurl}che-7/using-and-customizing-a-workspace-template-stack[Using and customizing a workspace template - stack]
+// * link:{site-baseurl}che-7/exporting-a-workspace-with-a-che-factory[Exporting a workspace with a Che factory]
+// * link:{site-baseurl}che-7/sharing-access-to-a-che-workspace[Sharing access to a Che workspace]
+* link:{site-baseurl}che-7/importing-a-kubernetes-application-into-a-che-workspace[Importing a Kubernetes application into a Che workspace]
+* link:{site-baseurl}che-7/remotely-accessing-che-workspaces[Remotely accessing workspaces]
+* link:{site-baseurl}che-7/creating-a-workspace-from-code-sample[Creating a workspace from code sample]
+* link:{site-baseurl}che-7/creating-a-workspace-by-importing-source-code-of-a-project[Creating a workspace by importing source code of a project]
+// * link:{site-baseurl}che-7/configuring-vcs-credentials-for-workspaces[Configuring VCS credentials for workspaces]
+// * link:{site-baseurl}che-7/use-an-alternative-che-workspace-editor[Using an alternative Che workspace editor]

--- a/src/main/pages/che-7/end-user-guide/proc_configuring-a-workspace-using-a-devfile.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_configuring-a-workspace-using-a-devfile.adoc
@@ -8,6 +8,8 @@ folder: che-7/end-user-guide
 summary:
 ---
 
+:page-liquid:
+
 [id="configuring-a-workspace-using-a-devfile"]
 = Configuring a workspace using a devfile
 
@@ -21,15 +23,15 @@ See the link:https://redhat-developer.github.io/devfile/devfile[Devfile specific
 
 * Or, you can use a Kubernetes cluster such as link:https://github.com/kubernetes/minikube#installation[Minikube].
 
-* To install on Minishift or Minikube, see link:{{site.baseurl}}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl].
+* To install on Minishift or Minikube, see link:{site-baseurl}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl].
 
-* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool]
+* `chectl` management tool is installed. See link:{site-baseurl}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool]
 
 .Procedure
 
 == Importing a project using a devfile
 
-Stacks are defined as link:{{site.baseurl}}che-7/making-a-workspace-portable-using-a-devfile/[devfiles]. This gives the user more flexibility when defining the project(s), IDE, commands, tools, and application runtimes needed in their workspace.
+Stacks are defined as link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile/[devfiles]. This gives the user more flexibility when defining the project(s), IDE, commands, tools, and application runtimes needed in their workspace.
 
 NOTE: In Che 6, a stack is defined with a Dockerfile. In Che 7, `devfile.yaml` is used instead.
 
@@ -64,7 +66,7 @@ To create a workspace from a devfile:
 
 . When the repository contains a `devfile.yaml` file, point a running Che 7 instance at that link:https://github.com/eclipse/che[project], and it will use the discovered link:https://github.com/eclipse/che/blob/master/devfile.yaml[devfile.yaml] file to build a workspace using the `/f?url=` API.
 
-* For example, when using link:{{site.baseurl}}che-7/running-che-locally/#deploying-che-using-chectl[Che inside Minishift]: `++http://che-che.<IP-address>.nip.io/f?url=https://github.com/eclipse/che++`.
+* For example, when using link:{site-baseurl}che-7/running-che-locally/#deploying-che-using-chectl[Che inside Minishift]: `++http://che-che.<IP-address>.nip.io/f?url=https://github.com/eclipse/che++`.
 
 image::workspaces/che-in-che-devfile.png[Che in Che]
 
@@ -72,7 +74,7 @@ image::workspaces/che-in-che-devfile.png[Che in Che]
 
 . If you are familiar with link:https://github.com/che-incubator/chectl/[chectl], you can also reference a local devfile. For example, to create a workspace in which to build the Che project:
 +
-* First link:{{site.baseurl}}che-7/running-che-locally/#deploying-che-using-chectl[deploy Che onto Minishift] (or another cluster).
+* First link:{site-baseurl}che-7/running-che-locally/#deploying-che-using-chectl[deploy Che onto Minishift] (or another cluster).
 +
 * Next, fetch the devfile and run the `chectl` command to start a workspace called *che-in-che* from the devfile in the Minishift `che-che` instance.
 +
@@ -90,7 +92,7 @@ http://che-che.`your.IP.address.here`.nip.io/dashboard/#/ide/che/che-in-che
 
 .Additional resources
 
-* link:{{site.baseurl}}che-7/making-a-workspace-portable-using-a-devfile[Making a workspace portable using a Devfile]
+* link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile[Making a workspace portable using a Devfile]
 * link:https://redhat-developer.github.io/devfile/devfile[Devfile specifications]
 * link:https://docs.okd.io/latest/minishift/getting-started/preparing-to-install.html[Minishift installation]
 * link:https://github.com/kubernetes/minikube#installation[Minikube installation]

--- a/src/main/pages/che-7/end-user-guide/proc_configuring-a-workspace-using-a-devfile.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_configuring-a-workspace-using-a-devfile.adoc
@@ -23,6 +23,8 @@ See the link:https://redhat-developer.github.io/devfile/devfile[Devfile specific
 
 * To install on Minishift or Minikube, see link:{{site.baseurl}}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl].
 
+* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool]
+
 .Procedure
 
 == Importing a project using a devfile

--- a/src/main/pages/che-7/end-user-guide/proc_configuring-a-workspace-using-a-devfile.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_configuring-a-workspace-using-a-devfile.adoc
@@ -23,7 +23,7 @@ See the link:https://redhat-developer.github.io/devfile/devfile[Devfile specific
 
 * To install on Minishift or Minikube, see link:{{site.baseurl}}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl].
 
-* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool]
+* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool]
 
 .Procedure
 

--- a/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-by-importing-source-code-of-a-project.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-by-importing-source-code-of-a-project.adoc
@@ -8,6 +8,8 @@ folder: che-7/end-user-guide
 summary:
 ---
 
+:page-liquid:
+
 [id="creating-a-workspace-by-importing-source-code-of-a-project"]
 = Creating a workspace by importing the source code of a project
 
@@ -16,7 +18,7 @@ This section is about how to create a new workspace to edit an existing codebase
 There are two ways to do that *before* starting a workspace:
 
 * xref:#configure-devfile[Select a stack from the *Dashboard*, then change the devfile to include your project]
-* link:{{site.baseurl}}che-7/configuring-a-workspace-using-a-devfile[Add a devfile to a git repository and start the workspace using chectl or a factory]
+* link:{site-baseurl}che-7/configuring-a-workspace-using-a-devfile[Add a devfile to a git repository and start the workspace using chectl or a factory]
 
 
 To create a new workspace to edit an existing codebase, use one of the following three methods *after* you have started the workspace:
@@ -31,7 +33,7 @@ To create a new workspace to edit an existing codebase, use one of the following
 
 * Or, you can use a Kubernetes cluster such as link:https://github.com/kubernetes/minikube#installation[Minikube].
 
-* To install on Minishift or Minikube, see link:{{site.baseurl}}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl].
+* To install on Minishift or Minikube, see link:{site-baseurl}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl].
 
 * You need to have created a workspace with plugins related to your development environment.
 

--- a/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-from-code-sample.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-from-code-sample.adoc
@@ -8,6 +8,8 @@ folder: che-7/end-user-guide
 summary:
 ---
 
+:page-liquid:
+
 [id="creating-a-workspace-from-code-sample"]
 = Creating a workspace from code sample
 
@@ -17,7 +19,7 @@ It will also explain how to customize a workspace using the *Dashboard*.
 
 [NOTE]
 ====
-Every stack includes a sample codebase, which is defined by the stack's devfile. For more information on devfiles, see link:{{site.baseurl}}che-7/configuring-a-workspace-using-a-devfile[Configuring a Che workspace using a devfile].
+Every stack includes a sample codebase, which is defined by the stack's devfile. For more information on devfiles, see link:{site-baseurl}che-7/configuring-a-workspace-using-a-devfile[Configuring a Che workspace using a devfile].
 ====
 
 .Prerequisites
@@ -26,7 +28,7 @@ Every stack includes a sample codebase, which is defined by the stack's devfile.
 
 * Or, you need a Kubernetes cluster such as link:https://github.com/kubernetes/minikube#installation[Minikube] to use Che on Kubernetes.
 
-* To install on Minishift or Minikube, see link:{{site.baseurl}}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl].
+* To install on Minishift or Minikube, see link:{site-baseurl}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl].
 
 .Procedure
 
@@ -36,7 +38,7 @@ The *Dashboard* is accessible on the cluster from a URL like `++http:/<che-insta
 
 === Minishift
 
-See link:{{site.baseurl}}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl].
+See link:{site-baseurl}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl].
 
 [NOTE]
 ====
@@ -135,6 +137,6 @@ image::workspaces/run-from-recent-workspaces.png[Run from Recent Workspaces]
 
 .Additional resources
 
-* link:{{site.baseurl}}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl]
+* link:{site-baseurl}che-7/running-che-locally/#deploying-che-using-chectl[Deploying Che using chectl]
 * link:https://docs.okd.io/latest/minishift/getting-started/preparing-to-install.html[Minishift installation]
 * link:https://github.com/kubernetes/minikube#installation[Minikube installation]

--- a/src/main/pages/che-7/end-user-guide/proc_generating-a-devfile-from-an-existing-kubernetes-application.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_generating-a-devfile-from-an-existing-kubernetes-application.adoc
@@ -7,7 +7,7 @@ This procedure demonstrates how to generate a devfile from an existing Kubernete
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool]
+* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool]
 
 .Procedure
 

--- a/src/main/pages/che-7/end-user-guide/proc_generating-a-devfile-from-an-existing-kubernetes-application.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_generating-a-devfile-from-an-existing-kubernetes-application.adoc
@@ -1,3 +1,5 @@
+:page-liquid:
+
 // importing-a-kubernetes-application-into-a-che-workspace
 
 [id="generating-a-devfile-from-an-existing-kubernetes-application_{context}"]
@@ -7,7 +9,7 @@ This procedure demonstrates how to generate a devfile from an existing Kubernete
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool]
+* `chectl` management tool is installed. See link:{site-baseurl}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool]
 
 .Procedure
 

--- a/src/main/pages/che-7/end-user-guide/proc_generating-a-devfile-from-an-existing-kubernetes-application.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_generating-a-devfile-from-an-existing-kubernetes-application.adoc
@@ -7,7 +7,7 @@ This procedure demonstrates how to generate a devfile from an existing Kubernete
 
 .Prerequisites
 
-* `chectl` is installed and running
+* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool]
 
 .Procedure
 

--- a/src/main/pages/che-7/overview/assembly_che-quick-starts.adoc
+++ b/src/main/pages/che-7/overview/assembly_che-quick-starts.adoc
@@ -18,7 +18,7 @@ summary:
 
 This section contains instructions for getting quickly started with Eclipse Che. You will learn how to:
 
-* link:{{site.baseurl}}che-7/running-che-locally[Start Che on your local workstation] using Minikube, Minishift, or Docker Desktop
+* link:{site-baseurl}che-7/running-che-locally[Start Che on your local workstation] using Minikube, Minishift, or Docker Desktop
 
 //include::proc_navigating-che-using-the-dashboard.adoc[leveloffset=+1]
 

--- a/src/main/pages/che-7/overview/assembly_hosted-che.adoc
+++ b/src/main/pages/che-7/overview/assembly_hosted-che.adoc
@@ -15,7 +15,7 @@ summary:
 
 :context: hosted-che
 
-This guide describes some procedures to get started with Hosted{nbsp}Che that are not covered by link:{{site.baseurl}}che-7/workspaces-overview[Using developer environments - workspaces].
+This guide describes some procedures to get started with Hosted{nbsp}Che that are not covered by link:{site-baseurl}che-7/workspaces-overview[Using developer environments - workspaces].
 
 It starts with a general overview of Eclipse{nbsp}Che terms of service.
 
@@ -45,6 +45,6 @@ include::proc_finding-the-cluster-where-the-hosted-che-workspace-is-running.adoc
 
 * Frequently Asked Questions (FAQs) and Troubleshooting can be found on the following link:https://github.com/redhat-developer/rh-che/blob/master/FAQ.adoc[link].
 
-* For general end-user guidance see link:{{site.baseurl}}che-7/workspaces-overview[Using developer environments - workspaces].
+* For general end-user guidance see link:{site-baseurl}che-7/workspaces-overview[Using developer environments - workspaces].
 
 :context: {parent-context-of-hosted-che}

--- a/src/main/pages/che-7/overview/assembly_installing-the-chectl-management-tool.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-the-chectl-management-tool.adoc
@@ -1,0 +1,38 @@
+---
+title: Installing the chectl management tool
+keywords:
+tags: []
+sidebar: che_7_docs
+permalink: che-7/installing-the-chectl-management-tool/
+folder: che-7/overview
+summary:
+---
+
+
+:parent-context-of-installing-the-chectl-management-tool: {context}
+
+[id='installing-the-chectl-management-tool_{context}']
+= Installing the chectl management tool
+
+:context: installing-the-chectl-management-tool
+
+Eclipse Che command-line management tool is called `chectl`. It is used for operations on the Che server (start, stop, update, delete) and on workspaces (list, start, stop, inject) and to generate devfiles. Following topics are described:
+
+* link:#installing-the-chectl-management-tool-on-windows_{context}[Installing the chectl management tool on Windows]
+
+* link:#installing-the-chectl-management-tool-on-linux-or-macos_{context}[Installing the chectl management tool on Linux or MacOS]
+
+* link:#upgrading-the-chectl-management-tool_{context}[Upgrading the chectl management tool]
+
+include::proc_installing-the-chectl-management-tool-on-windows.adoc[leveloffset=+1]
+
+include::proc_installing-the-chectl-management-tool-on-linux-or-macos.adoc[leveloffset=+1]
+
+include::proc_upgrading-the-chectl-management-tool.adoc[leveloffset=+1]
+
+[id='related-information-{context}']
+== Related information
+
+* link:https://github.com/che-incubator/chectl/blob/master/README.md[`chectl` README]
+
+:context: {parent-context-of-installing-the-chectl-management-tool}

--- a/src/main/pages/che-7/overview/assembly_introduction-to-eclipse-che.adoc
+++ b/src/main/pages/che-7/overview/assembly_introduction-to-eclipse-che.adoc
@@ -33,8 +33,8 @@ factories.
 
 Get started with Eclipse Che by:
 
-* Following the link:{{site.baseurl}}che-7/running-che-locally[quick-start guide] to get Eclipse Che installed locally on your computer.
-* Learning more about Eclipse Che: link:{{site.baseurl}}che-7/what-is-eclipse-che[What is Eclipse Che] and link:{{site.baseurl}}che-7/high-level-che-architecture[Architecture overview]
+* Following the link:{site-baseurl}che-7/running-che-locally[quick-start guide] to get Eclipse Che installed locally on your computer.
+* Learning more about Eclipse Che: link:{site-baseurl}che-7/what-is-eclipse-che[What is Eclipse Che] and link:{site-baseurl}che-7/high-level-che-architecture[Architecture overview]
 // TODO: link:che-features-and-benefits.html[Features and benefits of Eclipse Che].
 * Discovering Eclipse Che capabilities.
 

--- a/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
+++ b/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
@@ -69,19 +69,11 @@ Install the `chectl` command-line tool to be able to manage the Che Server appli
 
 === Installing chectl on Windows
 
-. Navigate to link:https://github.com/che-incubator/chectl/releases[chectl Releases].
-
-. Download the latest archive suitable for the target architecture.
-
-** Windows 64 bits: `chectl-win32-x64.tar.gz`
-
-** Windows 32 bits: `chectl-win32-x86.tar.gz`
-
-. Extract the archive.
-
-. The files are extracted in a directory called `chectl`. Binaries are in the `bin` subdirectory.
-
-. Add the full path of the `chectl\bin` directory to your `PATH` environment variable.
+. Run the following commands in the powershell terminal:
++
+----
+C:\Users> Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://www.eclipse.org/che/chectl/win/'))
+----
 
 === Installing chectl on Linux or MacOS
 

--- a/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
+++ b/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
@@ -75,6 +75,8 @@ Install the `chectl` command-line tool to be able to manage the Che Server appli
 C:\Users> Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://www.eclipse.org/che/chectl/win/'))
 ----
 
+. The chectl binary is installed in C:\ProgramData\chectl.
+
 === Installing chectl on Linux or MacOS
 
 .Prerequisites

--- a/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
+++ b/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
@@ -18,7 +18,7 @@ This article offers instructions for deploying and running Eclipse Che locally, 
 To run and manage Che you need:
 
 * A Kubernetes or OpenShift cluster to deploy Che on
-* The link:https://github.com/che-incubator/chectl[`chectl`] command-line tool for managing a Che server and its development workspaces. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* The link:https://github.com/che-incubator/chectl[`chectl`] command-line tool for managing a Che server and its development workspaces. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 Eclipse Che is available in two modes:
 
@@ -69,7 +69,7 @@ Start Che Server using the `chectl` tool.
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 === Deploying single-user Che on Minikube
 

--- a/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
+++ b/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
@@ -18,7 +18,7 @@ This article offers instructions for deploying and running Eclipse Che locally, 
 To run and manage Che you need:
 
 * A Kubernetes or OpenShift cluster to deploy Che on
-* The link:https://github.com/che-incubator/chectl[`chectl`] command-line tool for managing a Che server and its development workspaces.
+* The link:https://github.com/che-incubator/chectl[`chectl`] command-line tool for managing a Che server and its development workspaces. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 Eclipse Che is available in two modes:
 
@@ -63,38 +63,13 @@ $ minishift start --memory=4096
 See link:https://che.eclipse.org/running-eclipse-che-on-kubernetes-using-docker-desktop-for-mac-5d972ed511e1[Running Eclipse Che on Kubernetes using Docker Desktop on macOS or Windows].
 
 
-== Installing the chectl management tool
-
-Install the `chectl` command-line tool to be able to manage the Che Server application and development workspaces.
-
-=== Installing chectl on Windows
-
-. Run the following commands in the powershell terminal:
-+
-----
-C:\Users> Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://www.eclipse.org/che/chectl/win/'))
-----
-
-. The chectl binary is installed in C:\ProgramData\chectl.
-
-=== Installing chectl on Linux or MacOS
-
-.Prerequisites
-
-. `/usr/local/bin` in in your `$PATH`
-
-.Procedure 
-
-. Run the following commands in the terminal:
-+
-----
-# bash <(curl -sL  https://www.eclipse.org/che/chectl/)
-----
-. The `chectl` binary is installed in `/usr/local/bin`.
-
 == Deploying Che using chectl
 
 Start Che Server using the `chectl` tool.
+
+.Prerequisites
+
+* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 === Deploying single-user Che on Minikube
 

--- a/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
+++ b/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
@@ -69,32 +69,34 @@ Install the `chectl` command-line tool to be able to manage the Che Server appli
 
 === Installing chectl on Windows
 
-. Download link:https://github.com/che-incubator/chectl/releases/download/20190314232124/chectl-win.exe[chectl-win.exe].
+. Navigate to link:https://github.com/che-incubator/chectl/releases[chectl Releases].
 
-. Add the folder of the downloaded binary to your `PATH` environment variable.
+. Download the latest archive suitable for the target architecture.
 
-=== Installing chectl on macOS
+** Windows 64 bits: `chectl-win32-x64.tar.gz`
 
-Run the following commands in the terminal:
+** Windows 32 bits: `chectl-win32-x86.tar.gz`
 
+. Extract the archive.
+
+. The files are extracted in a directory called `chectl`. Binaries are in the `bin` subdirectory.
+
+. Add the full path of the `chectl\bin` directory to your `PATH` environment variable.
+
+=== Installing chectl on Linux or MacOS
+
+.Prerequisites
+
+. `/usr/local/bin` in in your `$PATH`
+
+.Procedure 
+
+. Run the following commands in the terminal:
++
 ----
-$ RELEASE="20190314232124/chectl-macos" && \
-URL=https://github.com/che-incubator/chectl/releases/download/${RELEASE} && \
-sudo curl -sSL ${URL} -o /usr/local/bin/chectl && \
-sudo chmod +x /usr/local/bin/chectl 
+# bash <(curl -sL  https://www.eclipse.org/che/chectl/)
 ----
-
-=== Installing chectl on Linux
-
-Run the following commands in the terminal:
-
-----
-$ RELEASE="20190314232124/chectl-linux" && \
-URL=https://github.com/che-incubator/chectl/releases/download/${RELEASE} && \
-sudo curl -sSL ${URL} -o /usr/local/bin/chectl && \
-sudo chmod +x /usr/local/bin/chectl 
-----
-
+. The `chectl` binary is installed in `/usr/local/bin`.
 
 == Deploying Che using chectl
 

--- a/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
+++ b/src/main/pages/che-7/overview/assembly_running-che-locally.adoc
@@ -18,7 +18,7 @@ This article offers instructions for deploying and running Eclipse Che locally, 
 To run and manage Che you need:
 
 * A Kubernetes or OpenShift cluster to deploy Che on
-* The link:https://github.com/che-incubator/chectl[`chectl`] command-line tool for managing a Che server and its development workspaces. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* The link:https://github.com/che-incubator/chectl[`chectl`] command-line tool for managing a Che server and its development workspaces. See link:{site-baseurl}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 Eclipse Che is available in two modes:
 
@@ -69,7 +69,7 @@ Start Che Server using the `chectl` tool.
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* `chectl` management tool is installed. See link:{site-baseurl}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 === Deploying single-user Che on Minikube
 
@@ -116,6 +116,6 @@ OPTIONS
 
 == Next steps after deploying and starting Che
 
-* link:{{site.baseurl}}che-7/creating-a-workspace-from-code-sample[Creating a workspace from code sample]
-* link:{{site.baseurl}}che-7/creating-a-workspace-by-importing-source-code-of-a-project[Creating a workspace by importing the source code of a project]
+* link:{site-baseurl}che-7/creating-a-workspace-from-code-sample[Creating a workspace from code sample]
+* link:{site-baseurl}che-7/creating-a-workspace-by-importing-source-code-of-a-project[Creating a workspace by importing the source code of a project]
 // TODO: * link:editing-commands-after-importing-a-project.html[Editing workspace commands] to build and run your project

--- a/src/main/pages/che-7/overview/con_high-level-che-architecture.adoc
+++ b/src/main/pages/che-7/overview/con_high-level-che-architecture.adoc
@@ -8,6 +8,8 @@ folder: che-7/overview
 summary:
 ---
 
+:page-liquid:
+
 [id="high-level-che-architecture_{context}"]
 = High-level Che architecture
 
@@ -20,5 +22,5 @@ When Che is installed on a Kubernetes cluster, the workspace controller is the o
 
 This section describes the different services that create the workspaces controller and the Che workspaces.
 
-* link:{{site.baseurl}}che-7/che-workspace-controller[Che workspace controller]
-* link:{{site.baseurl}}che-7/che-workspaces-architecture[Che workspaces architecture]
+* link:{site-baseurl}che-7/che-workspace-controller[Che workspace controller]
+* link:{site-baseurl}che-7/che-workspaces-architecture[Che workspaces architecture]

--- a/src/main/pages/che-7/overview/proc_creating-a-worskpace-from-the-user-dashboard.adoc
+++ b/src/main/pages/che-7/overview/proc_creating-a-worskpace-from-the-user-dashboard.adoc
@@ -1,3 +1,5 @@
+:page-liquid:
+
 // Module included in the following assemblies:
 //
 // assembly_hosted-che.adoc
@@ -32,4 +34,4 @@ This section describes how to create a workspace from the user dashboard in Host
 
 .Additional resources
 
-* For more details, see link:{{site.baseurl}}che-7/workspaces-overview[Using developer environments - workspaces].
+* For more details, see link:{site-baseurl}che-7/workspaces-overview[Using developer environments - workspaces].

--- a/src/main/pages/che-7/overview/proc_installing-che-on-azure-using-the-chectl-command.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-azure-using-the-chectl-command.adoc
@@ -3,7 +3,7 @@
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 
 .Procedure

--- a/src/main/pages/che-7/overview/proc_installing-che-on-azure-using-the-chectl-command.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-azure-using-the-chectl-command.adoc
@@ -1,9 +1,11 @@
+:page-liquid:
+
 [id='installing-che-on-azure-using-the-chectl-command_{context}']
 = Installing Che on Azure using the chectl command
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* `chectl` management tool is installed. See link:{site-baseurl}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 
 .Procedure

--- a/src/main/pages/che-7/overview/proc_installing-che-on-azure-using-the-chectl-command.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-azure-using-the-chectl-command.adoc
@@ -1,6 +1,10 @@
 [id='installing-che-on-azure-using-the-chectl-command_{context}']
 = Installing Che on Azure using the chectl command
 
+.Prerequisites
+
+* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+
 
 .Procedure
 

--- a/src/main/pages/che-7/overview/proc_installing-che-on-google-cloud-platform-using-chectl.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-google-cloud-platform-using-chectl.adoc
@@ -3,7 +3,7 @@
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 .Procedure
 

--- a/src/main/pages/che-7/overview/proc_installing-che-on-google-cloud-platform-using-chectl.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-google-cloud-platform-using-chectl.adoc
@@ -1,6 +1,9 @@
 [id="installing-che-on-google-cloud-platform-using-chectl_{context}"]
 = Installing Che on Google Cloud Platform using chectl
 
+.Prerequisites
+
+* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 .Procedure
 

--- a/src/main/pages/che-7/overview/proc_installing-che-on-google-cloud-platform-using-chectl.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-google-cloud-platform-using-chectl.adoc
@@ -1,9 +1,11 @@
+:page-liquid:
+
 [id="installing-che-on-google-cloud-platform-using-chectl_{context}"]
 = Installing Che on Google Cloud Platform using chectl
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* `chectl` management tool is installed. See link:{site-baseurl}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 .Procedure
 

--- a/src/main/pages/che-7/overview/proc_installing-che-on-kubernetes-using-the-chectl-command.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-kubernetes-using-the-chectl-command.adoc
@@ -3,6 +3,10 @@
 [id="installing-che-on-kubernetes-using-the-chectl-command_{context}"]
 = Installing Che on Kubernetes using the chectl command
 
+.Prerequisites
+
+* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+
 .Procedure
 
 To install Che:

--- a/src/main/pages/che-7/overview/proc_installing-che-on-kubernetes-using-the-chectl-command.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-kubernetes-using-the-chectl-command.adoc
@@ -1,3 +1,5 @@
+:page-liquid:
+
 // deploying-che-on-kubernetes-on-aws
 
 [id="installing-che-on-kubernetes-using-the-chectl-command_{context}"]
@@ -5,7 +7,7 @@
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* `chectl` management tool is installed. See link:{site-baseurl}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 .Procedure
 

--- a/src/main/pages/che-7/overview/proc_installing-che-on-kubernetes-using-the-chectl-command.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-kubernetes-using-the-chectl-command.adoc
@@ -5,7 +5,7 @@
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 .Procedure
 

--- a/src/main/pages/che-7/overview/proc_installing-che-on-openshift-using-the-operator.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-openshift-using-the-operator.adoc
@@ -1,3 +1,5 @@
+:page-liquid:
+
 // installing-che-on-openshift-3-using-the-operator
 
 [id="installing-che-on-openshift-using-the-operator_{context}"]
@@ -5,7 +7,7 @@
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* `chectl` management tool is installed. See link:{site-baseurl}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 .Procedure
 

--- a/src/main/pages/che-7/overview/proc_installing-che-on-openshift-using-the-operator.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-openshift-using-the-operator.adoc
@@ -5,7 +5,7 @@
 
 .Prerequisites
 
-* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
+* `chectl` management tool is installed. See link:{{site.baseurl}}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 .Procedure
 

--- a/src/main/pages/che-7/overview/proc_installing-che-on-openshift-using-the-operator.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-openshift-using-the-operator.adoc
@@ -3,6 +3,9 @@
 [id="installing-che-on-openshift-using-the-operator_{context}"]
 = Installing Che on OpenShift using the Operator
 
+.Prerequisites
+
+* `chectl` management tool is installed. See link:../installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 
 .Procedure
 

--- a/src/main/pages/che-7/overview/proc_installing-the-chectl-management-tool-on-linux-or-macos.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-the-chectl-management-tool-on-linux-or-macos.adoc
@@ -1,0 +1,26 @@
+[id="installing-the-chectl-management-tool-on-linux-or-macos_{context}"]
+= Installing the chectl management tool on Linux or MacOS
+
+This section describes how to install the chectl management tool on Linux or MacOS.
+
+[discrete]
+== Prerequisites
+
+* `/usr/local/bin` in in your `$PATH`
+
+[discrete]
+== Procedure
+
+. Run the following commands in the terminal:
++
+----
+# bash <(curl -sL  https://www.eclipse.org/che/chectl/)
+----
+. The `chectl` binary is installed in `/usr/local/bin`.
+
+[discrete]
+== Additional resources
+
+* link:#upgrading-the-chectl-management-tool_{context}[Upgrading the `chectl` management tool]
+
+* link:https://github.com/che-incubator/chectl/blob/master/README.md[`chectl` README]

--- a/src/main/pages/che-7/overview/proc_installing-the-chectl-management-tool-on-windows.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-the-chectl-management-tool-on-windows.adoc
@@ -1,0 +1,22 @@
+[id="installing-the-chectl-management-tool-on-windows_{context}"]
+= Installing the chectl management tool on Windows
+
+This section describes how to install the chectl management tool on Windows.
+
+[discrete]
+== Procedure
+
+. Run the following commands in the powershell terminal:
++
+----
+C:\Users> Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://www.eclipse.org/che/chectl/win/'))
+----
+
+. The chectl binary is installed in `C:\ProgramData\chectl`.
+
+[discrete]
+== Additional resources
+
+* link:#upgrading-the-chectl-management-tool_{context}[Upgrading the `chectl` management tool]
+
+* link:https://github.com/che-incubator/chectl/blob/master/README.md[`chectl` README]

--- a/src/main/pages/che-7/overview/proc_preparing-openshift-for-installing-che.adoc
+++ b/src/main/pages/che-7/overview/proc_preparing-openshift-for-installing-che.adoc
@@ -3,7 +3,6 @@
 [id="preparing-openshift-for-installing-che_{context}"]
 = Preparing OpenShift for installing Che
 
-
 .Procedure
 
 To install Che on OpenShift 3 using the operator:

--- a/src/main/pages/che-7/overview/proc_upgrading-the-chectl-management-tool.adoc
+++ b/src/main/pages/che-7/overview/proc_upgrading-the-chectl-management-tool.adoc
@@ -1,0 +1,40 @@
+[id="upgrading-the-chectl-management-tool_{context}"]
+= Upgrading the chectl management tool
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+[discrete]
+== Prerequisites
+
+* `chectl` is installed. See link:#installing-the-chectl-management-tool-on-windows_{context}[Installing the chectl management tool on Windows] and link:#installing-the-chectl-management-tool-on-linux-or-macos_{context}[Installing the chectl management tool on Linux or MacOS].
+
+[discrete]
+== Procedure
+
+. Run the following command in the terminal to update `chectl` to the latest version.
+----
+# chectl update
+----
+
+. It will update chectl based on its current channel.
+
+
+[NOTE]
+====
+Two update channels are available for `chectl`: `stable` and `next`.
+
+Stable is for the latest released version of Eclipse Che. 
+
+Next is updated after each activity in master branch.
+
+To move to a different channel, invoke the update with the name of the channel as an optional argument.
+
+----
+# chectl update [next|stable]
+----
+====
+
+[discrete]
+== Additional resources
+
+* link:https://github.com/che-incubator/chectl/blob/master/README.md[`chectl` README]

--- a/src/main/pages/che-7/overview/ref_about-hosted-che.adoc
+++ b/src/main/pages/che-7/overview/ref_about-hosted-che.adoc
@@ -1,3 +1,5 @@
+:page-liquid:
+
 // Module included in the following assemblies:
 //
 // assembly_hosted-che.adoc
@@ -35,4 +37,4 @@ NOTE: A started workspace can be used for an unlimited period of time. When ther
 +
 NOTE: In ephemeral mode, workspaces have no persistent storage attached. All content changes are lost when the workspace is stopped unless they are pushed to a source-code repository first. This is done to improve the performance of workspace starts and file-system operations in the IDE.
 
-It is possible to disable ephemeral mode while xref:creating-a-worskpace-from-the-user-dashboard_hosted-che[creating a workspace from the user dashboard]. For more information about ephemeral mode, including how to disable it after workspace creation, see link:{{site.baseurl}}che-7/workspaces-overview[Using developer environments - workspaces].
+It is possible to disable ephemeral mode while xref:creating-a-worskpace-from-the-user-dashboard_hosted-che[creating a workspace from the user dashboard]. For more information about ephemeral mode, including how to disable it after workspace creation, see link:{site-baseurl}che-7/workspaces-overview[Using developer environments - workspaces].


### PR DESCRIPTION
fix eclipse/che/#14237 

Installing chectl documentation becomes a quick start chapter and other guides refer to it