### PR TITLE
New attribute `prod-url-secure`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,24 @@ Then, instead of the `run.sh` script, run Maven directly:
 $ mvn clean install -Pnative
 ```
 
-## Adding a new page
+## Adding a new page with `newdoc`
+
+`newdoc` is a script that generates empty module and assembly files. `newdoc` can be installed locally or executed from the `che-docs` container.
+
+To install `newdoc` locally:
+
+```
+$ pip3 install newdoc
+$ cd src/main/pages/che-7/end-user-guide/
+$ newdoc -Ca "Using Che in restricted environment"
+```
+
+To run `newdoc` from the container:
+
+```
+$ bash run.sh -test-adoc src/main/pages/che-<MAJOR-VERSION>/${subdir}
+```
+
 
 In order to add a new page, create an `.adoc` file in `src/main/pages/che-<MAJOR-VERSION>/${subdir}` (substitute `<MAJOR-VERSION>` for either `6` or `7`, depending for which version of Che your content is intended).
 
@@ -54,7 +71,12 @@ To add a tag, look at available tags in `src/main/pages/che-<MAJOR-VERSION>/tags
 
 ## Formatting and AsciiDoc syntax
 
+Documentation is formatted in AsciiDoc.
 See [AsciiDoc Writer's Guide](https://asciidoctor.org/docs/asciidoc-writers-guide/) for syntax and general help with AsciiDoc.
+
+```
+bash run.sh -test-adoc pages/che-7/administration-guide/assembly_authenticating-in-a-che-workspace.adoc
+```  	    
 
 ### Links
 

--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -52,6 +52,7 @@ asciidoc_attributes: &asciidoc_attributes
   prod-checluster: eclipse-che
   prod-namespace: default
   prod-url: http(s)://che-host:che-port
+  prod-url-secure: https://++che-che.__<OPENSHIFT_APPS_URL>__
   prod-host: che-host
   ocp: OpenShift Container Platform
   prod-deployment: che

--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -52,7 +52,7 @@ asciidoc_attributes: &asciidoc_attributes
   prod-checluster: eclipse-che
   prod-namespace: default
   prod-url: http(s)://che-host:che-port
-  prod-url-secure: https://++che-che.__<OPENSHIFT_APPS_URL>__
+  prod-url-secure: https://che-che.__<OPENSHIFT_APPS_URL>__
   prod-host: che-host
   ocp: OpenShift Container Platform
   prod-deployment: che

--- a/src/main/pages/che-7/overview/proc_finding-che-cluster-url-using-openshift-4-cli-tools.adoc
+++ b/src/main/pages/che-7/overview/proc_finding-che-cluster-url-using-openshift-4-cli-tools.adoc
@@ -1,5 +1,4 @@
 [id="finding-{prod-id-short}-cluster-url-using-openshift-4-cli-tools_{context}"]
-
 = Finding {prod-short} cluster URL using the OpenShift 4 CLI
 This section describes how to obtain the {prod-short} cluster URL using the OpenShift 4 CLI (command line interface). The URL can be retrieved from the OpenShift logs or from the `checluster` Custom Resource.
 .Prerequisites

--- a/src/main/pages/che-7/overview/proc_finding-che-cluster-url-using-openshift-4-cli-tools.adoc
+++ b/src/main/pages/che-7/overview/proc_finding-che-cluster-url-using-openshift-4-cli-tools.adoc
@@ -1,4 +1,5 @@
 [id="finding-{prod-id-short}-cluster-url-using-openshift-4-cli-tools_{context}"]
+
 = Finding {prod-short} cluster URL using the OpenShift 4 CLI
 This section describes how to obtain the {prod-short} cluster URL using the OpenShift 4 CLI (command line interface). The URL can be retrieved from the OpenShift logs or from the `checluster` Custom Resource.
 .Prerequisites

--- a/src/main/pages/che-7/overview/proc_installing-che-on-openshift-3-using-the-operator-and-ssl.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-openshift-3-using-the-operator-and-ssl.adoc
@@ -34,5 +34,4 @@ To create the {prod-short} instance on demo OpenShift clusters that have not bee
 ----
 Command server:start has completed successfully.
 ----
-
-. Navigate to the {prod-short} cluster instance. The domain is now prefixed with HTTPS and using _Let’s Encrypt_ ACME certificates: `++https://++che-che.__<OPENSHIFT_APPS_URL>__`.
+. Navigate to the {prod-short} cluster instance. The domain is now prefixed with HTTPS and using _Let’s Encrypt_ ACME certificates: `{prod-url-secure}`.

--- a/src/main/pages/che-7/overview/proc_installing-che-on-openshift-3-using-the-operator.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-openshift-3-using-the-operator.adoc
@@ -40,4 +40,4 @@ $ {prod-cli} server:start --platform=openshift --installer=operator \
 Command server:start has completed successfully.
 ----
 
-. Navigate to the {prod-short} cluster instance: `++http://++che-che.__<OPENSHIFT_APPS_URL>__`.
+. Navigate to the {prod-short} cluster instance: `{prod-url}`.


### PR DESCRIPTION
### What does this PR do?
Adds conditionals to differentiate between che and CRW - where default project name is mentioned.

We don't have an attribute for `che-che`/`codeready-workspaces` so I decided to use conditionals.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-1548