### PR TITLE
Modify run.sh to work with podman

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,13 +8,45 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-if [ "$1" = "-prod" ]; then
-  echo "Building for production (publishing on eclipse.org/che/docs/). To preview"
-  echo -e "the docs locally, run the script ($0) without the '-prod' option.\n"
-  docker run --rm -v $(pwd)/src/main:/che-docs:Z eclipse/che-docs sh -c "cd /che-docs; jekyll clean; jekyll build --config _config.yml,_config-war.yml"
-else
-  echo "Building and serving the docs for local preview. To build for production"
-  echo "(publishing on eclipse.org/che/docs/), run the script with the '-prod' option:"
-  echo "$0 -prod"
-  docker run --rm -ti -p 35729:35729 -p 4000:4000 -v $(pwd)/src/main:/che-docs:Z eclipse/che-docs sh -c "cd /che-docs; jekyll clean; jekyll serve --livereload -H 0.0.0.0"
-fi
+set -e
+
+# Detect presence of podman. Fallback to docker
+RUNNER="$(command -v podman 2>/dev/null || command -v docker)"
+
+case "${RUNNER}" in
+  *podman)
+    echo "Using $RUNNER."
+    [ "$(find src/main/_site -user root -print -prune -o -prune 2>/dev/null)" ] && \
+      echo "Previous build was probably created with docker. We need root privileges to delete it." && \
+      sudo rm -rf src/main/_site/ 
+    ;;
+  *docker)
+    echo "podman not detected. Using fallback runner $RUNNER. This runner is deprecated, please install podman."
+    ;;
+  *)
+    echo "No runner detected. Please install podman."
+    ;;
+esac
+
+SRC_PATH="$(pwd)/src/main"
+
+case "$1" in
+  -prod)
+    echo "Building for production (publishing on eclipse.org/che/docs/). To preview"
+    echo "the docs locally, run the script ($0) without the '-prod' option."
+    $RUNNER run --rm \
+      -v "${SRC_PATH}":/che-docs \
+      eclipse/che-docs \
+      sh -c "cd /che-docs && jekyll clean && jekyll build --config _config.yml,_config-war.yml"
+    ;;
+  *)
+    echo "Building and serving the docs for local preview. To build for production"
+    echo "(publishing on eclipse.org/che/docs/), run the script with the '-prod' option:"
+    echo "$0 -prod"
+    $RUNNER run --rm -ti \
+      -p 35729:35729 -p 4000:4000 \
+      -v "${SRC_PATH}":/che-docs \
+      eclipse/che-docs \
+      sh -c "cd /che-docs && jekyll clean && jekyll serve --livereload -H 0.0.0.0 --trace"
+  ;;
+esac

--- a/run.sh
+++ b/run.sh
@@ -35,17 +35,17 @@ case "$1" in
     echo "Building for production (publishing on eclipse.org/che/docs/). To preview"
     echo "the docs locally, run the script ($0) without the '-prod' option."
     $RUNNER run --rm \
-      -v "${SRC_PATH}":/che-docs \
+      -v "${SRC_PATH}":/che-docs:Z \
       eclipse/che-docs \
       sh -c "cd /che-docs && jekyll clean && jekyll build --config _config.yml,_config-war.yml"
     ;;
   *)
-    echo "Building and serving the docs for local preview. To build for production"
+    echo "Building and serving the docs for local preview. To build for production testing"
     echo "(publishing on eclipse.org/che/docs/), run the script with the '-prod' option:"
     echo "$0 -prod"
     $RUNNER run --rm -ti \
       -p 35729:35729 -p 4000:4000 \
-      -v "${SRC_PATH}":/che-docs \
+      -v "${SRC_PATH}":/che-docs:Z \
       eclipse/che-docs \
       sh -c "cd /che-docs && jekyll clean && jekyll serve --livereload -H 0.0.0.0 --trace"
   ;;

--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,7 @@ case "${RUNNER}" in
       sudo rm -rf src/main/_site/ 
     ;;
   *docker)
-    echo "podman not detected. Using fallback runner $RUNNER. This runner is deprecated, please install podman."
+    echo "The preferred runner podman is not installed. Using fallback runner $RUNNER."
     ;;
   *)
     echo "No runner detected. Please install podman."


### PR DESCRIPTION
- Detect presence of podman and use it.
- Use docker as fallback.
- If podman is used for the first time, delete previous builds if they are owned by root.
- Remove the  `:Z ` mount option that don't behave well on podman.