### PR TITLE
move previewurl to stable

### DIFF
--- a/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
+++ b/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
@@ -738,14 +738,10 @@ In addition to the `vscode-task` commands, the Che-Theia editor understands `vsc
 
 === Command preview URL
 
-WARNING: This is a Beta feature. Definition may change in future releases without any warning. It's available in devfile version `1.0.1-beta`.
-
 It is possible to specify a preview URL for commands that expose web UI. This URL is offered for opening when the command is executed.
 
 [source,yaml]
 ----
-apiVersion: 1.0.1-beta
-
 commands:
     - name: tasks
       previewUrl:


### PR DESCRIPTION
### What does this PR do?
Previewurl is moving into stable devfile version 1.0.0 (https://github.com/eclipse/che/pull/15618)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15412