### PR TITLE
Remove TOC and add Apache license

### DIFF
--- a/src/main/pages/che-7/extensions/che4z-release-information.adoc
+++ b/src/main/pages/che-7/extensions/che4z-release-information.adoc
@@ -18,9 +18,17 @@ Eclipse Che4z provides components/extensions for Eclipse Che to facilitate mainf
 * Access to resources on z/OS
 * Smart editing support for COBOL, the most prominent language on the mainframe
 
-Eclipse Che4z currently comprises two products, z/OS Resource Explorer and LSP for COBOL.
+Eclipse Che4z currently comprises two products, z/OS Resource Explorer and COBOL Language Support.
 
-== Release Notes - LSP for COBOL
+== Release Notes - COBOL Language Support
+
+=== Version 0.81
+
+Version 0.8 was released on 1 October 2019.
+
+* Extension name updated.
+* Repository corrected including improved description.
+* Unexpected error message resolved. Re-directed to internal log.
 
 === Version 0.8
 
@@ -50,4 +58,4 @@ z/OS explorer integrates with JCL and COBOL syntax awareness extensions when bro
 
 == Third-party Software Agreements
 
-Eclipse Che4z uses the Eclipse Public License v2.0 (link:https://www.eclipse.org/legal/epl-v20.html[full text]) and the Apache License v2.0 (link:https://www.apache.org/licenses/LICENSE-2.0.txt[full text]) for both z/OS Resource Explorer and LSP for COBOL.
+Eclipse Che4z uses the Eclipse Public License v2.0 (link:https://www.eclipse.org/legal/epl-v20.html[full text]) and the Apache License v2.0 (link:https://www.apache.org/licenses/LICENSE-2.0.txt[full text]) for both z/OS Resource Explorer and COBOL Language Support.

--- a/src/main/pages/che-7/extensions/che4z-release-information.adoc
+++ b/src/main/pages/che-7/extensions/che4z-release-information.adoc
@@ -20,12 +20,6 @@ Eclipse Che4z provides components/extensions for Eclipse Che to facilitate mainf
 
 Eclipse Che4z currently comprises two products, z/OS Resource Explorer and LSP for COBOL.
 
-== Table of contents
-
-* link:https://projects.eclipse.org/projects/ecd.che.che4z/downloads[Installing Eclipse Che4z]
-* link:https://www.eclipse.org/che/docs/che-7/che4z-using-explorer-for-zos[Using z/OS Resource Explorer]
-* link:https://www.eclipse.org/che/docs/che-7/che4z-product-accessibility-features[Product Accessibility Features]
-
 == Release Notes - LSP for COBOL
 
 === Version 0.8
@@ -56,4 +50,4 @@ z/OS explorer integrates with JCL and COBOL syntax awareness extensions when bro
 
 == Third-party Software Agreements
 
-Eclipse Che4z uses the Eclipse Public License v2.0 (link:https://www.eclipse.org/legal/epl-v20.html[full text]) for both z/OS Resource Explorer and LSP for COBOL.
+Eclipse Che4z uses the Eclipse Public License v2.0 (link:https://www.eclipse.org/legal/epl-v20.html[full text]) and the Apache License v2.0 (link:https://www.apache.org/licenses/LICENSE-2.0.txt[full text]) for both z/OS Resource Explorer and LSP for COBOL.

--- a/src/main/pages/che-7/extensions/che4z-using-explorer-for-zos.adoc
+++ b/src/main/pages/che-7/extensions/che4z-using-explorer-for-zos.adoc
@@ -13,7 +13,7 @@ summary:
 
 :context: che4z-using-explorer-for-zos
 
-Eclipse Che4z z/OS Resource Explorer allows you to remotely view and edit the content of partitioned data sets within the Eclipse Theia IDE. You can create, copy and delete PDS members, and allocate new data sets copying the parameters of a model data set. You can also configure filters to enable fast indexing of large numbers of data sets. You can also enable syntax highlighting for COBOL text by installing the LSP for COBOL extension.
+Eclipse Che4z z/OS Resource Explorer allows you to remotely view and edit the content of partitioned data sets within the Eclipse Theia IDE. You can create, copy and delete PDS members, and allocate new data sets copying the parameters of a model data set. You can also configure filters to enable fast indexing of large numbers of data sets. You can also enable syntax highlighting for COBOL text by installing the COBOL Language Support extension.
 
 == Hosts
 


### PR DESCRIPTION
Signed-off-by: Zeibura Kathau <zeibura.kathau@broadcom.com>

### What does this PR do?
- TOC removed from Che4z release information page, as the scrollbar now works for the navigation pane
- Apache license added to TPSRs

### What issues does this PR fix or reference?
#14294 - scrollbar
#14764 - license
