### PR TITLE
Add a known issue to che 7.3.0 detailing that users should not instal…

### DIFF
--- a/src/main/pages/che-7/overview/ref_che-7-known-issues.adoc
+++ b/src/main/pages/che-7/overview/ref_che-7-known-issues.adoc
@@ -24,3 +24,14 @@ Issue: link:https://github.com/eclipse/che/issues/13442[]
 * link:https://github.com/eclipse/che/issues/13717[Prevent operator removal while it still has some CRs to manage]
 
 See the full list of link:https://github.com/eclipse/che/issues?&q=is%3Aopen+is%3Aissue+label%3Atarget%2Fche7+label%3Akind%2Fbug[Che 7 issues on GitHub].
+
+
+= Che 7.3.0 known issues
+
+This section contains information about selected existing issues known at the time of the Eclipse Che 7.3.0 release that affect user experience.
+
+== Permission denied errors when installing Eclipse Che in the default namespace
+
+When installing Eclipse Che in the `default` namespace, the proper security contexts and file permissions are not set appropriately, causing the installation to fail.  Users should avoid installing Eclipse Che in the `default` namespace, and instead create a new namespace, e.g. `che`, to house the Eclipse Che installation.
+
+Issue: link:https://github.com/eclipse/che/issues/14426[]

--- a/src/main/pages/che-7/overview/ref_che-7-known-issues.adoc
+++ b/src/main/pages/che-7/overview/ref_che-7-known-issues.adoc
@@ -1,7 +1,13 @@
-[id='che-7.0-known-issues']
-= Che 7.1 known issues
+[id='che-known-issues']
+= Che 7.3 known issues
 
-This section contains information about selected existing issues known at the time of the Eclipse Che 7.0 release that affect user experience.
+This section contains information about selected existing issues known at the time of the Eclipse Che 7.3 release that affect user experience.
+
+== Permission denied errors when installing Eclipse Che in the default namespace
+
+When installing Eclipse Che in the `default` namespace, the proper security contexts and file permissions are not set appropriately, causing the installation to fail.  Users should avoid installing Eclipse Che in the `default` namespace and instead create a new namespace, for example, `che`, to contain the Eclipse Che installation.
+
+Issue: link:https://github.com/eclipse/che/issues/14426[]
 
 
 == Language-support plug-ins potential malfunction
@@ -20,18 +26,6 @@ Issue: link:https://github.com/eclipse/che/issues/13442[]
 
 == Other issues
 
-* link:https://github.com/eclipse/che/issues/13607[PKIX error and impossible to start workspaces on OCP 4.1]
 * link:https://github.com/eclipse/che/issues/13717[Prevent operator removal while it still has some CRs to manage]
 
 See the full list of link:https://github.com/eclipse/che/issues?&q=is%3Aopen+is%3Aissue+label%3Atarget%2Fche7+label%3Akind%2Fbug[Che 7 issues on GitHub].
-
-
-= Che 7.3.0 known issues
-
-This section contains information about selected existing issues known at the time of the Eclipse Che 7.3.0 release that affect user experience.
-
-== Permission denied errors when installing Eclipse Che in the default namespace
-
-When installing Eclipse Che in the `default` namespace, the proper security contexts and file permissions are not set appropriately, causing the installation to fail.  Users should avoid installing Eclipse Che in the `default` namespace, and instead create a new namespace, e.g. `che`, to house the Eclipse Che installation.
-
-Issue: link:https://github.com/eclipse/che/issues/14426[]


### PR DESCRIPTION
…l Che in the default namespace

Signed-off-by: Tom George <tg82490@gmail.com>

### What does this PR do?

This issue adds a known issue to 7.3.0 about installing Che in the `default` openshift namespace.  Users should instead install Che in a new namespace specifically for Che.


### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/14426
