### PR TITLE
Nov13

### DIFF
--- a/src/main/pages/che-7/extensions/che4z-installing.adoc
+++ b/src/main/pages/che-7/extensions/che4z-installing.adoc
@@ -17,7 +17,7 @@ This page describes how to install the Eclipse Che4z basic stack.
 
 .Prerequisites
 
-* Eclipse Che 7.3.0
+* Eclipse Che 7.3.0 on Kubernetes
 
 .Procedure 
 

--- a/src/main/pages/che-7/extensions/che4z-installing.adoc
+++ b/src/main/pages/che-7/extensions/che4z-installing.adoc
@@ -25,7 +25,7 @@ This page describes how to install the Eclipse Che4z basic stack.
 
 . In a web browser, load `++https://++__<YOUR_CHE_HOST>__/f?url=__<DEV_FILE_LOCATION>__`.
 +
-* For the Eclipse Che4z basic stack, use the devfile `https://github.com/eclipse/che-che4z/raw/1.0.0/mainframe-basic-stack.yaml`
+* For the Eclipse Che4z basic stack, use the `++https://github.com/eclipse/che-che4z/raw/1.0.0/mainframe-basic-stack.yaml++` devfile.
 
 * For a purchased premium stack, use the devfile location specified in the PDF installation guide available from Broadcom Support. Refer to the link:http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside-enterprise/2-0/release-notes.html[Brightside documentation] ("Getting Started" section) for instructions on accessing the PDF.
 

--- a/src/main/pages/che-7/extensions/che4z-installing.adoc
+++ b/src/main/pages/che-7/extensions/che4z-installing.adoc
@@ -27,7 +27,7 @@ This page describes how to install the Eclipse Che4z basic stack.
 +
 * For the Eclipse Che4z basic stack, use the `++https://github.com/eclipse/che-che4z/raw/1.0.0/mainframe-basic-stack.yaml++` devfile.
 
-* For a purchased premium stack, use the devfile location specified in the PDF installation guide available from Broadcom Support. Refer to the link:http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside-enterprise/2-0/release-notes.html[Brightside documentation] ("Getting Started" section) for instructions on accessing the PDF.
+* For a purchased premium stack, use the devfile location specified in the PDF installation guide available from Broadcom Support. See the link:http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside-enterprise/2-0/release-notes.html[Brightside documentation] (the "Getting Started" section) for instructions on accessing the PDF.
 
 . Wait for the workspace to initialize.
 

--- a/src/main/pages/che-7/extensions/che4z-installing.adoc
+++ b/src/main/pages/che-7/extensions/che4z-installing.adoc
@@ -25,9 +25,9 @@ This page describes how to install the Eclipse Che4z basic stack.
 
 . In a web browser, load `++https://++__<YOUR_CHE_HOST>__/f?url=__<DEV_FILE_LOCATION>__`.
 +
-* For the Eclipse Che4z basic stack, use the link:https://github.com/eclipse/che-che4z/raw/1.0.0/mainframe-basic-stack.yaml[`mainframe-basic-stack.yaml`] devfile.
+* For the Eclipse Che4z basic stack, use the devfile `https://github.com/eclipse/che-che4z/raw/1.0.0/mainframe-basic-stack.yaml`
 
-* For a purchased premium stack, use the devfile location specified in the PDF installation guide available from link:https://casupport.broadcom.com/download-center/download-center.html[Broadcom Support].
+* For a purchased premium stack, use the devfile location specified in the PDF installation guide available from Broadcom Support. Refer to the link:http://techdocs.broadcom.com/content/broadcom/techdocs/us/en/ca-mainframe-software/devops/ca-brightside-enterprise/2-0/release-notes.html[Brightside documentation] ("Getting Started" section) for instructions on accessing the PDF.
 
 . Wait for the workspace to initialize.
 


### PR DESCRIPTION
### What does this PR do?
A couple more minor changes to the Che4z installing page:
- link to devfile location reverted to code block showing the full path. A link implies that the user should download the file and this is not the case.
- link to Brightside documentation added, showing instructions for accessing the named PDF.

### What issues does this PR fix or reference?
15165