### PR TITLE
Ifdef super-priv mode to limit to Che.

### DIFF
--- a/src/main/pages/che-7/administration-guide/assembly_authorizing-users.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_authorizing-users.adoc
@@ -39,7 +39,9 @@ include::ref_managesystem-permission.adoc[leveloffset=+1]
 
 include::ref_monitorsystem-permission.adoc[leveloffset=+1]
 
+ifeval::["{project-context} == "che"]
 include::con_super-privileged-mode.adoc[leveloffset=+1]
+endif::[]
 
 include::proc_listing-che-permissions.adoc[leveloffset=+1]
 


### PR DESCRIPTION
### What does this PR do?

Adds a condition to only include content about super-privileged mode in the Che context.
