### PR TITLE
Add the missing dockerimage component endpoint attributes to the devfile reference

### DIFF
--- a/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
+++ b/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
@@ -386,6 +386,14 @@ Here, there are two dockerimages, each defining a single endpoint. Endpoint is a
 
 * `protocol`: For public endpoints the protocol is a hint to the UI on how to construct the URL for the endpoint access. Typical values are `http`, `https`, `ws`, `wss`.
 
+* `secure`: A boolean (defaulting to `false`) specifying whether the endpoint will be put behind a JWT proxy requiring a JWT workspace token to grant access.
+
+* `path`: The URL path of the endpoint
+
+* `unsecuredPaths`: A comma-separated list of paths in the endpoint that should not be secured, even if the `secure` attribute is set to `true`
+
+* `cookieAuthEnabled`: If set to `true` (the default is `false`), the JWT workspace token will be automatically fetched and put to a workspace-specific cookie so that the JWT proxy let's the requests through. Note that this brings along with it a potential danger of a link:https://en.wikipedia.org/wiki/Cross-site_request_forgery[CSRF] attack if used conjunction with a server using POST requests. Use this after a careful consideration.
+
 If you start a new server within your component, Che will autodetect this and the UI will offer you to automatically expose this port as a `public` port. This is useful for debugging a web application, for example. But, it is not possible to do this for servers that autostart with the container (for example, a database server). For such components, you must specify the endpoints explicitly.
 
 ==== Kubernetes and OpenShift resources

--- a/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
+++ b/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
@@ -392,7 +392,7 @@ Here, there are two dockerimages, each defining a single endpoint. Endpoint is a
 
 * `unsecuredPaths`: A comma-separated list of paths in the endpoint that should not be secured, even if the `secure` attribute is set to `true`
 
-* `cookieAuthEnabled`: If set to `true` (the default is `false`), the JWT workspace token will be automatically fetched and put to a workspace-specific cookie so that the JWT proxy let's the requests through. Note that this brings along with it a potential danger of a link:https://en.wikipedia.org/wiki/Cross-site_request_forgery[CSRF] attack if used conjunction with a server using POST requests. Use this after a careful consideration.
+* `cookieAuthEnabled`: If set to `true` (the default is `false`), the JWT workspace token will be automatically fetched and put to a workspace-specific cookie so that the JWT proxy let's the requests through. Note that this brings along with it a potential danger of a link:https://en.wikipedia.org/wiki/Cross-site_request_forgery[CSRF] attack if used in conjunction with a server using POST requests. Use this after a careful consideration.
 
 If you start a new server within your component, Che will autodetect this and the UI will offer you to automatically expose this port as a `public` port. This is useful for debugging a web application, for example. But, it is not possible to do this for servers that autostart with the container (for example, a database server). For such components, you must specify the endpoints explicitly.
 

--- a/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
+++ b/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
@@ -386,15 +386,17 @@ Here, there are two dockerimages, each defining a single endpoint. Endpoint is a
 
 * `protocol`: For public endpoints the protocol is a hint to the UI on how to construct the URL for the endpoint access. Typical values are `http`, `https`, `ws`, `wss`.
 
-* `secure`: A boolean (defaulting to `false`) specifying whether the endpoint will be put behind a JWT proxy requiring a JWT workspace token to grant access.
+* `secure`: A boolean (defaulting to `false`) specifying whether the endpoint is put behind a JWT proxy requiring a JWT workspace token to grant access.
 
-* `path`: The URL path of the endpoint
+* `path`: The URL of the endpoint
 
 * `unsecuredPaths`: A comma-separated list of paths in the endpoint that should not be secured, even if the `secure` attribute is set to `true`
 
-* `cookieAuthEnabled`: If set to `true` (the default is `false`), the JWT workspace token will be automatically fetched and put to a workspace-specific cookie so that the JWT proxy let's the requests through. Note that this brings along with it a potential danger of a link:https://en.wikipedia.org/wiki/Cross-site_request_forgery[CSRF] attack if used in conjunction with a server using POST requests. Use this after a careful consideration.
+* `cookieAuthEnabled`: When set to `true` (the default is `false`), the JWT workspace token is automatically fetched and included in a workspace-specific cookie to allow requests to pass through the JWT proxy.
++
+WARNING: This setting potentially allows a link:https://en.wikipedia.org/wiki/Cross-site_request_forgery[CSRF] attack when used in conjunction with a server using POST requests.
 
-If you start a new server within your component, Che will autodetect this and the UI will offer you to automatically expose this port as a `public` port. This is useful for debugging a web application, for example. But, it is not possible to do this for servers that autostart with the container (for example, a database server). For such components, you must specify the endpoints explicitly.
+When starting a new server within a component, Che autodetects this, and the UI offers to automatically expose this port as a `public` port. This is useful for debugging a web application, for example. It is not possible to do this for servers that autostart with the container (for example, a database server). For such components, specify the endpoints explicitly.
 
 ==== Kubernetes and OpenShift resources
 


### PR DESCRIPTION
### What does this PR do?
`$TITLE`

### What issues does this PR fix or reference?
I've discovered this while investigating the docs for workspace exposure strategies (https://github.com/eclipse/che/issues/14189)