### PR TITLE
Add links to sample devfiles

### DIFF
--- a/src/main/pages/che-7/end-user-guide/proc_writing-a-devfile-for-your-project.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_writing-a-devfile-for-your-project.adoc
@@ -3,13 +3,6 @@
 
 This section describes how to create a minimal devfile for your project and how to include more than one projects in a devfile.
 
-// .Prerequisites
-// 
-// * A bulleted list of conditions that must be satisfied before the user starts following this assembly.
-// * You can also link to other modules or assemblies the user must follow before starting this assembly.
-// * Delete the section title and bullets if the assembly has no prerequisites.
-
-
 [id="preparing-a-minimal-devfile_{context}"]
 == Preparing a minimal devfile
 
@@ -83,3 +76,8 @@ For a detailed explanation of all devfile component assignments and possible val
 
 * link:https://github.com/redhat-developer/devfile[Specification repository]
 * link:https://redhat-developer.github.io/devfile/devfile[detailed json-schema documentation]
+
+These sample devfiles are a good source of inspiration:
+
+* link:https://github.com/eclipse/che-devfile-registry/tree/master/devfiles[Sample devfiles for Eclipse Che workspaces used by default in the user interface].
+* link:https://github.com/redhat-developer/devfile/tree/master/samples[Sample devfiles for Eclipse Che workspaces from Red Hat Developer program].


### PR DESCRIPTION
fix https://github.com/eclipse/che/issues/14274 - Add links to sample devfiles in the Additional resources section of Writing a devfile for a project procedure

Signed-off-by: Fabrice Flore-Thébault <ffloreth@redhat.com>