### PR TITLE
[13886] Reference module for che configmaps fields

### DIFF
--- a/src/main/pages/che-7/installation-guide/assembly_advanced-configuration-options.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_advanced-configuration-options.adoc
@@ -39,4 +39,6 @@ include::proc_configuring-namespace-strategies.adoc[leveloffset=+1]
 
 // include::proc_configuring-che-with-openshift-oauth.adoc[leveloffset=+1]
 
+include::ref_che-configmaps-fields-reference.adoc[leveloffset=+1]
+
 :context: {parent-context-of-advanced-configuration-options}

--- a/src/main/pages/che-7/installation-guide/ref_che-configmaps-fields-reference.adoc
+++ b/src/main/pages/che-7/installation-guide/ref_che-configmaps-fields-reference.adoc
@@ -1,0 +1,100 @@
+// Module included in the following assemblies:
+//
+// assembly_advanced-configuration-options.adoc
+
+[id="che-configmaps-fields-reference_{context}"]
+
+= Che configMaps fields reference 
+
+.`server` settings related to the Che server
+`airGapContainerRegistryHostname`:: Optional hostname or URL to an alternate container registry to pull images from. This value overrides the container registry hostname defined in all default container images involved in a Che deployment. This is particularly useful to install Che in an air-gapped environment.
+`airGapContainerRegistryOrganization`:: Optional repository name of an alternate container registry to pull images from. This value overrides the container registry organization defined in all the default container images involved in a Che deployment. This is particularly useful to install Che in an air-gapped environment.
+`cheImage`:: Overrides the container image used in Che deployment. This does not include the container image tag. Omit it or leave it empty to use the defaut container image provided by the Operator.
+`cheImageTag`:: Overrides the tag of the container image used in Che deployment. Omit it or leave it empty to use the default image tag provided by the Operator.
+`cheImagePullPolicy`:: Overrides the image pull policy used in Che deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+`cheFlavor`:: Flavor of the installation. The default value is `che` for upstream Che installations and `codeready` for CodeReady Workspaces installation.
+`cheHost`:: Public hostname of the installed Che server. The Operator automatically sets the value.
+`cheLogLevel`:: Log level for the Che server: `INFO` or `DEBUG`. Defaults to `INFO`.
+`cheDebug`:: Enables the debug mode for Che server. Defaults to `false`.
+`cheWorkspaceClusterRole`:: Custom cluster role bound to the user for the Che workspaces. Omit or leave empty to use the default roles.
+`selfSignedCert`:: Enables the support of OpenShift clusters with routers that use self-signed certificates. When enabled, the Operator retrieves the default self-signed certificate of OpenShift routes and adds it to the Java trust store of the Che server. Required when activating the `tlsSupport` field on demo OpenShift clusters that have not been setup with a valid certificate for the routes. Disabled by default.
+`tlsSupport`:: Instructs the Operator to deploy Che in TLS mode. Disabled by default.
+WARNING: Enabling TLS requires enabling the `selfSignedCert` field. 
+`devfileRegistryUrl`:: Public URL of the Devfile registry that serves sample, ready-to-use devfiles. Set it if you use an external devfile registry (see the `externalDevfileRegistry` field). The Operator automatically sets the value. 
+`devfileRegistryImage`:: Overrides the container image used in the Devfile registry deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+`devfileRegistryPullPolicy`:: Overrides the image pull policy used in the Devfile registry deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+`devfileRegistryMemoryLimit`:: Overrides the memory limit used in the Devfile registry deployment. Defaults to 256Mi.
+`devfileRegistryMemoryRequest`:: Overrides the memory request used in the Devfile registry deployment. Defaults to 16Mi.
+`externalDevfileRegistry`:: Instructs the Operator to deploy a dedicated Devfile registry server. By default a dedicated devfile registry server is started. If `externalDevfileRegistry` set to `true`, the Operator does not start a dedicated registry server automatically and you need to set the `devfileRegistryUrl` field manually.
+`pluginRegistryUrl`:: Public URL of the Plugin registry that serves sample ready-to-use devfiles. Set it only when using an external devfile registry (see the `externalPluginRegistry` field). By default, the Operator sets the value automatically.
+`pluginRegistryImage`:: Overrides the container image used in the Plugin registry deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+`pluginRegistryPullPolicy`::  Overrides the image pull policy used in the Plugin registry deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+`pluginRegistryMemoryLimit`:: Overrides the memory limit used in the Plugin registry deployment. Defaults to 256Mi.
+`pluginRegistryMemoryRequest`::  Overrides the memory request used in the Plugin registry deployment. Defaults to 16Mi.
+`externalPluginRegistry`:: Instructs the Operator to deploy a dedicated Plugin registry server. By default, a dedicated plugin registry server is started. If `externalPluginRegistry` set to `true`, the Operator does not deploy a dedicated server automatically and you need to set the `pluginRegistryUrl` field manually.
+`customCheProperties`:: Map of additional environment variables that will be applied in the generated `che` config map to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If `customCheProperties` contains a property that would be normally generated in `che` config map from other CR fields, then the value defined in the `customCheProperties` will be used instead.
+`proxyURL`:: URL (protocol+hostname) of the proxy server. This drives the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy` variables in the Che server and workspaces containers. Only use when configuring a proxy is required.
+`proxyPort`:: Port of the proxy server. Only use when configuring a proxy is required (see also the `proxyURL` field). 
+`nonProxyHosts`:: List of hosts that should not use the configured proxy. Use `|`` as delimiter, eg `localhost|my.host.com|123.42.12.32` Only use when configuring a proxy is required (see also the `proxyURL` field).
+`proxyUser`::  User name of the proxy server. Only use when configuring a proxy is required (see also the `proxyURL` field).
+`proxyPassword`:: Password of the proxy server.  Only use when proxy configuration is required.
+`serverMemoryRequest`::  Overrides the memory request used in the Che server deployment. Defaults to 512Mi.
+`serverMemoryLimit`:: Overrides the memory limit used in the Che server deployment. Defaults to 1Gi.
+
+.`database` configuration settings related to the database used by the Che
+`externalDb`:: Instructs the Operator to deploy a dedicated database. By default, a dedicated Postgres database is deployed as part of the Che installation. If set to `true`, the Operator does not deploy a dedicated database automatically, you need to provide connection details to an external database. See all the fields starting with: `chePostgres`.
+`chePostgresHostName`:: Postgres Database hostname that the Che server uses to connect to. Defaults to postgres. Override this value only when using an external database. (See the field `externalDb`.) By default, the Operator sets the value automatically.
+`chePostgresPort`:: Postgres Database port that the Che server uses to connect to. Defaults to `5432`. Override this value only when using an external database (see field `externalDb`). By default, the Operator sets the value automatically.
+`chePostgresUser`:: Postgres user that the Che server uses to connect to the database. Defaults to `pgche`.
+`chePostgresPassword` Postgres password that the Che server uses to connect to the database. Omit or leave empty to set an auto-generated value.
+`chePostgresDb`:: Postgres database name that the Che server uses to connect to the database. Defaults to `dbche`.
+`postgresImage`:: Overrides the container image used in the Postgres database deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+`postgresImagePullPolicy`:: Overrides the image pull policy used in the Postgres database deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+
+.`auth` configuration settings related to the Authentication used by the Che installation.
+`externalIdentityProvider`:: By default, a dedicated Identity Provider server is deployed as part of the Che installation. But if `externalIdentityProvider` is `true`, then no dedicated identity provider will be deployed by the operator and you might need to provide details about the external identity provider you want to use. See also all the other fields starting with: `identityProvider`.
+`identityProviderURL`:: Instructs the Operator to deploy a dedicated Identity Provider (Keycloak or RH SSO instance). Public URL of the Identity Provider server (Keycloak / RH SSO server). Set it only when using an external Identity Provider (see the `externalIdentityProvider` field). By default, the Operator sets the value automatically.
+`identityProviderAdminUserName` Overrides the name of the Identity Provider admin user. Defaults to `admin`.
+`identityProviderPassword`:: Overrides the password of Keycloak admin user. Override it only when using an external Identity Provider (see the `externalIdentityProvider` field). Omit or leave empty to set an auto-generated password. 
+`identityProviderRealm`:: Name of an Identity provider (Keycloak / RH SSO) realm. Override it only when using an external Identity Provider (see the `externalIdentityProvider` field). Omit or leave empty blank to set it to the value of the `flavor` field.
+`identityProviderClientId`:: Name of a Identity provider (Keycloak / RH SSO) `client-id` that should be used for Che. This is useful to override it ONLY if you use an external Identity Provider (see the `externalIdentityProvider` field). If omitted or left blank, it will be set to the value of the `flavor` field suffixed with `-public`.
+`identityProviderPostgresPassword`:: Password for The Identity Provider (Keycloak / RH SSO) to connect to the database. This is useful to override it ONLY if you use an external Identity Provider (see the `externalIdentityProvider` field). If omitted or left blank, it will be set to an auto-generated password.
+`updateAdminPassword`:: Forces the default `admin` Che user to update password on first login. Defaults to `false`.
+`openShiftoAuth`:: Enables the integration of the identity provider (Keycloak / RHSSO) with OpenShift OAuth. Enabled by default on OpenShift. This allows users to login with their Openshift login and have their workspaces created under personnal OpenShift namespaces.
+WARNING: The `kuebadmin` user is not supported, and logging through does not allow access to the Che Dashboard.
+`oAuthClientName`:: Name of the OpenShift `OAuthClient` resource used to setup identity federation on the OpenShift side. Auto-generated if left blank. See also the `OpenShiftoAuth` field.
+`oAuthSecret`:: Name of the secret set in the OpenShift `OAuthClient` resource used to setup identity federation on the OpenShift side. Auto-generated if left blank. See also the `OAuthClientName` field.
+`identityProviderImage`:: Overrides the container image used in the Identity Provider (Keycloak / RH SSO) deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+`identityProviderImagePullPolicy`:: Overrides the image pull policy used in the Identity Provider (Keycloak / RH SSO) deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+
+.`storage` configuration settings related to the persistent storage used by the Che
+`pvcStrategy`:: This Can be:`common` (all workspaces PVCs in one volume), `per-workspace` (one PVC per workspace for all declared volumes) and `unique` (one PVC per declared volume). Defaults to `common`.
+`pvcClaimSize`:: Size of the persistent volume claim for workspaces. Defaults to `1Gi`.
+`preCreateSubPaths`:: Instructs the Che server to launch a special Pod to pre-create a subpath in the Persistent Volumes. Defaults to `false`. Enable it according to the configuration of your K8S cluster.
+`pvcJobsImage`:: Overrides the container image used to create sub-paths in the Persistent Volumes. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator. See also the `preCreateSubPaths` field.
+`postgresPVCStorageClassName`:: Storage class for the Persistent Volume Claim dedicated to the Postgres database. Omitted or leave empty to use a default storage class.
+`workspacePVCStorageClassName`:: Storage class for the Persistent Volume Claims dedicated to the Che workspaces. Omit or leave empty to use a default storage class.
+
+.`k8s` Configuration settings specific to Che installations made on upstream Kubernetes.
+`ingressDomain`:: Global ingress domain for a K8S cluster. No default values. This fiels must be explicitly specified.
+`ingressStrategy` Strategy for ingress creation. This can be `multi-host` (host is explicitly provided in ingress), `single-host` (host is provided, path-based rules) and `default-host.*`(no host is provided, path-based rules). Defaults to `multi-host`.
+`ingressClass` Ingress class that defines which controller manages ingresses. Defaults to `nginx`.
+NOTE: This drives the `is kubernetes.io/ingress.class` annotation on Che-related ingresses.
+`tlsSecretName`:: Name of a secret that is used to set ingress TLS termination if TLS is enabled. See also the `tlsSupport` field.
+`securityContextFsGroup,omitempty`:: FSGroup the Che Pod and Workspace Pods containers should run in. Defaults to `1724`.
+`securityContextRunAsUser`:: ID of the user the Che Pod and Workspace Pods containers should run as. Defaults to `1724`.
+
+.`installation` defines the observed state of Che installation
+
+`dbProvisioned`:: Indicates whether a Postgres instance has been correctly provisioned.
+`keycloakProvisioned`:: Indicates whether an Identity Provider instance (Keycloak / RH SSO) has been provisioned with realm, client and user. 
+`openShiftoAuthProvisioned`:: Indicates whether an Identity Provider instance (Keycloak / RH SSO) has been configured to integrate with the OpenShift OAuth.
+`cheClusterRunning`:: Status of a Che installation. Can be `Available`, `Unavailable`, or `Available, Rolling Update in Progress`.
+`cheVersion`:: Currently installed Che version.
+`cheURL`:: Public URL to the Che server.
+`keycloakURL`:: Public URL to the Identity Provider server (Keycloak / RH SSO).
+`devfileRegistryURL`:: Public URL to the Devfile registry.
+`pluginRegistryURL`:: Public URL to the Plugin registry.
+`message`:: A human-readable message with details about why the Pod is in this state.
+`reason`:: A brief CamelCase message with details about why the Pod is in this state.
+`helpLink`:: A URL to where to find help related to the current Operator status.

--- a/src/main/pages/che-7/installation-guide/ref_che-configmaps-fields-reference.adoc
+++ b/src/main/pages/che-7/installation-guide/ref_che-configmaps-fields-reference.adoc
@@ -6,95 +6,109 @@
 
 = Che configMaps fields reference 
 
-.`server` settings related to the Che server
+== `server` settings related to the Che server
+
 `airGapContainerRegistryHostname`:: Optional hostname or URL to an alternate container registry to pull images from. This value overrides the container registry hostname defined in all default container images involved in a Che deployment. This is particularly useful to install Che in an air-gapped environment.
 `airGapContainerRegistryOrganization`:: Optional repository name of an alternate container registry to pull images from. This value overrides the container registry organization defined in all the default container images involved in a Che deployment. This is particularly useful to install Che in an air-gapped environment.
-`cheImage`:: Overrides the container image used in Che deployment. This does not include the container image tag. Omit it or leave it empty to use the defaut container image provided by the Operator.
-`cheImageTag`:: Overrides the tag of the container image used in Che deployment. Omit it or leave it empty to use the default image tag provided by the Operator.
-`cheImagePullPolicy`:: Overrides the image pull policy used in Che deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+`cheDebug`:: Enables the debug mode for Che server. Defaults to `false`.
 `cheFlavor`:: Flavor of the installation. The default value is `che` for upstream Che installations and `codeready` for CodeReady Workspaces installation.
 `cheHost`:: Public hostname of the installed Che server. The Operator automatically sets the value.
+`cheImagePullPolicy`:: Overrides the image pull policy used in Che deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+`cheImageTag`:: Overrides the tag of the container image used in Che deployment. Omit it or leave it empty to use the default image tag provided by the Operator.
+`cheImage`:: Overrides the container image used in Che deployment. This does not include the container image tag. Omit it or leave it empty to use the defaut container image provided by the Operator.
 `cheLogLevel`:: Log level for the Che server: `INFO` or `DEBUG`. Defaults to `INFO`.
-`cheDebug`:: Enables the debug mode for Che server. Defaults to `false`.
 `cheWorkspaceClusterRole`:: Custom cluster role bound to the user for the Che workspaces. Omit or leave empty to use the default roles.
-`selfSignedCert`:: Enables the support of OpenShift clusters with routers that use self-signed certificates. When enabled, the Operator retrieves the default self-signed certificate of OpenShift routes and adds it to the Java trust store of the Che server. Required when activating the `tlsSupport` field on demo OpenShift clusters that have not been setup with a valid certificate for the routes. Disabled by default.
-`tlsSupport`:: Instructs the Operator to deploy Che in TLS mode. Disabled by default.
-WARNING: Enabling TLS requires enabling the `selfSignedCert` field. 
-`devfileRegistryUrl`:: Public URL of the Devfile registry that serves sample, ready-to-use devfiles. Set it if you use an external devfile registry (see the `externalDevfileRegistry` field). The Operator automatically sets the value. 
+`customCheProperties`:: Map of additional environment variables that will be applied in the generated `che` config map to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If `customCheProperties` contains a property that would be normally generated in `che` config map from other CR fields, then the value defined in the `customCheProperties` will be used instead.
 `devfileRegistryImage`:: Overrides the container image used in the Devfile registry deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
-`devfileRegistryPullPolicy`:: Overrides the image pull policy used in the Devfile registry deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
 `devfileRegistryMemoryLimit`:: Overrides the memory limit used in the Devfile registry deployment. Defaults to 256Mi.
 `devfileRegistryMemoryRequest`:: Overrides the memory request used in the Devfile registry deployment. Defaults to 16Mi.
+`devfileRegistryPullPolicy`:: Overrides the image pull policy used in the Devfile registry deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+`devfileRegistryUrl`:: Public URL of the Devfile registry that serves sample, ready-to-use devfiles. Set it if you use an external devfile registry (see the `externalDevfileRegistry` field). The Operator automatically sets the value. 
 `externalDevfileRegistry`:: Instructs the Operator to deploy a dedicated Devfile registry server. By default a dedicated devfile registry server is started. If `externalDevfileRegistry` set to `true`, the Operator does not start a dedicated registry server automatically and you need to set the `devfileRegistryUrl` field manually.
-`pluginRegistryUrl`:: Public URL of the Plugin registry that serves sample ready-to-use devfiles. Set it only when using an external devfile registry (see the `externalPluginRegistry` field). By default, the Operator sets the value automatically.
+`externalPluginRegistry`:: Instructs the Operator to deploy a dedicated Plugin registry server. By default, a dedicated plugin registry server is started. If `externalPluginRegistry` set to `true`, the Operator does not deploy a dedicated server automatically and you need to set the `pluginRegistryUrl` field manually.
+`nonProxyHosts`:: List of hosts that should not use the configured proxy. Use `|`` as delimiter, eg `localhost|my.host.com|123.42.12.32` Only use when configuring a proxy is required (see also the `proxyURL` field).
 `pluginRegistryImage`:: Overrides the container image used in the Plugin registry deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
-`pluginRegistryPullPolicy`::  Overrides the image pull policy used in the Plugin registry deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
 `pluginRegistryMemoryLimit`:: Overrides the memory limit used in the Plugin registry deployment. Defaults to 256Mi.
 `pluginRegistryMemoryRequest`::  Overrides the memory request used in the Plugin registry deployment. Defaults to 16Mi.
-`externalPluginRegistry`:: Instructs the Operator to deploy a dedicated Plugin registry server. By default, a dedicated plugin registry server is started. If `externalPluginRegistry` set to `true`, the Operator does not deploy a dedicated server automatically and you need to set the `pluginRegistryUrl` field manually.
-`customCheProperties`:: Map of additional environment variables that will be applied in the generated `che` config map to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If `customCheProperties` contains a property that would be normally generated in `che` config map from other CR fields, then the value defined in the `customCheProperties` will be used instead.
-`proxyURL`:: URL (protocol+hostname) of the proxy server. This drives the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy` variables in the Che server and workspaces containers. Only use when configuring a proxy is required.
-`proxyPort`:: Port of the proxy server. Only use when configuring a proxy is required (see also the `proxyURL` field). 
-`nonProxyHosts`:: List of hosts that should not use the configured proxy. Use `|`` as delimiter, eg `localhost|my.host.com|123.42.12.32` Only use when configuring a proxy is required (see also the `proxyURL` field).
-`proxyUser`::  User name of the proxy server. Only use when configuring a proxy is required (see also the `proxyURL` field).
+`pluginRegistryPullPolicy`::  Overrides the image pull policy used in the Plugin registry deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+`pluginRegistryUrl`:: Public URL of the Plugin registry that serves sample ready-to-use devfiles. Set it only when using an external devfile registry (see the `externalPluginRegistry` field). By default, the Operator sets the value automatically.
 `proxyPassword`:: Password of the proxy server.  Only use when proxy configuration is required.
-`serverMemoryRequest`::  Overrides the memory request used in the Che server deployment. Defaults to 512Mi.
+`proxyPort`:: Port of the proxy server. Only use when configuring a proxy is required (see also the `proxyURL` field). 
+`proxyURL`:: URL (protocol+hostname) of the proxy server. This drives the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy` variables in the Che server and workspaces containers. Only use when configuring a proxy is required.
+`proxyUser`::  User name of the proxy server. Only use when configuring a proxy is required (see also the `proxyURL` field).
+`selfSignedCert`:: Enables the support of OpenShift clusters with routers that use self-signed certificates. When enabled, the Operator retrieves the default self-signed certificate of OpenShift routes and adds it to the Java trust store of the Che server. Required when activating the `tlsSupport` field on demo OpenShift clusters that have not been setup with a valid certificate for the routes. Disabled by default.
 `serverMemoryLimit`:: Overrides the memory limit used in the Che server deployment. Defaults to 1Gi.
+`serverMemoryRequest`::  Overrides the memory request used in the Che server deployment. Defaults to 512Mi.
+`tlsSupport`:: Instructs the Operator to deploy Che in TLS mode. Disabled by default.
++
+WARNING: Enabling TLS requires enabling the `selfSignedCert` field. 
 
-.`database` configuration settings related to the database used by the Che
-`externalDb`:: Instructs the Operator to deploy a dedicated database. By default, a dedicated Postgres database is deployed as part of the Che installation. If set to `true`, the Operator does not deploy a dedicated database automatically, you need to provide connection details to an external database. See all the fields starting with: `chePostgres`.
+
+== `database` configuration settings related to the database used by Che
+
+`chePostgresDb`:: Postgres database name that the Che server uses to connect to the database. Defaults to `dbche`.
 `chePostgresHostName`:: Postgres Database hostname that the Che server uses to connect to. Defaults to postgres. Override this value only when using an external database. (See the field `externalDb`.) By default, the Operator sets the value automatically.
+`chePostgresPassword` Postgres password that the Che server uses to connect to the database. Omit or leave empty to set an auto-generated value.
 `chePostgresPort`:: Postgres Database port that the Che server uses to connect to. Defaults to `5432`. Override this value only when using an external database (see field `externalDb`). By default, the Operator sets the value automatically.
 `chePostgresUser`:: Postgres user that the Che server uses to connect to the database. Defaults to `pgche`.
-`chePostgresPassword` Postgres password that the Che server uses to connect to the database. Omit or leave empty to set an auto-generated value.
-`chePostgresDb`:: Postgres database name that the Che server uses to connect to the database. Defaults to `dbche`.
-`postgresImage`:: Overrides the container image used in the Postgres database deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+`externalDb`:: Instructs the Operator to deploy a dedicated database. By default, a dedicated Postgres database is deployed as part of the Che installation. If set to `true`, the Operator does not deploy a dedicated database automatically, you need to provide connection details to an external database. See all the fields starting with: `chePostgres`.
 `postgresImagePullPolicy`:: Overrides the image pull policy used in the Postgres database deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+`postgresImage`:: Overrides the container image used in the Postgres database deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
 
-.`auth` configuration settings related to the Authentication used by the Che installation.
+
+== `auth` configuration settings related to authentication used by Che installation
+
 `externalIdentityProvider`:: By default, a dedicated Identity Provider server is deployed as part of the Che installation. But if `externalIdentityProvider` is `true`, then no dedicated identity provider will be deployed by the operator and you might need to provide details about the external identity provider you want to use. See also all the other fields starting with: `identityProvider`.
-`identityProviderURL`:: Instructs the Operator to deploy a dedicated Identity Provider (Keycloak or RH SSO instance). Public URL of the Identity Provider server (Keycloak / RH SSO server). Set it only when using an external Identity Provider (see the `externalIdentityProvider` field). By default, the Operator sets the value automatically.
 `identityProviderAdminUserName` Overrides the name of the Identity Provider admin user. Defaults to `admin`.
-`identityProviderPassword`:: Overrides the password of Keycloak admin user. Override it only when using an external Identity Provider (see the `externalIdentityProvider` field). Omit or leave empty to set an auto-generated password. 
-`identityProviderRealm`:: Name of an Identity provider (Keycloak / RH SSO) realm. Override it only when using an external Identity Provider (see the `externalIdentityProvider` field). Omit or leave empty blank to set it to the value of the `flavor` field.
 `identityProviderClientId`:: Name of a Identity provider (Keycloak / RH SSO) `client-id` that should be used for Che. This is useful to override it ONLY if you use an external Identity Provider (see the `externalIdentityProvider` field). If omitted or left blank, it will be set to the value of the `flavor` field suffixed with `-public`.
+`identityProviderImagePullPolicy`:: Overrides the image pull policy used in the Identity Provider (Keycloak / RH SSO) deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+`identityProviderImage`:: Overrides the container image used in the Identity Provider (Keycloak / RH SSO) deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+`identityProviderPassword`:: Overrides the password of Keycloak admin user. Override it only when using an external Identity Provider (see the `externalIdentityProvider` field). Omit or leave empty to set an auto-generated password. 
 `identityProviderPostgresPassword`:: Password for The Identity Provider (Keycloak / RH SSO) to connect to the database. This is useful to override it ONLY if you use an external Identity Provider (see the `externalIdentityProvider` field). If omitted or left blank, it will be set to an auto-generated password.
-`updateAdminPassword`:: Forces the default `admin` Che user to update password on first login. Defaults to `false`.
-`openShiftoAuth`:: Enables the integration of the identity provider (Keycloak / RHSSO) with OpenShift OAuth. Enabled by default on OpenShift. This allows users to login with their Openshift login and have their workspaces created under personnal OpenShift namespaces.
-WARNING: The `kuebadmin` user is not supported, and logging through does not allow access to the Che Dashboard.
+`identityProviderRealm`:: Name of an Identity provider (Keycloak / RH SSO) realm. Override it only when using an external Identity Provider (see the `externalIdentityProvider` field). Omit or leave empty blank to set it to the value of the `flavor` field.
+`identityProviderURL`:: Instructs the Operator to deploy a dedicated Identity Provider (Keycloak or RH SSO instance). Public URL of the Identity Provider server (Keycloak / RH SSO server). Set it only when using an external Identity Provider (see the `externalIdentityProvider` field). By default, the Operator sets the value automatically.
 `oAuthClientName`:: Name of the OpenShift `OAuthClient` resource used to setup identity federation on the OpenShift side. Auto-generated if left blank. See also the `OpenShiftoAuth` field.
 `oAuthSecret`:: Name of the secret set in the OpenShift `OAuthClient` resource used to setup identity federation on the OpenShift side. Auto-generated if left blank. See also the `OAuthClientName` field.
-`identityProviderImage`:: Overrides the container image used in the Identity Provider (Keycloak / RH SSO) deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
-`identityProviderImagePullPolicy`:: Overrides the image pull policy used in the Identity Provider (Keycloak / RH SSO) deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+`openShiftoAuth`:: Enables the integration of the identity provider (Keycloak / RHSSO) with OpenShift OAuth. Enabled by default on OpenShift. This allows users to login with their Openshift login and have their workspaces created under personnal OpenShift namespaces.
++
+WARNING: The `kuebadmin` user is not supported, and logging through does not allow access to the Che Dashboard.
 
-.`storage` configuration settings related to the persistent storage used by the Che
-`pvcStrategy`:: This Can be:`common` (all workspaces PVCs in one volume), `per-workspace` (one PVC per workspace for all declared volumes) and `unique` (one PVC per declared volume). Defaults to `common`.
-`pvcClaimSize`:: Size of the persistent volume claim for workspaces. Defaults to `1Gi`.
-`preCreateSubPaths`:: Instructs the Che server to launch a special Pod to pre-create a subpath in the Persistent Volumes. Defaults to `false`. Enable it according to the configuration of your K8S cluster.
-`pvcJobsImage`:: Overrides the container image used to create sub-paths in the Persistent Volumes. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator. See also the `preCreateSubPaths` field.
+`updateAdminPassword`:: Forces the default `admin` Che user to update password on first login. Defaults to `false`.
+
+== `storage` configuration settings related to persistent storage used by Che
+
 `postgresPVCStorageClassName`:: Storage class for the Persistent Volume Claim dedicated to the Postgres database. Omitted or leave empty to use a default storage class.
+`preCreateSubPaths`:: Instructs the Che server to launch a special Pod to pre-create a subpath in the Persistent Volumes. Defaults to `false`. Enable it according to the configuration of your K8S cluster.
+`pvcClaimSize`:: Size of the persistent volume claim for workspaces. Defaults to `1Gi`.
+`pvcJobsImage`:: Overrides the container image used to create sub-paths in the Persistent Volumes. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator. See also the `preCreateSubPaths` field.
+`pvcStrategy`:: This Can be:`common` (all workspaces PVCs in one volume), `per-workspace` (one PVC per workspace for all declared volumes) and `unique` (one PVC per declared volume). Defaults to `common`.
 `workspacePVCStorageClassName`:: Storage class for the Persistent Volume Claims dedicated to the Che workspaces. Omit or leave empty to use a default storage class.
 
-.`k8s` Configuration settings specific to Che installations made on upstream Kubernetes.
+
+== `k8s` configuration settings specific to Che installations on Kubernetes
+
+`ingressClass`:: Ingress class that defines which controller manages ingresses. Defaults to `nginx`.
 `ingressDomain`:: Global ingress domain for a K8S cluster. No default values. This fiels must be explicitly specified.
-`ingressStrategy` Strategy for ingress creation. This can be `multi-host` (host is explicitly provided in ingress), `single-host` (host is provided, path-based rules) and `default-host.*`(no host is provided, path-based rules). Defaults to `multi-host`.
-`ingressClass` Ingress class that defines which controller manages ingresses. Defaults to `nginx`.
++
 NOTE: This drives the `is kubernetes.io/ingress.class` annotation on Che-related ingresses.
-`tlsSecretName`:: Name of a secret that is used to set ingress TLS termination if TLS is enabled. See also the `tlsSupport` field.
+
+`ingressStrategy`:: Strategy for ingress creation. This can be `multi-host` (host is explicitly provided in ingress), `single-host` (host is provided, path-based rules) and `default-host.*`(no host is provided, path-based rules). Defaults to `multi-host`.
 `securityContextFsGroup,omitempty`:: FSGroup the Che Pod and Workspace Pods containers should run in. Defaults to `1724`.
 `securityContextRunAsUser`:: ID of the user the Che Pod and Workspace Pods containers should run as. Defaults to `1724`.
+`tlsSecretName`:: Name of a secret that is used to set ingress TLS termination if TLS is enabled. See also the `tlsSupport` field.
 
-.`installation` defines the observed state of Che installation
 
-`dbProvisioned`:: Indicates whether a Postgres instance has been correctly provisioned.
-`keycloakProvisioned`:: Indicates whether an Identity Provider instance (Keycloak / RH SSO) has been provisioned with realm, client and user. 
-`openShiftoAuthProvisioned`:: Indicates whether an Identity Provider instance (Keycloak / RH SSO) has been configured to integrate with the OpenShift OAuth.
+== `installation` defines the observed state of Che installation
+
 `cheClusterRunning`:: Status of a Che installation. Can be `Available`, `Unavailable`, or `Available, Rolling Update in Progress`.
-`cheVersion`:: Currently installed Che version.
 `cheURL`:: Public URL to the Che server.
-`keycloakURL`:: Public URL to the Identity Provider server (Keycloak / RH SSO).
+`cheVersion`:: Currently installed Che version.
+`dbProvisioned`:: Indicates whether a Postgres instance has been correctly provisioned.
 `devfileRegistryURL`:: Public URL to the Devfile registry.
-`pluginRegistryURL`:: Public URL to the Plugin registry.
-`message`:: A human-readable message with details about why the Pod is in this state.
-`reason`:: A brief CamelCase message with details about why the Pod is in this state.
 `helpLink`:: A URL to where to find help related to the current Operator status.
+`keycloakProvisioned`:: Indicates whether an Identity Provider instance (Keycloak / RH SSO) has been provisioned with realm, client and user. 
+`keycloakURL`:: Public URL to the Identity Provider server (Keycloak / RH SSO).
+`message`:: A human-readable message with details about why the Pod is in this state.
+`openShiftoAuthProvisioned`:: Indicates whether an Identity Provider instance (Keycloak / RH SSO) has been configured to integrate with the OpenShift OAuth.
+`pluginRegistryURL`:: Public URL to the Plugin registry.
+`reason`:: A brief CamelCase message with details about why the Pod is in this state.


### PR DESCRIPTION
Signed-off-by: Yana Hontyk <yhontyk@redhat.com>

### What does this PR do?
Added a reference module for configmaps fields.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13886