### PR TITLE
Add Preview URL preferences documentation

### DIFF
--- a/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
+++ b/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
@@ -758,16 +758,18 @@ commands:
 
 The example above opens `++http://__<server-domain>__/myweb++`, where `_<server-domain>_` is the URL to the dynamically created Kubernetes Ingress or OpenShift Route.
 
-By default the notification is displayed to ask a user how a URL should be opened.
-You can specify the preferred way of previewing a service URL by using preferences.
-To set your choice open {prod-short} preferences from *File* -> *Settings* -> *Open Preferences* and find `che.task.preview.notifications` in the `Che` section.
+==== Setting the default way of opening preview URLs
 
-Here is the list of possible values:
+By default, a notification is displayed to ask the user how the URL should be opened. To specify the preferred way of previewing a service URL, use preferences.
 
-* `on` value enables a notification to ask a user how a URL should be opened
-* `alwaysPreview` value tells IDE to open a preview URL automatically in the Preview panel as soon as a task is running
-* `alwaysGoTo` value tells IDE to open a preview URL automatically in a separate browser's tab as soon as a task is running
-* `off` value disables opening a preview URL (automatically and with a notification)
+. Open {prod-short} preferences in *File -> Settings -> Open Preferences* and find `che.task.preview.notifications` in the *Che* section.
+
+. Choose from the list of possible values:
++
+* `on` -- enables a notification to ask the user how the URL should be opened
+* `alwaysPreview` -- the preview URL opens automatically in the *Preview* panel as soon as a task is running
+* `alwaysGoTo` -- the preview URL opens automatically in a separate browser tab as soon as a task is running
+* `off` -- disables opening the preview URL (automatically and with a notification)
 
 
 == Devfile attributes

--- a/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
+++ b/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
@@ -758,6 +758,18 @@ commands:
 
 The example above opens `++http://__<server-domain>__/myweb++`, where `_<server-domain>_` is the URL to the dynamically created Kubernetes Ingress or OpenShift Route.
 
+By default the notification is displayed to ask a user how a URL should be opened.
+You can specify the preferred way of previewing a service URL by using preferences.
+To set your choice open {prod-short} preferences from *File* -> *Settings* -> *Open Preferences* and find `che.task.preview.notifications` in the `Che` section.
+
+Here is the list of possible values:
+
+* `on` value enables a notification to ask a user how a URL should be opened
+* `alwaysPreview` value tells IDE to open a preview URL automatically in the Preview panel as soon as a task is running
+* `alwaysGoTo` value tells IDE to open a preview URL automatically in a separate browser's tab as soon as a task is running
+* `off` value disables opening a preview URL (automatically and with a notification)
+
+
 == Devfile attributes
 
 Devfile attributes can be used to configure various features.


### PR DESCRIPTION
### What does this PR do?
Add documentation related to Preview URL preferences

![preview_doc](https://user-images.githubusercontent.com/5676062/69577973-308b2780-0fd8-11ea-9abe-d8defb44cda0.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14999

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>