### PR TITLE
Update che4z-installing.adoc

### DIFF
--- a/src/main/pages/che-7/extensions/che4z-installing.adoc
+++ b/src/main/pages/che-7/extensions/che4z-installing.adoc
@@ -13,8 +13,6 @@ summary:
 
 :context: installing-che4z
 
-To download and install the Eclipse Che4z plugins, follow the instructions at the link: https://projects.eclipse.org/projects/ecd.che.che4z/downloads[Eclipse Che4z page].
-
 .Prerequisites
 
 - Minimum of 2 CPUs and 4GB RAM


### PR DESCRIPTION
Removed redundant link

Signed-off-by: Daniel Statham <Daniel.Statham@Broadcom.com>

### What does this PR do?
Removes redundant link from Che4z install guide Doc. Link currently points to same info already contained in the doc

### What issues does this PR fix or reference?
#15073