### PR TITLE
fix reference to {context} in a link

### DIFF
--- a/src/main/pages/che-7/end-user-guide/con_che-theia-plug-in-concept-in-detail.adoc
+++ b/src/main/pages/che-7/end-user-guide/con_che-theia-plug-in-concept-in-detail.adoc
@@ -81,4 +81,4 @@ An Eclipse Theia plug-in:: You can build a Che-Theia plug-in by implementing an 
 
 .Additional resources
 
-* xref:embedded-and-remote-che-theia-plug-ins_what-is-a-che-theia-plug-in[]
+* xref:embedded-and-remote-che-theia-plug-ins_{context}[]


### PR DESCRIPTION
fix reference to {context} in a link to make reusable.