### PR TITLE
Add configuration file for linkchecker

### DIFF
--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -1,0 +1,27 @@
+[checking]
+
+# Checks validity of HTML anchors.
+# Option for old versions of linkchecker
+anchors=1
+
+[filtering]
+
+# Check external links.
+checkextern=1
+
+# URLs matching the given regular expression will be ignored and not checked.
+# Multiline option. Each line has to be indented for that to work.
+# Lines starting with a hash (#) will be ignored, though they must still be indented. 
+ignore=
+  feed.xml
+  /che-6/
+  http://che.aws.my-ide.cloud
+  https://che-che.apps.rhpds311.openshift.opentlc.com
+  https://my-plugin-registry
+  https://my-registry.com
+  http://che_host:8080
+  https://domain.net
+
+# Checks validity of HTML anchors.
+# Add section in the configuration file to enable the plugin
+[AnchorCheck]


### PR DESCRIPTION
Add a configuration file for linkchecker.

Ensure linkchecker will check validity of HTML anchors and external links.
Restrict scope to che-7 documentation.
Set an ingore list for URLs that are expected not to exist.

Usage:

1. Execute `run.sh`
2. `eclipse/che-docs` docker image is running and responding on port 4000
3. Run linkchecker using the configuration file:

```
linkchecker http://0.0.0.0:4000/ --config linkcheckerrc
```

As this is a very first step, I am not sure if and how we should document it in the README.md.

Signed-off-by: Fabrice Flore-Thébault <ffloreth@redhat.com>
