### PR TITLE
I15219 quick start redir

### DIFF
--- a/src/main/pages/che-7/overview/assembly_che-quick-starts.adoc
+++ b/src/main/pages/che-7/overview/assembly_che-quick-starts.adoc
@@ -19,18 +19,20 @@ This section contains instructions for getting quickly started with {prod}.
 
 Various installation methods are covered:
 
-* link:{site-baseurl}che-7/running-che-locally/[Running {prod-short} locally] on a personal workstation.
+* link:{site-baseurl}che-7/installing-the-chectl-management-tool/[Installing the {prod-cli} management tool]
 
-* link:{site-baseurl}che-7/deploying-che-on-kubernetes-on-aws/[Deploying {prod-short} on Kubernetes on Amazon Elastic Compute Cloud ].
+* link:{site-baseurl}che-7/running-che-locally/[Running {prod-short} locally] on a personal workstation
 
-* link:{site-baseurl}che-7/installing-che-on-openshift-3-using-the-operator/[Installing {prod-short} on OpenShift 3 using the Operator].
+* link:{site-baseurl}che-7/deploying-che-on-kubernetes-on-aws/[Deploying {prod-short} on Kubernetes on Amazon Elastic Compute Cloud]
 
-* link:{site-baseurl}che-7/installing-che-on-openshift-4-from-operatorhub/[Installing {prod-short} on OpenShift 4 from OperatorHub].
+* link:{site-baseurl}che-7/installing-che-on-openshift-3-using-the-operator/[Installing {prod-short} on OpenShift 3 using the Operator]
 
-* link:{site-baseurl}che-7/installing-che-on-google-cloud-platform/[Installing {prod-short} on Google Cloud Platform].
+* link:{site-baseurl}che-7/installing-che-on-openshift-4-from-operatorhub/[Installing {prod-short} on OpenShift 4 from OperatorHub]
 
-* link:{site-baseurl}che-7/installing-eclipse-che-on-microsoft-azure/[Installing {prod-short} on Microsoft Azure].
+* link:{site-baseurl}che-7/installing-che-on-google-cloud-platform/[Installing {prod-short} on Google Cloud Platform]
 
-* link:{site-baseurl}che-7/accessing-che-from-openshift-developer-perspective/[Accessing {prod-short} from OpenShift Developer Perspective].
+* link:{site-baseurl}che-7/installing-eclipse-che-on-microsoft-azure/[Installing {prod-short} on Microsoft Azure]
+
+* link:{site-baseurl}che-7/accessing-che-from-openshift-developer-perspective/[Accessing {prod-short} from OpenShift Developer Perspective]
 
 :context: {parent-context-of-che-quick-starts}

--- a/src/main/pages/che-7/overview/assembly_che-quick-starts.adoc
+++ b/src/main/pages/che-7/overview/assembly_che-quick-starts.adoc
@@ -4,6 +4,8 @@ keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/che-quick-starts/
+redirect_from:
+  - quick-start.html
 folder: che-7/overview
 summary:
 ---


### PR DESCRIPTION
### What does this PR do?

* Fixes small miistakes on Quick-starts Overview page.
* Adds a redirect for https://www.eclipse.org/che/docs/quick-start.html -> https://www.eclipse.org/che/docs/che-7/che-quick-starts/

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/15219