### PR TITLE
Use run.sh -war for maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
                                         <!-- build Jekyll docs with docker -->
                                         <exec executable="bash">
                                             <arg value="-c" />
-                                            <arg value="docker run -v $(pwd):/che-docs eclipse/che-docs sh -c 'cd /che-docs/src/main; mkdir -p _site; chown jekyll:jekyll _site; jekyll build --config _config.yml,_config-war.yml'" />
+                                            <arg value="./run.sh -war" />
                                         </exec>
                                     </target>
                                 </configuration>


### PR DESCRIPTION
Use `run.sh -war` for maven build

fixes https://github.com/eclipse/che/issues/15737