### PR TITLE
Add Viewing plug-in broker logs

### DIFF
--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -191,6 +191,9 @@ entries:
     - title: Viewing Che workspaces logs
       url: che-7/viewing-kubernetes-events
       output: web
+    - title: Viewing the plug-in broker logs
+      url: che-7/viewing-plug-in-broker-logs
+      output: web
   - title: Monitoring Che
     url: che-7/monitoring-che
     output: web

--- a/src/main/pages/che-7/administration-guide/assembly_retrieving-che-logs.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_retrieving-che-logs.adoc
@@ -21,6 +21,7 @@ This is a catalog of the location and instructions to retrieve application logs 
 * link:{site-baseurl}che-7/viewing-che-server-logs[Viewing Che server logs]
 * link:{site-baseurl}che-7/viewing-external-service-logs[Viewing external service logs]
 * link:{site-baseurl}che-7/viewing-che-workspaces-logs[Viewing Che workspaces logs]
+* link:{site-baseurl}che-7/proc_viewing-plug-in-broker-logs[Viewing the plug-in broker logs]
 
 // TODO: include::proc_viewing-che-operator-logs.adoc[leveloffset=+1]
 

--- a/src/main/pages/che-7/administration-guide/proc_viewing-plug-in-broker-logs.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_viewing-plug-in-broker-logs.adoc
@@ -1,8 +1,21 @@
+---
+title: Viewing the plug-in broker logs
+keywords: 
+tags: []
+sidebar: che_7_docs
+permalink: che-7/viewing-plug-in-broker-logs/
+folder: che-7/administration-guide
+summary: 
+---
+
+
 [id="viewing-plug-in-broker-logs_{context}"]
 = Viewing the plug-in broker logs
 
 This section describes how to view the plug-in broker logs.
 
+The logs from the plug-in broker are not persisted. As the Pod itself is deleted very quickly, events will in most cases be unavailable.
+
 .Procedure
 
-// TODO: The "Viewing the plug-in broker logs" procedure need to be written 
+* Logs are displayed to the user while the workspace is starting. 


### PR DESCRIPTION
Add Viewing plug-in broker logs in the Administration Guide / Retrieving Che logs.

fix https://github.com/eclipse/che/issues/14363

Signed-off-by: Fabrice Flore-Thébault <ffloreth@redhat.com>

