### PR TITLE
use latest container image for devfile

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -22,7 +22,7 @@ components:
         port: 35729
     memoryLimit: 1Gi
     type: dockerimage
-    image: 'eclipse/che-docs:latest'
+    image: 'quay.io/eclipse/che-docs:latest'
     alias: che-docs-dev
   - id: joaompinto/vscode-asciidoctor/latest
     type: chePlugin


### PR DESCRIPTION
Latest container has moved to quay.io/eclipse/che-docs
fixes eclipse/che/issues/15546
