### PR TITLE
Add missed headers

### DIFF
--- a/src/main/pages/che-7/administration-guide/examples/che-build-the-devfile-registry.sh
+++ b/src/main/pages/che-7/administration-guide/examples/che-build-the-devfile-registry.sh
@@ -1,1 +1,13 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 $ docker build -t my-devfile-registry .

--- a/src/main/pages/che-7/administration-guide/examples/che-build-the-plug-in-registry.sh
+++ b/src/main/pages/che-7/administration-guide/examples/che-build-the-plug-in-registry.sh
@@ -1,1 +1,13 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 $ docker build -t my-plug-in-registry .

--- a/src/main/pages/che-7/administration-guide/examples/che-clone-the-devfile-registry-repository.sh
+++ b/src/main/pages/che-7/administration-guide/examples/che-clone-the-devfile-registry-repository.sh
@@ -1,2 +1,14 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 $ git clone git@github.com:eclipse/che-devfile-registry.git
 $ cd che-devfile-registry

--- a/src/main/pages/che-7/administration-guide/examples/che-clone-the-plug-in-registry-repository.sh
+++ b/src/main/pages/che-7/administration-guide/examples/che-clone-the-plug-in-registry-repository.sh
@@ -1,2 +1,14 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 $ git clone git@github.com:eclipse/che-plugin-registry.git
 $ cd che-plugin-registry

--- a/src/main/pages/che-7/administration-guide/examples/crw-build-the-devfile-registry.sh
+++ b/src/main/pages/che-7/administration-guide/examples/crw-build-the-devfile-registry.sh
@@ -1,1 +1,13 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 $ docker build -t my-devfile-registry .

--- a/src/main/pages/che-7/administration-guide/examples/crw-build-the-plug-in-registry.sh
+++ b/src/main/pages/che-7/administration-guide/examples/crw-build-the-plug-in-registry.sh
@@ -1,1 +1,13 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 $ docker build -t my-plug-in-registry .

--- a/src/main/pages/che-7/administration-guide/examples/crw-clone-the-devfile-registry-repository.sh
+++ b/src/main/pages/che-7/administration-guide/examples/crw-clone-the-devfile-registry-repository.sh
@@ -1,2 +1,14 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 $ git clone git@github.com:redhat-developer/codeready-workspaces.git
 $ cd codeready-workspaces/che-devfile-registry

--- a/src/main/pages/che-7/administration-guide/examples/crw-clone-the-plug-in-registry-repository.sh
+++ b/src/main/pages/che-7/administration-guide/examples/crw-clone-the-plug-in-registry-repository.sh
@@ -1,2 +1,14 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 $ git clone git@github.com:redhat-developer/codeready-workspaces.git
 $ cd codeready-workspaces/che-plugin-registry


### PR DESCRIPTION
### What does this PR do?
It adds license headers to *.sh files, and so fixes che-docs build error:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.678 s
[INFO] Finished at: 2019-12-23T17:44:33+02:00
[INFO] Final Memory: 26M/1237M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.mycila:license-maven-plugin:3.0:check (check-headers) on project che-docs: Some files do not have the expected license header -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che-docs/pull/998