### PR TITLE
New run.sh functionalities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,23 +10,24 @@
 FROM ruby:2.6-alpine
 COPY src/main/Gemfile* /tmp/
 
-RUN apk add --no-cache --update libstdc++ bash ca-certificates curl python3 \
+RUN apk add --no-cache --update libstdc++ bash ca-certificates curl python3 grep perl libxml2-dev xmlstarlet \
     && apk add --no-cache --virtual build-dependencies build-base \
     && cd /tmp \
     && time bundle install --no-cache --frozen \
     && time apk del build-dependencies build-base \
+    && rm -rf /root/.bundle/cache \
     && time pip3 install newdoc --upgrade pip --no-cache-dir \
+    && newdoc --version \
     && curl -sfLo /usr/bin/test-adoc.sh https://raw.githubusercontent.com/jhradilek/check-links/master/test-adoc.sh \
     && chmod +x /usr/bin/test-adoc.sh \
-    && curl -sfLo vale.sh https://install.goreleaser.com/github.com/ValeLint/vale.sh \
-    && bash vale.sh -b /usr/bin \
-    && newdoc --version \
     && test-adoc.sh -V \
     && curl -sfLo /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
     && curl -sfLo glibc-2.30-r0.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/glibc-2.30-r0.apk \
-    && apk add glibc-2.30-r0.apk \
+    && apk add --no-cache glibc-2.30-r0.apk \
+    && curl -sfLo vale.tar.gz https://github.com/errata-ai/vale/releases/download/v2.0.0/vale_2.0.0_Linux_64-bit.tar.gz \
+    && tar xvzf vale.tar.gz -C /usr/bin/ \
+    && rm vale.tar.gz \
     && vale -v \
-    && rm -rf /root/.bundle/cache \
     && mkdir /che-docs \
     && for f in "/che-docs"; do \
            chgrp -R 0 ${f} && \

--- a/run.sh
+++ b/run.sh
@@ -101,7 +101,8 @@ case "$1" in
     ;;
   -test-adoc)
     shift
-    FILES="${*:-pages/*/*/*.adoc}"
+    SRC_PATH="$(pwd)"
+    FILES="${*:-src/main/pages/*/*/*.adoc}"
     echo "Running test-adoc.sh on ${FILES}"
     runner "${IMAGE}" \
       bash -c "test-adoc.sh ${FILES}"


### PR DESCRIPTION
- Add test-adoc.sh dependencies in che-docs container.
- Fix vale installation (see https://github.com/errata-ai/vale/issues/177)
- Add new functionalities for run.sh:

```
  OPTIONS:
    (no option)                     Building and serving the docs for local preview.
    -prod                           Building for production, to publish on eclipse.org/che/docs/.
    -war                            Building for embedding in Che, to link from the app.
    -newassembly <guide> <title>    Create a new assembly in guide <guide>, with title <title>
    -newconcept <guide> <title>     Create a new concept in guide <guide>, with title <title>
    -newprocedure <guide> <title>   Create a new procedure in guide <guide>, with title <title>
    -newreference <guide> <title>   Create a new reference in guide <guide>, with title <title>
    -test-adoc [<fileslist>]        Run test-adoc.sh on files (default: on all files)
    -vale [<fileslist>]             Run vale linter on files (default: on all files)
  VARIABLES:
     CHEDOCSIMAGE             Override the default container image.
```