### PR TITLE
Add table of contents to release information

### DIFF
--- a/src/main/pages/che-7/extensions/che4z-release-information.adoc
+++ b/src/main/pages/che-7/extensions/che4z-release-information.adoc
@@ -20,6 +20,12 @@ Eclipse Che4z provides components/extensions for Eclipse Che to facilitate mainf
 
 Eclipse Che4z currently comprises two products, z/OS Resource Explorer and LSP for COBOL.
 
+== Table of contents
+
+* link:https://projects.eclipse.org/projects/ecd.che.che4z/downloads[Installing Eclipse Che4z]
+* link:https://www.eclipse.org/che/docs/che-7/che4z-using-explorer-for-zos[Using z/OS Resource Explorer]
+* link:https://www.eclipse.org/che/docs/che-7/che4z-product-accessibility-features[Product Accessibility Features]
+
 == Release Notes - LSP for COBOL
 
 === Version 0.8


### PR DESCRIPTION
Add table of contents to release information, with links to pages inaccessible from the navigation bar.

Signed-off-by: Zeibura Kathau <zeibura.kathau@broadcom.com>

### What does this PR do?

Currently due to a bug none of the Eclipse Che4z pages except Release Information are accessible from the navigation bar. This is a workaround to make the rest of the documentation usable while the navigation bar bug is fixed.

### What issues does this PR fix or reference?

#14294
