### PR TITLE
Remove the --incremental option from the run.sh script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,5 +16,5 @@ else
   echo "Building and serving the docs for local preview. To build for production"
   echo "(publishing on eclipse.org/che/docs/), run the script with the '-prod' option:"
   echo "$0 -prod"
-  docker run --rm -ti -p 35729:35729 -p 4000:4000 -v $(pwd)/src/main:/che-docs:Z eclipse/che-docs sh -c "cd /che-docs; jekyll clean; jekyll serve --incremental --livereload -H 0.0.0.0"
+  docker run --rm -ti -p 35729:35729 -p 4000:4000 -v $(pwd)/src/main:/che-docs:Z eclipse/che-docs sh -c "cd /che-docs; jekyll clean; jekyll serve --livereload -H 0.0.0.0"
 fi

--- a/src/main/pages/che-7/overview/assembly_installing-che-on-openshift-4-from-operatorhub.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-che-on-openshift-4-from-operatorhub.adoc
@@ -26,14 +26,19 @@ Following steps are described:
 
 * xref:installing-che-using-the-che-operator-in-openshift-4-web-console_{context}[].
 
-* xref:viewing-the-state-of-the-che-cluster-deployment-in-openshift-4-web-console_{context}[] or xref:viewing-the-state-of-the-che-cluster-deployment-using-openshift-4-cli-tools_{context}[].
+* xref:viewing-the-state-of-the-che-cluster-deployment-in-openshift-4-web-console_{context}[].
 
-* xref:finding-che-cluster-url-in-openshift-4-web-console_{context}[] or xref:finding-che-cluster-url-using-openshift-4-cli-tools_{context}[].
+* xref:viewing-the-state-of-the-che-cluster-deployment-using-openshift-4-cli-tools_{context}[].
+
+* xref:finding-che-cluster-url-in-openshift-4-web-console_{context}[].
+
+* xref:finding-che-cluster-url-using-openshift-4-cli-tools_{context}[].
 
 * xref:enabling-ssl-on-openshift-4_{context}[].
 
-* xref:logging-in-to-che-on-openshift-for-the-first-time-using-oauth_{context}[] or xref:logging-in-to-che-on-openshift-for-the-first-time-registering-as-a-new-user_{context}[].
+* xref:logging-in-to-che-on-openshift-for-the-first-time-using-oauth_{context}[] 
 
+* xref:logging-in-to-che-on-openshift-for-the-first-time-registering-as-a-new-user_{context}[].
 
 include::proc_creating-the-che-project-in-openshift-4-web-console.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Remove the --incremental option from the run.sh script because it is working only when editing assembly files.
