### PR TITLE
Remove section about installing vscode extension in running workspace

### DIFF
--- a/src/main/pages/che-7/end-user-guide/assembly_using-a-visual-studio-code-extension-in-che.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_using-a-visual-studio-code-extension-in-che.adoc
@@ -26,8 +26,6 @@ This document describes:
 ** The extension-hosting sidecar container and the use of the extension in a devfile are optional for this.
 ** How to review the compatibility of the VS Code extensions to be informed whether a specific API is supported or has not been implemented yet.
 
-include::proc_importing-a-vs-code-extension-in-the-che-theia-editor.adoc[leveloffset=+1]
-
 include::assembly_publishing-a-vs-code-extension-into-the-che-plug-in-registry.adoc[leveloffset=+1]
 
 include::assembly_adding-che-plug-in-registry-vs-code-extension-to-a-workspace.adoc[leveloffset=+1]


### PR DESCRIPTION
Remove section about installing vscode extension in running workspace

### What does this PR do?
This PR removes from the documentation a possible use case not compliant with the term of use of the vscode marketplace. 

### What issues does this PR fix or reference?
