### PR TITLE
Explain that at least one user using OAuth is needed

### DIFF
--- a/src/main/pages/che-7/overview/proc_installing-che-using-the-che-operator-in-openshift-4-web-console.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-using-the-che-operator-in-openshift-4-web-console.adoc
@@ -8,7 +8,7 @@ This section describes how to install Che using the Che operator in OpenShift 4 
 
 * An administrator account on a running instance of OpenShift 4.
 
-* At least one Oauth user provisionned on this instance of OpenShift 4.
+* At least one OAuth user provisionned on this instance of OpenShift 4.
 
 * The Che operator is installed on this instance of OpenShift 4. See xref:installing-the-che-operator-in-openshift-4-web-console_{context}[]
 

--- a/src/main/pages/che-7/overview/proc_installing-che-using-the-che-operator-in-openshift-4-web-console.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-using-the-che-operator-in-openshift-4-web-console.adoc
@@ -8,6 +8,8 @@ This section describes how to install Che using the Che operator in OpenShift 4 
 
 * An administrator account on a running instance of OpenShift 4.
 
+* At least one Oauth user provisionned on this instance of OpenShift 4.
+
 * The Che operator is installed on this instance of OpenShift 4. See xref:installing-the-che-operator-in-openshift-4-web-console_{context}[]
 
 [discrete]

--- a/src/main/pages/che-7/overview/proc_using-codeready-containers-to-set-up-openshift-4.adoc
+++ b/src/main/pages/che-7/overview/proc_using-codeready-containers-to-set-up-openshift-4.adoc
@@ -14,7 +14,7 @@ This section describes how to use CodeReady Containers to set up OpenShift 4.
 . Set up your host machine for CodeReady Containers:
 +
 ----
-crc setup
+$ crc setup
 ----
 
 . Remove any previous cluster
@@ -26,7 +26,7 @@ $ crc delete
 . Start the CodeReady Containers virtual machine with at least 12 GB of RAM.
 +
 ----
-crc start --memory 12288
+$ crc start --memory 12288
 ----
 
 . When prompted, supply your user pull secret.
@@ -36,14 +36,14 @@ crc start --memory 12288
 . Access the OpenShift web console
 +
 ----
-crc console
+$ crc console
 ----
 
 . Log in a first time with the `developer` account (password: `developer`) to initialize a first user using OAuth.
 
 . Log out.
 
-. Log in again with the previously mentionned `kubadmin` user and password.
+. Log in again with the previously mentioned `kubadmin` user and password.
 
 . Follow the procedure for link:{site-baseurl}che-7/installing-che-on-openshift-4-from-operatorhub/[Installing Che on OpenShift 4 from OperatorHub].
 

--- a/src/main/pages/che-7/overview/proc_using-codeready-containers-to-set-up-openshift-4.adoc
+++ b/src/main/pages/che-7/overview/proc_using-codeready-containers-to-set-up-openshift-4.adoc
@@ -31,10 +31,25 @@ crc start --memory 12288
 
 . When prompted, supply your user pull secret.
 
+. Take note of the password for the user `kudadmin` that is displayed at the end of the installation.
+
+. Access the OpenShift web console
++
+----
+crc console
+----
+
+. Log in a first time with the `developer` account (password: `developer`) to initialize a first user using OAuth.
+
+. Log out.
+
+. Log in again with the previously mentionned `kubadmin` user and password.
+
+. Follow the procedure for link:{site-baseurl}che-7/installing-che-on-openshift-4-from-operatorhub/[Installing Che on OpenShift 4 from OperatorHub].
+
 [discrete]
 == Additional resources
 
-* See https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/[Product documentation for Red Hat CodeReady Containers].
+* See link:https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/[Product documentation for Red Hat CodeReady Containers].
 
 * CodeReady Containers on GitHub. See link:https://github.com/code-ready/crc[CodeReady Containers - OpenShift 4 on your Laptop].
-


### PR DESCRIPTION
As OAuth is enabled by default, Che cluster will not be deployed unless one Oauth user is provisionned in OpenShift 4. Make it clear on both OpenShift 4 and CRC preparation documentation/
