### PR TITLE
Do Not Strip / From url for Search

### DIFF
--- a/src/main/search.json
+++ b/src/main/search.json
@@ -11,7 +11,7 @@ search: exclude
 "title": "{{ page.title | escape }}",
 "tags": "{{ page.tags }}",
 "keywords": "{{page.keywords}}",
-"url": "{{ page.url | remove: "/"}}",
+"url": "{{ page.url }}",
 "summary": "{{page.summary | strip }}"
 }
 {% unless forloop.last and site.posts.size < 1 %},{% endunless %}
@@ -24,7 +24,7 @@ search: exclude
 "title": "{{ post.title | escape }}",
 "tags": "{{ post.tags }}",
 "keywords": "{{post.keywords}}",
-"url": "{{ post.url | remove: "/" }}",
+"url": "{{ post.url }}",
 "summary": "{{post.summary | strip }}"
 }
 {% unless forloop.last %},{% endunless %}


### PR DESCRIPTION
### What does this PR do?

This pull request removes the stripping of the url for search which causes a 404 whenever a search is currently done on the documentation site. 

Follow steps in the issue below to reproduce the issue. 

### What issues does this PR fix or reference?

Closes https://github.com/eclipse/che/issues/14647