### PR TITLE
Fix navig menu link

### DIFF
--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -189,7 +189,7 @@ entries:
       url: che-7/viewing-external-service-logs
       output: web
     - title: Viewing Che workspaces logs
-      url: che-7/viewing-kubernetes-events
+      url: che-7/viewing-che-workspaces-logs
       output: web
   - title: Monitoring Che
     url: che-7/monitoring-che


### PR DESCRIPTION
### What does this PR do?

Fixes incorrect link from nav menu "Viewing Che workspaces logs".
