### PR TITLE
Improving 'Registering to Hosted Che' procedure doc

### DIFF
--- a/src/main/pages/che-7/overview/proc_registering-to-hosted-che.adoc
+++ b/src/main/pages/che-7/overview/proc_registering-to-hosted-che.adoc
@@ -11,7 +11,7 @@ This section describes how to register to Hosted{nbsp}Che.
 
 . Navigate to link:https://che.openshift.io/[Hosted{nbsp}Che].
 
-. Log in with the existing OpenShift{nbsp}Online, Red{nbsp}Hat Developer{nbsp}Program, or Red{nbsp}Hat Customer{nbsp}Portal account, *or* register for a new Red{nbsp}Hat account.
+. Log in with an existing OpenShift{nbsp}Online, Red{nbsp}Hat Developer{nbsp}Program, or Red{nbsp}Hat Customer{nbsp}Portal account, *or* register for a new Red{nbsp}Hat account.
 
 . Click the btn:[Activate account] button.
 

--- a/src/main/pages/che-7/overview/proc_registering-to-hosted-che.adoc
+++ b/src/main/pages/che-7/overview/proc_registering-to-hosted-che.adoc
@@ -7,10 +7,6 @@
 
 This section describes how to register to Hosted{nbsp}Che.
 
-.Prerequisites
-
-* Existing OpenShift{nbsp}Online, Red{nbsp}Hat Developer{nbsp}Program, or Red{nbsp}Hat Customer{nbsp}Portal account.
-
 .Procedure
 
 . Navigate to link:https://che.openshift.io/[Hosted{nbsp}Che].

--- a/src/main/pages/che-7/overview/proc_registering-to-hosted-che.adoc
+++ b/src/main/pages/che-7/overview/proc_registering-to-hosted-che.adoc
@@ -15,7 +15,7 @@ This section describes how to register to Hosted{nbsp}Che.
 
 . Navigate to link:https://che.openshift.io/[Hosted{nbsp}Che].
 
-. Log in with the existing OpenShift{nbsp}Online, Red{nbsp}Hat Developer{nbsp}Program, or Red{nbsp}Hat Customer{nbsp}Portal account.
+. Log in with the existing OpenShift{nbsp}Online, Red{nbsp}Hat Developer{nbsp}Program, or Red{nbsp}Hat Customer{nbsp}Portal account, *or* register for a new Red{nbsp}Hat account.
 
 . Click the btn:[Activate account] button.
 


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Improving 'Registering to Hosted Che' procedure doc. Making it clear that it is possible to create a new Red Hat account after the redirect from che.openshift.io and consistent with the registration form

![image](https://user-images.githubusercontent.com/1461122/64101781-e266df00-cd6e-11e9-8892-dc1378cd13e4.png)


### What issues does this PR fix or reference?
N/A