### PR TITLE
Removing optional project definition from the devfile

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,10 +1,5 @@
 metadata:
   name: che-docs-in-che
-projects:
-  - name: che-docs
-    source:
-      location: 'https://github.com/eclipse/che-docs.git'
-      type: git
 components:
   - mountSources: true
     endpoints:


### PR DESCRIPTION
### What does this PR do?
Removing an optional project definition from the devfile.
Fixes is available in 7.8.0 eclipse/che@dc2f3b5

### What issues does this PR fix or reference?
N/A