### PR TITLE
Doc changes related to default project source from Git repository

### DIFF
--- a/src/main/pages/che-7/end-user-guide/con_a-minimal-devfile.adoc
+++ b/src/main/pages/che-7/end-user-guide/con_a-minimal-devfile.adoc
@@ -7,18 +7,12 @@ The following is the minimum content required in a `devfile.yaml` file:
 
 * link:https://redhat-developer.github.io/devfile/devfile#apiversion[apiVersion]
 * link:https://redhat-developer.github.io/devfile/devfile#metadata[metadata name]
-* link:https://redhat-developer.github.io/devfile/devfile#projects[projects name and source]
 
 [source,yaml]
 ----
 apiVersion: 1.0.0
 metadata:
   name: che-in-che-out
-projects:
-  - name: che
-    source:
-      type: git
-      location: 'https://github.com/eclipse/che.git'
 ----
 
 For a complete devfile example, see link:https://github.com/eclipse/che/blob/master/devfile.yaml[{prod} in {prod-short} devfile.yaml].

--- a/src/main/pages/che-7/end-user-guide/proc_writing-a-devfile-for-your-project.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_writing-a-devfile-for-your-project.adoc
@@ -19,7 +19,7 @@ metadata:
   name: minimal-workspace
 ----
 
-Without any further configuration, a workspace with the default editor is launched along with its default plug-ins, which are configured on the {prod-short} Server. Che-Theia is configured as the default editor along with the *{prod-short} Machine Exec* plug-in.
+Without any further configuration, a workspace with the default editor is launched along with its default plug-ins, which are configured on the {prod-short} Server. Che-Theia is configured as the default editor along with the *{prod-short} Machine Exec* plug-in. If workspace is launched within a git reposiotory using factory, the project from given repository and branch will be created by default. Project name will match repository name.
 
 Add the following parts for a more functional workspace:
 

--- a/src/main/pages/che-7/end-user-guide/proc_writing-a-devfile-for-your-project.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_writing-a-devfile-for-your-project.adoc
@@ -19,7 +19,7 @@ metadata:
   name: minimal-workspace
 ----
 
-Without any further configuration, a workspace with the default editor is launched along with its default plug-ins, which are configured on the {prod-short} Server. Che-Theia is configured as the default editor along with the *{prod-short} Machine Exec* plug-in. If workspace is launched within a git repository using factory, the project from given repository and branch will be created by default. Project name will match repository name.
+Without any further configuration, a workspace with the default editor is launched along with its default plug-ins, which are configured on the {prod-short} Server. Che-Theia is configured as the default editor along with the *{prod-short} Machine Exec* plug-in. When launching a workspace within a Git repository using a factory, the project from the given repository and branch is be created by default. The project name then matches the repository name.
 
 Add the following parts for a more functional workspace:
 

--- a/src/main/pages/che-7/end-user-guide/proc_writing-a-devfile-for-your-project.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_writing-a-devfile-for-your-project.adoc
@@ -19,7 +19,7 @@ metadata:
   name: minimal-workspace
 ----
 
-Without any further configuration, a workspace with the default editor is launched along with its default plug-ins, which are configured on the {prod-short} Server. Che-Theia is configured as the default editor along with the *{prod-short} Machine Exec* plug-in. If workspace is launched within a git reposiotory using factory, the project from given repository and branch will be created by default. Project name will match repository name.
+Without any further configuration, a workspace with the default editor is launched along with its default plug-ins, which are configured on the {prod-short} Server. Che-Theia is configured as the default editor along with the *{prod-short} Machine Exec* plug-in. If workspace is launched within a git repository using factory, the project from given repository and branch will be created by default. Project name will match repository name.
 
 Add the following parts for a more functional workspace:
 


### PR DESCRIPTION
### What does this PR do?
Proposed changes related to setting default project source from if WS launched from Git repository and devfile have noo project defined.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14547