### PR TITLE
Escape { for non-attributes words (again)

### DIFF
--- a/src/main/pages/che-7/administration-guide/proc_listing-che-permissions.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_listing-che-permissions.adoc
@@ -7,9 +7,9 @@
 
 To list Che permissions that apply to a specific *resource*, perform the `GET /permissions` request.
 
-To list the permissions that apply to a *user*, perform the `GET /permissions/{domain}` request.
+To list the permissions that apply to a *user*, perform the `GET /permissions/\{domain}` request.
 
-To list the permissions that apply to *all users*, perform the `GET /permissions/{domain}/all`  request. The user must have *manageSystem* permissions to see this information. 
+To list the permissions that apply to *all users*, perform the `GET /permissions/\{domain}/all`  request. The user must have *manageSystem* permissions to see this information. 
 
 The suitable domain values are:
 


### PR DESCRIPTION
Ensure that words which are not supposed to be attributes, but are surrounded by braces, are not interpreted as attributes. Second iteration.



