### PR TITLE
Prepend site.baseurl in search.json

### DIFF
--- a/src/main/search.json
+++ b/src/main/search.json
@@ -11,7 +11,7 @@ search: exclude
 "title": "{{ page.title | escape }}",
 "tags": "{{ page.tags }}",
 "keywords": "{{page.keywords}}",
-"url": "{{ page.url }}",
+"url": "{{ page.url | prepend: '/che/docs' }}",
 "summary": "{{page.summary | strip }}"
 }
 {% unless forloop.last and site.posts.size < 1 %},{% endunless %}
@@ -24,7 +24,7 @@ search: exclude
 "title": "{{ post.title | escape }}",
 "tags": "{{ post.tags }}",
 "keywords": "{{post.keywords}}",
-"url": "{{ post.url }}",
+"url": "{{ post.url | prepend: '/che/docs' }}",
 "summary": "{{post.summary | strip }}"
 }
 {% unless forloop.last %},{% endunless %}

--- a/src/main/search.json
+++ b/src/main/search.json
@@ -11,8 +11,8 @@ search: exclude
 "title": "{{ page.title | escape }}",
 "tags": "{{ page.tags }}",
 "keywords": "{{page.keywords}}",
-"url": "{{ page.url | prepend: '/che/docs' }}",
-"summary": "{{page.summary | strip }}"
+"url": "{{ page.url | remove_first: '/' | prepend: site.baseurl }}",
+"summary": "{{ page.summary | strip }}"
 }
 {% unless forloop.last and site.posts.size < 1 %},{% endunless %}
 {% endunless %}
@@ -23,9 +23,9 @@ search: exclude
 {
 "title": "{{ post.title | escape }}",
 "tags": "{{ post.tags }}",
-"keywords": "{{post.keywords}}",
-"url": "{{ post.url | prepend: '/che/docs' }}",
-"summary": "{{post.summary | strip }}"
+"keywords": "{{ post.keywords }}",
+"url": "{{ post.url | remove_first: '/' | prepend: site.baseurl }}",
+"summary": "{{ post.summary | strip }}"
 }
 {% unless forloop.last %},{% endunless %}
 {% endfor %}


### PR DESCRIPTION
Signed-off-by: danielhelfand <helfand.4@gmail.com>

### What does this PR do?

#828 removed the stripping of the url from `search.json` as part of an effort to fix https://github.com/eclipse/che/issues/14647. While running locally with changes in #828 fixes the issue, it does not solve the problem for the che-docs site.

There appears to be a difference in how search works locally versus the site itself. The site requires `/che/docs` as part of the url while it does not locally.

This pull request prepends `/che/docs` in `search.json` as part of the url.

## Considerations

This change will mean that search will not work locally for the site. 

If there is a staging environment for the site, it would make sense to test there as opposed to verifying locally.
