### PR TITLE
Add Debug Adapter Protocol reference

### DIFF
--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -237,6 +237,9 @@ entries:
   #- title: Che API reference
     #url: che-7/che-api-reference
     #output: web
+  - title: Debug Adapter Protocol reference
+    url: che-7/debug-adapter-protocol-reference
+    output: web
 
 # Tips and tricks for Che
   #- title: Tips and tricks for Che

--- a/src/main/pages/che-7/contributor-guide/ref_debug-adapter-protocol.adoc
+++ b/src/main/pages/che-7/contributor-guide/ref_debug-adapter-protocol.adoc
@@ -1,23 +1,16 @@
+---
+title: Debug Adapter Protocol reference
+keywords:
+tags: []
+sidebar: che_7_docs
+permalink: che-7/debug-adapter-protocol-reference/
+folder: che-7/contributor-guide
+summary:
+---
+
 [id="debug-adapter-protocol_{context}"]
 = Debug Adapter Protocol
 
-This paragraph is the reference module introduction and is only optional. Include it to provide a short overview of the module.
+The Debug Adapter Protocol (DAP) defines the abstract protocol used between a development tool (e.g. IDE or editor) and a debugger. 
 
-A reference module provide data that users might want to look up, but do not need to remember. It has a very strict structure, often in the form of a list or a table. A well-organized reference module enables users to scan it quickly to find the details they want. AsciiDoc markup to consider for reference data:
-
-
-.Unordered lists
-* For more details on writing reference modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-
-.Labeled lists
-Term 1:: Definition
-Term 2:: Definition
-
-.Tables
-[options="header"]
-|====
-|Column 1|Column 2|Column 3
-|Row 1, column 1|Row 1, column 2|Row 1, column 3
-|Row 2, column 1|Row 2, column 2|Row 2, column 3
-|====
+For more details refer to the link:https://microsoft.github.io/debug-adapter-protocol/[Debug Adapter Protocol website].


### PR DESCRIPTION
Add Debug Adapter Protocol reference as a Contributor Guide section. 

fix https://github.com/eclipse/che/issues/14372

Signed-off-by: Fabrice Flore-Thébault <ffloreth@redhat.com>