### PR TITLE
Exclude examples for license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,14 @@
                         <exclude>**/**/*.svg</exclude>
                         <exclude>**/**/*.css</exclude>
                         <exclude>**/**/*.yml</exclude>
+                        <exclude>**/**/*.adoc</exclude>
+                        <exclude>**/**/*.png</exclude>
+                        <exclude>**/**/*.gif</exclude>
+                        <exclude>**/**/*.eot</exclude>
+                        <exclude>**/**/*.ttf</exclude>
+                        <exclude>**/**/*.woff2</exclude>
+                        <exclude>**/examples/*.sh</exclude>
+                        <exclude>**/examples/*</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/src/main/pages/che-7/administration-guide/examples/che-build-the-devfile-registry.sh
+++ b/src/main/pages/che-7/administration-guide/examples/che-build-the-devfile-registry.sh
@@ -1,13 +1,1 @@
-#
-# Copyright (c) 2012-2018 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#   Red Hat, Inc. - initial API and implementation
-#
-
 $ docker build -t my-devfile-registry .

--- a/src/main/pages/che-7/administration-guide/examples/che-build-the-plug-in-registry.sh
+++ b/src/main/pages/che-7/administration-guide/examples/che-build-the-plug-in-registry.sh
@@ -1,13 +1,1 @@
-#
-# Copyright (c) 2012-2018 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#   Red Hat, Inc. - initial API and implementation
-#
-
 $ docker build -t my-plug-in-registry .

--- a/src/main/pages/che-7/administration-guide/examples/che-clone-the-devfile-registry-repository.sh
+++ b/src/main/pages/che-7/administration-guide/examples/che-clone-the-devfile-registry-repository.sh
@@ -1,14 +1,2 @@
-#
-# Copyright (c) 2012-2018 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#   Red Hat, Inc. - initial API and implementation
-#
-
 $ git clone git@github.com:eclipse/che-devfile-registry.git
 $ cd che-devfile-registry

--- a/src/main/pages/che-7/administration-guide/examples/che-clone-the-plug-in-registry-repository.sh
+++ b/src/main/pages/che-7/administration-guide/examples/che-clone-the-plug-in-registry-repository.sh
@@ -1,14 +1,2 @@
-#
-# Copyright (c) 2012-2018 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#   Red Hat, Inc. - initial API and implementation
-#
-
 $ git clone git@github.com:eclipse/che-plugin-registry.git
 $ cd che-plugin-registry

--- a/src/main/pages/che-7/administration-guide/examples/crw-build-the-devfile-registry.sh
+++ b/src/main/pages/che-7/administration-guide/examples/crw-build-the-devfile-registry.sh
@@ -1,13 +1,1 @@
-#
-# Copyright (c) 2012-2018 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#   Red Hat, Inc. - initial API and implementation
-#
-
 $ docker build -t my-devfile-registry .

--- a/src/main/pages/che-7/administration-guide/examples/crw-build-the-plug-in-registry.sh
+++ b/src/main/pages/che-7/administration-guide/examples/crw-build-the-plug-in-registry.sh
@@ -1,13 +1,1 @@
-#
-# Copyright (c) 2012-2018 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#   Red Hat, Inc. - initial API and implementation
-#
-
 $ docker build -t my-plug-in-registry .

--- a/src/main/pages/che-7/administration-guide/examples/crw-clone-the-devfile-registry-repository.sh
+++ b/src/main/pages/che-7/administration-guide/examples/crw-clone-the-devfile-registry-repository.sh
@@ -1,14 +1,2 @@
-#
-# Copyright (c) 2012-2018 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#   Red Hat, Inc. - initial API and implementation
-#
-
 $ git clone git@github.com:redhat-developer/codeready-workspaces.git
 $ cd codeready-workspaces/che-devfile-registry

--- a/src/main/pages/che-7/administration-guide/examples/crw-clone-the-plug-in-registry-repository.sh
+++ b/src/main/pages/che-7/administration-guide/examples/crw-clone-the-plug-in-registry-repository.sh
@@ -1,14 +1,2 @@
-#
-# Copyright (c) 2012-2018 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#   Red Hat, Inc. - initial API and implementation
-#
-
 $ git clone git@github.com:redhat-developer/codeready-workspaces.git
 $ cd codeready-workspaces/che-plugin-registry


### PR DESCRIPTION
As discussed in https://github.com/eclipse/che-docs/pull/1005, not having a license in examples is a feature. 

This PR is adding the required exclude statements to the `pom.xml` file, so that `mvn clean install -U` can run nicely, without errors and warnings.