### PR TITLE
Update the version Control section with the latest changes

### DIFF
--- a/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-https.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-https.adoc
@@ -21,7 +21,7 @@ Alternatively, use the native *Git* commands in the terminal to clone a project.
 $ git clone _<link>_
 ----
 
-WARNING: Self-Signed SSL Certificates are not supported, use SSH keys instead.
+WARNING: Self-signed SSL certificates are not supported. Use SSH keys instead.
 
 ////
 .Additional resources

--- a/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-https.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-https.adoc
@@ -21,6 +21,8 @@ Alternatively, use the native *Git* commands in the terminal to clone a project.
 $ git clone _<link>_
 ----
 
+WARNING: Self-Signed SSL Certificates are not supported, use SSH keys instead.
+
 ////
 .Additional resources
 

--- a/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-ssh.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-ssh.adoc
@@ -9,7 +9,7 @@
 
 == Generating an SSH key
 
-A common SSH key, that will work for all Git providers, is already present by default. You just need to add the public key to the Git provider.
+A common SSH key that works with all Git providers is present by default. To start using it, add the public key to the Git provider.
 
 To generate an SSH key pair that will work only with a particular Git provider:
 

--- a/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-ssh.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-ssh.adoc
@@ -5,14 +5,15 @@
 
 
 .Prerequisites
-* Personal link:https://help.github.com/en/articles/types-of-github-accounts[GitHub account] created.
-* SSH key pair generated.
+* Personal link:https://help.github.com/en/articles/types-of-github-accounts[GitHub account] or other Git provider account created.
 
 == Generating an SSH key
 
-To generate an SSH key pair:
+A common SSH key, that will work for all Git providers, is already present by default. You just need to add the public key to the Git provider.
 
-. Run the *SSH: generate key pair* command, or, to generate a key that will work only with a particular Git provider, run *SSH: generate key pair for particular host*.
+To generate an SSH key pair that will work only with a particular Git provider:
+
+. Run the *SSH: generate key pair for particular host*.
 . After the key is generated, click the btn:[View] button and copy the public key from the editor.
 . Add the public key to the Git provider.
 

--- a/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-ssh.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-ssh.adoc
@@ -13,7 +13,7 @@ A common SSH key that works with all Git providers is present by default. To sta
 
 To generate an SSH key pair that only works with a particular Git provider:
 
-. Run the *SSH: generate key pair for particular host*.
+. Run the *SSH: generate key pair for particular host* command.
 . After the key is generated, click the btn:[View] button and copy the public key from the editor.
 . Add the public key to the Git provider.
 

--- a/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-ssh.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-ssh.adoc
@@ -11,7 +11,7 @@
 
 A common SSH key that works with all Git providers is present by default. To start using it, add the public key to the Git provider.
 
-To generate an SSH key pair that will work only with a particular Git provider:
+To generate an SSH key pair that only works with a particular Git provider:
 
 . Run the *SSH: generate key pair for particular host*.
 . After the key is generated, click the btn:[View] button and copy the public key from the editor.


### PR DESCRIPTION
### What does this PR do?
Update the documentation about Version Control: add a warning in the `Accessing a Git repository via HTTPS` section, change the beginning of `Accessing a Git repository via SSH` section.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14917