### PR TITLE
Clarify process for adding a VS Code extension to Che

### DIFF
--- a/src/main/pages/che-7/end-user-guide/proc_adding-the-vs-code-extension-using-the-workspace-configuration.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_adding-the-vs-code-extension-using-the-workspace-configuration.adoc
@@ -25,5 +25,15 @@ To add the VS Code extension using the workspace configuration:
 <1> Link to the `meta.yaml` file in your registry, for example, `https://my-plug-in-registry/v3/plugins/__<publisher>__/__<plug-inName>__/__<plug-inVersion>__/meta.yaml`
 +
 {prod-short} automatically adds the other fields to the new component.
++
+Alternatively, you can link to a `meta.yaml` file hosted on GitHub, via the reference field.
++
+[source,yaml,subs="+quotes"]
+----
+ - type: chePlugin
+   reference:              <1>
+----
+<1> `https://raw.githubusercontent.com/__<username>__/__<registryRepository>__/v3/plugins/__<publisher>__/__<plug-inName>__/__<plug-inVersion>__/meta.yaml`
++
 
 . Restart the workspace for the changes to take effect.


### PR DESCRIPTION
Improve the docs a bit so that it's clear that a meta.yaml file
can be hosted on GitHub, and not just a self-hosted registry link.

See eclipse/che#15982

Signed-off-by: Eric Williams <ericwill@redhat.com>