### PR TITLE
Fixing broken link and table formating

### DIFF
--- a/src/main/pages/che-6/user-management/resource-management.adoc
+++ b/src/main/pages/che-6/user-management/resource-management.adoc
@@ -61,11 +61,11 @@ The following are ways to distribute resources to an account:
 [id="configuring-workspaces-and-resources"]
 == Configuring workspaces and resources
 
-The Che administrator can limit how workspaces are created and the resources that these workspaces consume. Detailed information about each property can be found in the https://github.com/eclipse/che/blob/master/dockerfiles/init/manifests/che.env#L538[`che.env`] file.
+The Che administrator can limit how workspaces are created and the resources that these workspaces consume. Detailed information about each property can be found in the https://github.com/eclipse/che/blob/6.19.x/dockerfiles/init/manifests/che.env#L538[`che.env`] file.
 
 See link:docker-config.html[Docker] and link:openshift-config.html[OpenShift] configuration documentation for more information.
 
-[width="100%",cols="33%,8%,6%,53%",options="header",]
+[options="header"]
 |===
 |Property name |Default Value |Unit |Description
 |`CHE_LIMITS_USER_WORKSPACES_COUNT` |-1 |item |maximum number of workspaces that the Che user can create
@@ -73,8 +73,8 @@ See link:docker-config.html[Docker] and link:openshift-config.html[OpenShift] co
 |`CHE_LIMITS_USER_WORKSPACES_RAM` |-1 |memory |maximum amount of RAM that workspaces use
 |`CHE_LIMITS_ORGANIZATION_WORKSPACES_COUNT` |-1 |item |maximum number of workspaces that members of an organization can create
 |`CHE_LIMITS_ORGANIZATION_WORKSPACES_RUN_COUNT` |-1 |item |maximum number of workspaces that members of an organization can simultaneously run
-|`CHE_LIMITS_ORGANIZATION_WORKSPACES_RAM` |-1 |memory |maximum amount of RAM that workspaces from all organizations can simultaneously use 
-|`CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT` |-1 |millisecond |maxium number of workspaces that can stay inactive before they are idled 
+|`CHE_LIMITS_ORGANIZATION_WORKSPACES_RAM` |-1 |memory |maximum amount of RAM that workspaces from all organizations can simultaneously use
+|`CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT` |-1 |millisecond |maxium number of workspaces that can stay inactive before they are idled
 |`CHE_LIMITS_WORKSPACE_ENV_RAM` |16gb |memory |maximum amount of RAM that workspace environment can use simultaneously
 |===
 


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

Fixing broken link and table formating in old docs

Updating the 1.2 guide [1] to link to the 6.19.x branch instead of master [2].

[1] https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/1.2/html-single/administration_guide/index#configuring-workspaces-and-resources
[2] https://github.com/eclipse/che/blob/6.19.x/dockerfiles/init/manifests/che.env#L538