### PR TITLE
Removed harcoded instances of eclipse.org

### DIFF
--- a/src/main/pages/che-7/administration-guide/proc_viewing-che-theia-ide-logs-on-the-cli.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_viewing-che-theia-ide-logs-on-the-cli.adoc
@@ -6,7 +6,7 @@ Observing Che-Theia editor logs helps to get a better understanding and insight 
 .Prerequisites
 
 ifeval::["{project-context}" == "che"]
-* {prod-short} is deployed in an OpenShift cluster. Verify the state of the deployment in the OpenShift logs. See link:https://www.eclipse.org/che/docs/che-7/installing-che-on-openshift-4-from-operatorhub/#viewing-the-state-of-the-che-cluster-deployment-using-openshift-4-cli-tools_installing-che-on-openshift-4-from-operatorhub[Viewing the state of the {prod-short} cluster deployment using OpenShift 4 CLI tools].
+* {prod-short} is deployed in an OpenShift cluster. Verify the state of the deployment in the OpenShift logs. See link:{site-baseurl}che-7/installing-che-on-openshift-4-from-operatorhub/#viewing-the-state-of-the-che-cluster-deployment-using-openshift-4-cli-tools_installing-che-on-openshift-4-from-operatorhub[Viewing the state of the {prod-short} cluster deployment using OpenShift 4 CLI tools].
 endif::[]
 ifeval::["{project-context}" == "crw"]
 * {prod-short} is deployed in an OpenShift cluster. Verify the state of the deployment in the OpenShift logs. See link:{prod-ig-url}installing-{prod-id-short}-on-ocp-4_crw#viewing-the-state-of-the-{prod-id-short}-cluster-deployment-using-openshift-4-cli-tools_installing-{prod-id-short}-on-openshift-4-from-operatorhub[Viewing the state of the {prod-short} cluster deployment using OpenShift 4 CLI tools].

--- a/src/main/pages/che-7/end-user-guide/assembly_configuring-github-oauth.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_configuring-github-oauth.adoc
@@ -27,7 +27,7 @@ To enable automatic SSH key upload to GitHub for users:
 image::git/github_oauth.png[]
 
 ifeval::["{project-context}" == "che"]
-. On OpenShift or Kubernetes, update the deployment configuration (see link:https://www.eclipse.org/che/docs/che-6/openshift-config.html[OpenShift configuration]).
+. On OpenShift or Kubernetes, update the deployment configuration (see link:{site-baseurl}che-7/openshift-config.html[OpenShift configuration]).
 +
 [subs=+quotes]
 ----

--- a/src/main/pages/che-7/extensions/assembly_eclipse-che4z.adoc
+++ b/src/main/pages/che-7/extensions/assembly_eclipse-che4z.adoc
@@ -15,7 +15,7 @@ summary:
 
 Eclipse Che4z is an all-in-one mainframe extension stack for Eclipse Che, which provides a modern experience for mainframe software developers working with z/OS applications.
 
-Powered by the open-source projects https://www.zowe.org/[Zowe] and https://www.eclipse.org/che/docs/che-7[Eclipse Che], Che4z offers an easy and streamlined on-boarding process to get new developers using the tools they need. Using container technology and stacks, Eclipse Che brings the necessary technology to the task at hand.
+Powered by the open-source projects https://www.zowe.org/[Zowe] and link:{site-baseurl}che-7[Eclipse Che], Che4z offers an easy and streamlined on-boarding process to get new developers using the tools they need. Using container technology and stacks, Eclipse Che brings the necessary technology to the task at hand.
 
 Developers can now find the code they need to work on in Explorer for Endevor, Git and Zowe Explorer, edit code assisted by COBOL or HLASM Language Support, and test the resulting code with the Debugger, all in one Mainframe development package.
 


### PR DESCRIPTION
### What does this PR do?
Removes hardcoded instances of eclipse.org, replaces them with `site-baseurl` attribute.

### What issues does this PR fix or reference?
Downstreaming issue: https://issues.redhat.com/browse/RHDEVDOCS-1647