### PR TITLE
A rule to check links with www.eclipse.org instead of {site-baseurl}.

### DIFF
--- a/.ci/vale/styles/CheDocs/Links.yml
+++ b/.ci/vale/styles/CheDocs/Links.yml
@@ -1,0 +1,7 @@
+extends: substitution
+message: Use '%s' instead of '%s.'
+level: error
+ignorecase: true
+swap:
+  \slink\:https\://www.eclipse.org\S*\s: link:{site-baseurl}che-7/
+  \shttps\://www.eclipse.org\S*\s: link:{site-baseurl}che-7/

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,7 +3,7 @@ StylesPath = .ci/vale/styles
 MinAlertLevel = suggestion
 
 [*.adoc]
-BasedOnStyles = ModularDoc
+BasedOnStyles =  ModularDoc,CheDocs
 ; BasedOnStyles = ModularDoc,PlainLanguage
 ; BasedOnStyles = ModularDoc,PlainLanguage,Vale
 


### PR DESCRIPTION
### What does this PR do?
At each occurence of `link:https://www.eclipse.org/che/docs/che-7/` or `https://www.eclipse.org/che/docs/che-7/`, proposes to replace it by  `link:{site-baseurl}che-7/`.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-1646