### PR TITLE
Fix https deploy doc

### DIFF
--- a/src/main/pages/che-7/overview/proc_creating-a-service-account-secret-on-azure.adoc
+++ b/src/main/pages/che-7/overview/proc_creating-a-service-account-secret-on-azure.adoc
@@ -1,5 +1,5 @@
 [id='creating-a-service-account-secret-on-azure_{context}']
-= reating a Service Account Secret on Azure
+= Creating a Service Account Secret on Azure
 
 The secret must be in the *cert-manager* namespace. Otherwise the secret cannot be found, and cert-manager reports errors.
 

--- a/src/main/pages/che-7/overview/proc_preparing-the-aws-system-for-installing-che.adoc
+++ b/src/main/pages/che-7/overview/proc_preparing-the-aws-system-for-installing-che.adoc
@@ -394,7 +394,6 @@ image::installation/create-policy-review.png[link="{imagesdir}/installation/crea
 . In the *Name* field, type `route53`, and click *Create policy*.
 . To create the certificate issuer, change the email address and specify the `accessKeyID`:
 +
-[subs="+quotes",options="nowrap"]
 ----
 $ cat <<EOF | kubectl apply -f -
 apiVersion: certmanager.k8s.io/v1alpha1
@@ -421,7 +420,6 @@ EOF
 
 . Add the certificate by editing the domain name value (`aws.my-ide.cloud`, in this case) and the `dnsName` value:
 +
-[subs="+quotes",options="nowrap"]
 ----
 $ cat <<EOF | kubectl apply -f -
 apiVersion: certmanager.k8s.io/v1alpha1


### PR DESCRIPTION
### What does this PR do?
1. Fixes typo
2. Aligns AWS YAML section options with Azure and GCP ones, to make * displayable. Maybe there are more preferable ways to make * displayable, but I just did in the same way as other similar docs have.

### What issues does this PR fix or reference?
It fixes a documentation issue a used faced in https://github.com/eclipse/che/issues/14584