### PR TITLE
che #14308 Adding 'IMPORTANT' note to the main Che 6 workspace page with a refence to the 'Converting a Che 6 workspace to a Che 7 devfile' documentation

### DIFF
--- a/src/main/pages/che-6/workspace-admin/what-are-workspaces.adoc
+++ b/src/main/pages/che-6/workspace-admin/what-are-workspaces.adoc
@@ -8,6 +8,9 @@ redirect_from: what-are-workspaces.html
 folder: che-6/workspace-admin
 ---
 
+IMPORTANT: Che 6 workspace configuration format is no longer supported in the latest Che 7 release. Please, follow the 
+link:{site-baseurl}che-7/converting-a-che-6-workspace-to-a-che-7-devfile["Converting a Che 6 workspace to a Che 7 devfile"] documentation in order to update the definition of the workspace and benefit from the latest capabilities.
+    
 [id="workspace"]
 == Workspace
 


### PR DESCRIPTION
### What does this PR do?
 Adding 'IMPORTANT' note to the main Che 6 workspace page with a refence to the 'Converting a Che 6 workspace to a Che 7 devfile' documentation

![image](https://user-images.githubusercontent.com/1461122/63527118-ceb2b180-c500-11e9-9a98-97dea99108b8.png)


### What issues does this PR fix or reference?
workaround for https://github.com/eclipse/che/issues/14308