### PR TITLE
fix link in proc_including-the-plug-in-binaries-in-the-registry-image

### DIFF
--- a/src/main/pages/che-7/administration-guide/proc_including-the-plug-in-binaries-in-the-registry-image.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_including-the-plug-in-binaries-in-the-registry-image.adoc
@@ -51,4 +51,4 @@ $ sed -i -e 's/$\{URL_PLUGIN2}/$\{NEW_URL_VS_CODE_EXT2}/g' \
   ./che-plugin-registry/v3/plugins/$\{ORG}/$\{NAME}/$\{VERSION}/meta.yaml
 ----
 
-. Build and deploy the plug-in registry using the instructions in the xref:building-and-running-a-custom-registry-image_customizing-the-devfile-and-plug-in-registries[] section.
+. Build and deploy the plug-in registry using the instructions in the link:{site-baseurl}che-7/building-and-running-a-custom-registry-image[Building and running a custom registry image] section.


### PR DESCRIPTION
Fix a broken link in 
https://www.eclipse.org/che/docs/che-7/including-the-plug-in-binaries-in-the-registry-image/#building-and-running-a-custom-registry-image_customizing-the-devfile-and-plug-in-registries