### PR TITLE
Added configMap concept module to the Che 7 docs

### DIFF
--- a/src/main/pages/che-6/setup-kubernetes/kubernetes-config.adoc
+++ b/src/main/pages/che-6/setup-kubernetes/kubernetes-config.adoc
@@ -28,7 +28,7 @@ $ kubectl set env dc/che <key>=<value> <key1>=<value1>
 [id="configurable-che-properties"]
 == Configurable Che properties
 
-You can find the deployment environment variables or configuration map in the YAML files. For a complete list of all the properties that are configurable for the Che server, see https://github.com/eclipse/che/tree/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che[Che properties].
+You can find the deployment environment variables or configuration map in the YAML files. For a complete list of all the properties that are configurable for the Che server, see link:https://github.com/eclipse/che/tree/master/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che[Che properties].
 
 To manually convert properties into environment variables, follow the instructions on the link:properties.html#properties-and-environment-variables[properties page].
 

--- a/src/main/pages/che-7/installation-guide/assembly_advanced-configuration-options.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_advanced-configuration-options.adoc
@@ -1,11 +1,11 @@
 ---
 title: Advanced configuration options
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/advanced-configuration-options.html
 folder: che-7/installation-guide
-summary: 
+summary:
 ---
 
 :parent-context-of-advanced-configuration-options: {context}
@@ -15,45 +15,28 @@ summary:
 
 :context: advanced-configuration-options
 
+Following section describes advanced deployment and configuration methods for Eclipse Che.
 
-This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. Can include more than one paragraph. Consider using the information from the user story.
+include::con_che-configmaps-and-their-behavior.adoc[leveloffset=+1]
 
-[id='prerequisites-{context}']
-== Prerequisites
+// include::ref_che-configuration-reference-table.adoc[leveloffset=+1]
 
-* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
-* You can also link to other modules or assemblies the user must follow before starting this assembly.
-* Delete the section title and bullets if the assembly has no prerequisites.
+// include::proc_deploying-che-with-https-mode.adoc[leveloffset=+1]
 
+// include::proc_deploying-che-without-keycloak.adoc[leveloffset=+1]
 
+// include::proc_configuring-che-persistent-volumes-strategy.adoc[leveloffset=+1]
 
-include::ref_che-configuration-reference-table.adoc[leveloffset=+1]
+// include::proc_configuring-che-with-and-without-keycloak.adoc[leveloffset=+1]
 
-include::proc_deploying-che-with-https-mode.adoc[leveloffset=+1]
+// include::proc_configuring-private-docker-registries.adoc[leveloffset=+1]
 
-include::proc_deploying-che-without-keycloak.adoc[leveloffset=+1]
+// include::proc_configuring-email-notifications.adoc[leveloffset=+1]
 
-include::proc_configuring-che-persistent-volumes-strategy.adoc[leveloffset=+1]
+// include::proc_configuring-namespace-strategies.adoc[leveloffset=+1]
 
-include::proc_configuring-che-with-and-without-keycloak.adoc[leveloffset=+1]
+// include::proc_configuring-workspace-memory-settings.adoc[leveloffset=+1]
 
-include::proc_configuring-private-docker-registries.adoc[leveloffset=+1]
-
-include::proc_configuring-email-notifications.adoc[leveloffset=+1]
-
-include::proc_configuring-namespace-strategies.adoc[leveloffset=+1]
-
-include::proc_configuring-workspace-memory-settings.adoc[leveloffset=+1]
-
-include::proc_configuring-che-with-openshift-oauth.adoc[leveloffset=+1]
-
-
-
-[id='related-information-{context}']
-== Related information
-
-* A bulleted list of links to other material closely related to the contents of the concept module.
-* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+// include::proc_configuring-che-with-openshift-oauth.adoc[leveloffset=+1]
 
 :context: {parent-context-of-advanced-configuration-options}

--- a/src/main/pages/che-7/installation-guide/assembly_advanced-configuration-options.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_advanced-configuration-options.adoc
@@ -15,7 +15,7 @@ summary:
 
 :context: advanced-configuration-options
 
-Following section describes advanced deployment and configuration methods for Eclipse Che.
+The following section describes advanced deployment and configuration methods for Eclipse Che.
 
 include::con_che-configmaps-and-their-behavior.adoc[leveloffset=+1]
 

--- a/src/main/pages/che-7/installation-guide/con_che-configmaps-and-their-behavior.adoc
+++ b/src/main/pages/che-7/installation-guide/con_che-configmaps-and-their-behavior.adoc
@@ -5,32 +5,35 @@
 
 The following section describes Che `configMaps` and how they behave.
 
-A link:https://docs.openshift.com/container-platform/4.1/builds/setting-up-trusted-ca.html[`configMap`] is provided as an editable file that lists options to customize the Che environment. Based on the Che installation method, `configMaps` can be used to customize the working environment. The type of configMaps available in your Che environment varies based on the method used for installing Che.
+A link:https://docs.openshift.com/container-platform/latest/builds/setting-up-trusted-ca.html[`configMap`] is provided as an editable file that lists options to customize the Che environment. Based on the Che installation method, `configMaps` can be used to customize the working environment. The type of configMaps available in your Che environment varies based on the method used for installing Che.
 
-== Che installed using the Operator
+== Che installed using an Operator
 
-link:https://docs.openshift.com/container-platform/4.1/applications/operators/olm-what-operators-are.html[Operators] are software extensions to Kubernetes that use link:https://docs.openshift.com/container-platform/4.1/applications/crds/crd-managing-resources-from-crds.html[custom resources] to manage applications and their components.
+link:https://docs.openshift.com/container-platform/latest/applications/operators/olm-what-operators-are.html[Operators] are software extensions to Kubernetes that use link:https://docs.openshift.com/container-platform/latest/applications/crds/crd-managing-resources-from-crds.html[custom resources] to manage applications and their components.
 
-When Che is installed using the Operator, this installation provides the user with two automatically generated `configMaps`: `che` (main) and `custom` (additional).
+Che installed using the Operator provides the user with two automatically generated `configMaps`:
 
-* The `che` `configMap` contains the main properties for the installation and is in sync with the information stored in the CheCluster Custom Resource file. If the user edits the `che` `configMap` after installing Che from the Operator, those changes are automatically overwritten by the values that the Operator obtains from the CheCluster Custom Resource.
+* `che` (main)
+* `custom` (additional)
+
+* The `che` `configMap` contains the main properties for the installation and is in sync with the information stored in the CheCluster Custom Resource file. User modifications of the `che` `configMap` after installing Che using the Operator are automatically overwritten by values that the Operator obtains from the `CheCluster` Custom Resource. +
 To edit the `che` `configMap`, edit the Custom Resource manually.
-The `configMap` derives values from the CheCluster field. If a user changes the CheCluster Custom Resource field, the Operator changes the attributes of the `che` `configMap` accordingly. Those `configMap` changes automatically trigger a restart of the Che pod.
+The `configMap` derives values from the `CheCluster` field. User modifications of the `CheCluster` Custom Resource field cause the Operator to change the attributes of the `che` `configMap` accordingly. The `configMap` changes automatically trigger a restart of the Che Pod.
 
-* The secondary `custom` `configMap` is for additional properties customization that the user can edit manually. These properties include environment variables that are not already specified in the main che `configMap`. To apply the manual changes to the `custom` `configMap`, delete the Che pod to manually restart it.
+* The secondary `custom` `configMap` is intended for additional manual customization of properties by users. These properties include environment variables that are not already specified in the main `che` `configMap`. To apply manual changes to the `custom` `configMap`, delete the Che Pod to manually restart it.
 
-== Che installed using a Helm Chart:
+== Che installed using a Helm Chart
 
-A (https://helm.sh/)[Helm Chart] is the Kubernetes extension for defining, installing, and upgrading Kubernetes applications.
+A link:https://helm.sh/[Helm Chart] is a Kubernetes extension for defining, installing, and upgrading Kubernetes applications.
 
-* When Che is installed using a Helm Chart, the user configures Che manually by modifying the `configMap` object. The `configMap` object is called `che` and is generated as an editable template after the installation. To apply the manual changes to the `custom` `configMap`, delete the Che pod to manually restart it.
-Alternatively, use the following command in the kubectl command-line interface:
+* When Che is installed using a Helm Chart, the user configures Che manually by modifying the `configMap` object. The `configMap` object is called `che` and is generated as an editable template after the installation. To apply manual changes to the `custom` `configMap`, delete the Che pod to manually restart it. +
+Alternatively, use the following `kubectl` command:
 +
 ----
 $ kubectl rollout restart deployment/che
 ----
 +
-This avoids the downtime associated with deleting a pod, as it deploys and starts a new pod, and only then deletes the old pod.
+This avoids the downtime associated with deleting a Pod because it deploys and starts a new Pod, and only then deletes the old Pod.
 
 ////
 .Additional resources

--- a/src/main/pages/che-7/installation-guide/con_che-configmaps-and-their-behavior.adoc
+++ b/src/main/pages/che-7/installation-guide/con_che-configmaps-and-their-behavior.adoc
@@ -1,0 +1,41 @@
+// advanced-configuration-options
+
+[id="che-configmaps-and-their-behavior_{context}"]
+= Che configMaps and their behavior
+
+The following section describes Che `configMaps` and how they behave.
+
+A link:https://docs.openshift.com/container-platform/4.1/builds/setting-up-trusted-ca.html[`configMap`] is provided as an editable file that lists options to customize the Che environment. Based on the Che installation method, `configMaps` can be used to customize the working environment. The type of configMaps available in your Che environment varies based on the method used for installing Che.
+
+== Che installed using the Operator
+
+link:https://docs.openshift.com/container-platform/4.1/applications/operators/olm-what-operators-are.html[Operators] are software extensions to Kubernetes that use link:https://docs.openshift.com/container-platform/4.1/applications/crds/crd-managing-resources-from-crds.html[custom resources] to manage applications and their components.
+
+When Che is installed using the Operator, this installation provides the user with two automatically generated `configMaps`: `che` (main) and `custom` (additional).
+
+* The `che` `configMap` contains the main properties for the installation and is in sync with the information stored in the CheCluster Custom Resource file. If the user edits the `che` `configMap` after installing Che from the Operator, those changes are automatically overwritten by the values that the Operator obtains from the CheCluster Custom Resource.
+To edit the `che` `configMap`, edit the Custom Resource manually.
+The `configMap` derives values from the CheCluster field. If a user changes the CheCluster Custom Resource field, the Operator changes the attributes of the `che` `configMap` accordingly. Those `configMap` changes automatically trigger a restart of the Che pod.
+
+* The secondary `custom` `configMap` is for additional properties customization that the user can edit manually. These properties include environment variables that are not already specified in the main che `configMap`. To apply the manual changes to the `custom` `configMap`, delete the Che pod to manually restart it.
+
+== Che installed using a Helm Chart:
+
+A (https://helm.sh/)[Helm Chart] is the Kubernetes extension for defining, installing, and upgrading Kubernetes applications.
+
+* When Che is installed using a Helm Chart, the user configures Che manually by modifying the `configMap` object. The `configMap` object is called `che` and is generated as an editable template after the installation. To apply the manual changes to the `custom` `configMap`, delete the Che pod to manually restart it.
+Alternatively, use the following command in the kubectl command-line interface:
++
+----
+$ kubectl rollout restart deployment/che
+----
++
+This avoids the downtime associated with deleting a pod, as it deploys and starts a new pod, and only then deletes the old pod.
+
+////
+.Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the concept module.
+* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
+* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].


### PR DESCRIPTION
Waiting for the information where to put this concent in Che  6 @rkratky  
Robert, your peer review would also be useful before moving this concept module into Che 6 docs (to prevent duplicated typos and so on)

https://github.com/eclipse/che/issues/14075

https://docs.google.com/document/d/1eMRB_FDgEqzVzCBKOdhjA1eypw-Fl6bljuDrnRepBHk/edit#