### PR TITLE
Updating the examples for pulling crw registries, small fixes

### DIFF
--- a/src/main/pages/che-7/administration-guide/assembly_customizing-the-devfile-and-plug-in-registries.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_customizing-the-devfile-and-plug-in-registries.adoc
@@ -21,7 +21,7 @@ The plug-in registry makes it possible to share a plug-in definition across all 
 
 The devfile registry holds the definitions of the {prod-short} stacks. These are available on the {prod-short} user dashboard when selecting *Create Workspace*. It contains the list of {prod-short} technological stack samples with example projects.
 
-The devfile and plug-in registries run in two separate pods and are deployed when the {prod-short} server is deployed (that is the default behavior of the Helm chart or the {prod-short} Operator). The metadata of the plug-ins and devfiles are versioned on GitHub and follow the {prod-short} server life cycle.
+The devfile and plug-in registries run in two separate pods and are deployed when the {prod-short} server is deployed (that is the default behavior of the {prod-short} Operator). The metadata of the plug-ins and devfiles are versioned on GitHub and follow the {prod-short} server life cycle.
 
 In this document, the following two ways to customize the default registries that are deployed with {prod-short} (to modify the plug-ins or devfile metadata) are described:
 

--- a/src/main/pages/che-7/administration-guide/examples/crw-clone-the-devfile-registry-repository.sh
+++ b/src/main/pages/che-7/administration-guide/examples/crw-clone-the-devfile-registry-repository.sh
@@ -1,2 +1,7 @@
-$ git clone git@github.com:redhat-developer/codeready-workspaces.git
-$ cd codeready-workspaces/che-devfile-registry
+$ podman login registry.redhat.io
+Username: ${REGISTRY-SERVICE-ACCOUNT-USERNAME}
+Password: ${REGISTRY-SERVICE-ACCOUNT-PASSWORD}
+Login Succeeded!
+
+$ podman pull registry.redhat.io/codeready-workspaces/devfileregistry-rhel8
+$ cd codeready-workspaces/devfileregistry-rhel8

--- a/src/main/pages/che-7/administration-guide/examples/crw-clone-the-plug-in-registry-repository.sh
+++ b/src/main/pages/che-7/administration-guide/examples/crw-clone-the-plug-in-registry-repository.sh
@@ -1,2 +1,7 @@
-$ git clone git@github.com:redhat-developer/codeready-workspaces.git
-$ cd codeready-workspaces/che-plugin-registry
+$ podman login registry.redhat.io
+Username: ${REGISTRY-SERVICE-ACCOUNT-USERNAME}
+Password: ${REGISTRY-SERVICE-ACCOUNT-PASSWORD}
+Login Succeeded!
+
+$ podman pull registry.redhat.io/codeready-workspaces/pluginregistry-rhel8
+$ cd codeready-workspaces/pluginregistry-rhel8


### PR DESCRIPTION
### What does this PR do?
Updates the example files for pulling plugin and devfile registries for CRW. The registries are distributed via redhat.io, not GH.

### What issues does this PR fix or reference?
