### PR TITLE
Name change

### DIFF
--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -267,7 +267,7 @@ entries:
     - title: Installing
       url: che-7/che4z-installing
       output: web
-    - title: Using Explorer for z/OS
+    - title: Using z/OS Resource Explorer
       url: che-7/che4z-using-explorer-for-zos
       output: web
     - title: Product Accessibility Features

--- a/src/main/pages/che-7/extensions/che4z-release-information.adoc
+++ b/src/main/pages/che-7/extensions/che4z-release-information.adoc
@@ -18,7 +18,7 @@ Eclipse Che4z provides components/extensions for Eclipse Che to facilitate mainf
 * Access to resources on z/OS
 * Smart editing support for COBOL, the most prominent language on the mainframe
 
-Eclipse Che4z currently comprises two products, Explorer for z/OS and LSP for COBOL.
+Eclipse Che4z currently comprises two products, z/OS Resource Explorer and LSP for COBOL.
 
 == Release Notes - LSP for COBOL
 
@@ -33,21 +33,21 @@ Checks for mistakes and errors in COBOL code.
 * *Third-party COBOL syntax highlighting support* +
 Enables syntax highlighting for COBOL code as long as you have an appropriate third-party syntax highlighting extension installed.
 
-== Release Notes - Explorer for z/OS
+== Release Notes - z/OS Resource Explorer
 
 === Version 0.8
 
 Version 0.8 was released on 1 August 2019 and includes the following features:
 
 * *Browse, edit, copy, delete and create members* +
-Explorer for z/OS lets you browse, edit, copy, delete and create PDS members.
+z/OS Resource Explorer lets you browse, edit, copy, delete and create PDS members.
 * *Allocate data sets* +
-Explorer for z/OS lets you allocate new data sets by copying the parameters of an existing data set. Only PDS and PDSE libraries, and sequential files that use "tracks" or "cylinders" as their storage unit are supported.
+z/OS Resource Explorer lets you allocate new data sets by copying the parameters of an existing data set. Only PDS and PDSE libraries, and sequential files that use "tracks" or "cylinders" as their storage unit are supported.
 * *Filters* +
-Explorer for z/OS lets you create customisable filters for ease of browsing data sets.
+z/OS Resource Explorer lets you create customisable filters for ease of browsing data sets.
 * *COBOL and JCL syntax awareness support* +
 z/OS explorer integrates with JCL and COBOL syntax awareness extensions when browsing and editing members of data sets with the extensions .JCL and .COBOL.
 
 == Third-party Software Agreements
 
-Eclipse Che4z uses the Eclipse Public License v2.0 (link:https://www.eclipse.org/legal/epl-v20.html[full text]) for both Explorer for z/OS and LSP for COBOL.
+Eclipse Che4z uses the Eclipse Public License v2.0 (link:https://www.eclipse.org/legal/epl-v20.html[full text]) for both z/OS Resource Explorer and LSP for COBOL.

--- a/src/main/pages/che-7/extensions/che4z-using-explorer-for-zos.adoc
+++ b/src/main/pages/che-7/extensions/che4z-using-explorer-for-zos.adoc
@@ -1,5 +1,5 @@
 ---
-title: Using Explorer for z/OS
+title: Using z/OS Resource Explorer
 keywords: 
 tags: [Che4z]
 sidebar: che_7_docs
@@ -9,15 +9,15 @@ summary:
 ---
 
 [id="che4z-using-explorer-for-zos"]
-= Using Explorer for z/OS
+= Using z/OS Resource Explorer
 
 :context: che4z-using-explorer-for-zos
 
-Eclipse Che4z Explorer for z/OS allows you to remotely view and edit the content of partitioned data sets within the Eclipse Theia IDE. You can create, copy and delete PDS members, and allocate new data sets copying the parameters of a model data set. You can also configure filters to enable fast indexing of large numbers of data sets. You can also enable syntax highlighting for COBOL text by installing the LSP for COBOL extension.
+Eclipse Che4z z/OS Resource Explorer allows you to remotely view and edit the content of partitioned data sets within the Eclipse Theia IDE. You can create, copy and delete PDS members, and allocate new data sets copying the parameters of a model data set. You can also configure filters to enable fast indexing of large numbers of data sets. You can also enable syntax highlighting for COBOL text by installing the LSP for COBOL extension.
 
 == Hosts
 
-Before you start using Explorer for z/OS, you first create a host connection to the mainframe. This produces a list of all data sets with your user name as the high level qualifier. You can have as many host connections as you need.
+Before you start using z/OS Resource Explorer, you first create a host connection to the mainframe. This produces a list of all data sets with your user name as the high level qualifier. You can have as many host connections as you need.
 
 === Create a Host Connection to z/OS
 
@@ -25,7 +25,7 @@ To be able to work with z/OS data sets, a host connection to z/OS is required. A
 
 *Follow these steps:*
 
-. In Explorer for z/OS, click *New connection*.
+. In z/OS Resource Explorer, click *New connection*.
 . Fill in the following fields:
 	* URL (http://host:port or https://host:port)
 	* Host name (identifies the mainframe instance). +
@@ -70,7 +70,7 @@ To edit or delete an existing filter, click the *edit* or *delete* icons next to
 
 == Actions
 
-In Explorer for z/OS you can browse, edit, copy and delete members of partitioned data sets (PDS) and allocate data sets.
+In z/OS Resource Explorer you can browse, edit, copy and delete members of partitioned data sets (PDS) and allocate data sets.
 
 === Browse a Member
 
@@ -88,9 +88,9 @@ TIP: If you try to edit a locked data set or member, you cannot save the data se
 
 === Syntax Awareness
 
-If a data set name ends with .JCL, Explorer for z/OS recognizes the member or data set as a JCL. If you have third-party JCL syntax awareness software installed, the syntax is highlighted when browsing or editing members of the data set.
+If a data set name ends with .JCL, z/OS Resource Explorer recognizes the member or data set as a JCL. If you have third-party JCL syntax awareness software installed, the syntax is highlighted when browsing or editing members of the data set.
 
-If the data set name ends with .COBOL, z/OS Explorer recognizes the members of the data set as COBOL files, and Eclipse Che4z LSP syntax awareness is enabled when browsing or editing members of the data set.
+If the data set name ends with .COBOL, z/OS Resource Explorer recognizes the members of the data set as COBOL files, and Eclipse Che4z LSP syntax awareness is enabled when browsing or editing members of the data set.
 
 === Create a Member
 
@@ -98,13 +98,13 @@ To create a new member of a PDS, right click on the data set and select *Create 
 
 === Allocate a Data Set
 
-Explorer for z/OS lets you allocate a data set using the parameters of an existing data set as a model. The parameters cannot be edited. As well as partitioned data sets, this functionality is also supported for sequential files, as long as they use tracks (TRK) or cylinders (CYL) as the space allocation unit. VSAM data sets and sequential files that use blocks (BLK) as the space allocation unit are not supported.
+z/OS Resource Explorer lets you allocate a data set using the parameters of an existing data set as a model. The parameters cannot be edited. As well as partitioned data sets, this functionality is also supported for sequential files, as long as they use tracks (TRK) or cylinders (CYL) as the space allocation unit. VSAM data sets and sequential files that use blocks (BLK) as the space allocation unit are not supported.
 
 To allocate a new data set like a model, right click on the model data set and select *Allocate like*. Specify a unique name for the new data set. 
 
 === Copy a Member 
 
-Explorer for z/OS lets you copy members of a data set to another data set or the same data set. The destination data set can be on the same host or a different host.
+z/OS Resource Explorer lets you copy members of a data set to another data set or the same data set. The destination data set can be on the same host or a different host.
 
 *Follow these steps:*
 


### PR DESCRIPTION
Explorer for z/OS has been renamed to z/OS Resource Explorer

Signed-off-by: Zeibura Kathau <zeibura.kathau@broadcom.com>

### What does this PR do?
Changes "Explorer for z/OS" to "z/OS Resource Explorer" after a rename of the product.

### What issues does this PR fix or reference?
#14582