### PR TITLE
Fix broken attribute prod-shor and add a vale rule for it

### DIFF
--- a/.ci/vale/styles/ModularDoc/Attributes.yml
+++ b/.ci/vale/styles/ModularDoc/Attributes.yml
@@ -1,0 +1,7 @@
+---
+extends: substitution
+message: Use '%s' instead of '%s.'
+level: error
+ignorecase: true
+swap:
+  prod-shor: prod-short

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,6 +3,7 @@ StylesPath = .ci/vale/styles
 MinAlertLevel = suggestion
 
 [*.adoc]
-BasedOnStyles = PlainLanguage
-; BasedOnStyles = PlainLanguage,Vale
+BasedOnStyles = ModularDoc
+; BasedOnStyles = ModularDoc,PlainLanguage
+; BasedOnStyles = ModularDoc,PlainLanguage,Vale
 

--- a/src/main/pages/che-7/extensions/proc_creating-components-with-openshift-connector-in-eclipse-che.adoc
+++ b/src/main/pages/che-7/extensions/proc_creating-components-with-openshift-connector-in-eclipse-che.adoc
@@ -14,7 +14,7 @@ summary:
 
 In the context of OpenShift, Components and Services are basic structures that need to be stored in Application, which is a part of the OpenShift project that organizes deployables into virtual folders for better readability.
 
-This chapter describes how to create OpenShift Components in the {prod-shor} using the OpenShift Connector plug-in and push them to an OpenShift cluster.
+This chapter describes how to create OpenShift Components in the {prod-short} using the OpenShift Connector plug-in and push them to an OpenShift cluster.
 
 .Prerequisites
 

--- a/src/main/pages/che-7/overview/proc_finding-che-cluster-url-using-openshift-4-cli-tools.adoc
+++ b/src/main/pages/che-7/overview/proc_finding-che-cluster-url-using-openshift-4-cli-tools.adoc
@@ -20,7 +20,7 @@ Alternatively, wait for the deployment logs as mentioned in the Prerequisites se
 include::examples/{project-context}-cluster-url-logs.log[]
 ----
 +
-After the deployment is finished, in the log output, click the {prod-short} cluster URL to start the {prod-shor} instance, or use the following command to isolate it:
+After the deployment is finished, in the log output, click the {prod-short} cluster URL to start the {prod-short} instance, or use the following command to isolate it:
 +
 [options="nowrap",role=white-space-pre]
 ----


### PR DESCRIPTION
- fix broken attribute prod-shor 
- add a vale rule to propose the correct attribute

Example vale run with errors
```
 vale .
 src/main/pages/che-7/extensions/proc_creating-components-with-openshift-connector-in-eclipse-che.adoc
 17:67  error  Use 'prod-short' instead of     ModularDoc.Attributes 
               'prod-shor.'                                          
 src/main/pages/che-7/overview/proc_finding-che-cluster-url-using-openshift-4-cli-tools.adoc
 23:103  error  Use 'prod-short' instead of     ModularDoc.Attributes 
                'prod-shor.'                                          
✖ 2 errors, 0 warnings and 0 suggestions in 435 files.
```
