### PR TITLE
Execute environment variable docs generation during publish docs ci process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ spec:
       steps {
         container('che-docs') {
             dir('che-docs') {
-                sh 'cd src/main && jekyll build --config _config.yml,_config-web.yml'
+                sh './tools/enviromnent_docs_gen.sh &&  cd src/main && jekyll build --config _config.yml,_config-web.yml'
             }
         }
       }


### PR DESCRIPTION
### What does this PR do?
Execute environment variable docs generation during publish docs ci process

### What issues does this PR fix or reference?

Docs published without environment variables page content
<img width="1427" alt="Знімок екрана 2020-02-10 о 10 02 00" src="https://user-images.githubusercontent.com/1614429/74135359-77a6b300-4bec-11ea-9161-e31ef3fcb52e.png">
