### PR TITLE
Document Route/Ingress accessability in restricted netowrk environments

### DIFF
--- a/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
@@ -29,6 +29,11 @@ To deploy {prod-short} in an environment where these external resources are not 
 * Configure {prod-short} to use these images.
 
 
+== Prerequesite Notes on Network Connectivity
+
+Restricted network environments can range from a private subnet in a cloud provider, to a separate network owned by a company, cut off from the public internet.  While your organization's network will be different, Che will work *provided that the Ingress/Routes that are created for the Che components (che-server, keycloak, devfile-registry, plugin-registry) are accessible from inside the Kubernetes cluster).*  You should take into account the network topology of your environment to determine how best to accomplish this.  For example, in a network owned by a company or organization, the network administrators should ensure that traffic bound from the cluster can be routed to Ingress/Route hostnames.  In other cases, e.g. in AWS, you may need to create a proxy configuration allowing the traffic to leave the node to get to an external-facing Load Balancer.
+
+
 [id="building-offline-versions-of-the-plug-in-and-devfile-registry_{context}"]
 == Building offline versions of the plug-in and devfile registry
 

--- a/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
@@ -29,10 +29,11 @@ To deploy {prod-short} in an environment where these external resources are not 
 * Configure {prod-short} to use these images.
 
 
-== Prerequesite Notes on Network Connectivity
+== Notes on network connectivity in restricted environments
 
-Restricted network environments can range from a private subnet in a cloud provider, to a separate network owned by a company, cut off from the public internet.  While your organization's network will be different, Che will work *provided that the Ingress/Routes that are created for the Che components (che-server, keycloak, devfile-registry, plugin-registry) are accessible from inside the Kubernetes cluster).*  You should take into account the network topology of your environment to determine how best to accomplish this.  For example, in a network owned by a company or organization, the network administrators should ensure that traffic bound from the cluster can be routed to Ingress/Route hostnames.  In other cases, e.g. in AWS, you may need to create a proxy configuration allowing the traffic to leave the node to get to an external-facing Load Balancer.
+Restricted network environments range from a private subnet in a cloud provider to a separate network owned by a company, disconnected from the public Internet. Regardless of the network configuration, {prod-short} works *provided that the Ingress and Routes that are created for {prod-short} components ({prod-id-short}-server, keycloak, devfile-registry, plugin-registry) are accessible from inside the Kubernetes or OpenShift cluster.*
 
+Take into account the network topology of the environment to determine how best to accomplish this. For example, on a network owned by a company or an organization, the network administrators must ensure that traffic bound from the cluster can be routed to Ingress and Route hostnames. In other cases, for example, on AWS, create a proxy configuration allowing the traffic to leave the node to reach an external-facing Load Balancer.
 
 [id="building-offline-versions-of-the-plug-in-and-devfile-registry_{context}"]
 == Building offline versions of the plug-in and devfile registry


### PR DESCRIPTION
### What does this PR do?
Documents the requirement of traffic from outside the cluster to be able to reach Route/Ingress hostnames

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15308
https://github.com/eclipse/che/issues/15187