### PR TITLE
Add documentation about new resource limits of Che plugins

### DIFF
--- a/src/main/pages/che-7/contributor-guide/proc_overriding-ram-of-a-che-theia-plug-in.adoc
+++ b/src/main/pages/che-7/contributor-guide/proc_overriding-ram-of-a-che-theia-plug-in.adoc
@@ -6,16 +6,16 @@ Sometimes, a plug-in consumes more memory than what has been allocated to it by 
 
 .Procedure
 
-Users can override the RAM limit for a particular plug-in in their workspace configuration.
+Users can override the RAM limit and request for a particular plug-in in their workspace configuration.
 
-* Set the `memoryLimit` for devfile component  to `1000M` or `10Gi`, or any other value formatted as a number and a unit (`b, k, ki, m, mi, g, gi`). When no unit is specified, the number is in bytes.
+* Set the `memoryLimit` and/or `memoryRequest` for devfile component  to `1000M` or `10Gi`, or any other value formatted as a number and a unit (`b, k, ki, m, mi, g, gi`). When no unit is specified, the number is in bytes.
 
 NOTE: Using this notation, units that contain the character `i`, denote a number that is of the power 2, such as 1024 (as opposed to numbers that use a power of 10, such as 1000).
 
 .Limiting RAM use for a plug-in
 [example]
 ====
-Example of an attribute that sets the RAM limit for the link:https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml[YAML language server plug-in] to 768 mebibytes (1073741824 bytes):
+Example of an attribute that sets the RAM limit for the link:https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml[YAML language server plug-in] to 768 mebibytes (1073741824 bytes) and RAM request to 500 megabytes:
 
 [source,yaml]
 ----
@@ -23,6 +23,22 @@ components:
   - id: redhat/vscode-yaml/0.3.0
     type: chePlugin
     memoryLimit: 768mi
+    memoryRequest: 500M
+----
+====
+
+.Limiting CPU use for a plug-in
+[example]
+====
+Example of an attribute that sets the CPU limit for the link:https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml[YAML language server plug-in] to 1.5 cores and CPU request to 500 millicores:
+
+[source,yaml]
+----
+components:
+  - id: redhat/vscode-yaml/0.3.0
+    type: chePlugin
+    cpuLimit: 1.5
+    cpuRequest: 500m
 ----
 ====
 

--- a/src/main/pages/che-7/end-user-guide/proc_configuring-the-workspace-and-adding-tooling.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_configuring-the-workspace-and-adding-tooling.adoc
@@ -163,12 +163,13 @@ image::workspaces/workspace_devfile_che_7_.png[]
   alias: maven3-jdk11
 ----
 
-. Change the `memoryLimit` field to specify the `RAM` required for the component.
+. Change the `memoryLimit` and/or `memoryRequest` field to specify the `RAM` required for the component.
 +
 [source,yaml]
 ----
   alias: maven3-jdk11
   memoryLimit: 256M
+  memoryRequest: 128M
 ----
 
 . Open the *Devfile* tab to see the changes.

--- a/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
+++ b/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
@@ -367,7 +367,7 @@ components:
 
 === Specifying container memory limit for components
 
-To specify a container(s) memory limit for `dockerimage`, `chePlugin`, `cheEditor`, `kubernetes`, `openshift`, use the `memoryLimit` parameter:
+To specify a container(s) memory limit for `dockerimage`, `chePlugin`, `cheEditor`, use the `memoryLimit` parameter:
 
 [source,yaml]
 ----
@@ -376,12 +376,89 @@ To specify a container(s) memory limit for `dockerimage`, `chePlugin`, `cheEdito
      type: chePlugin
      id: eclipse/che-machine-exec-plugin/0.0.1
      memoryLimit: 1Gi
-   - type: kubernetes
-     reference: ../relative/path/postgres.yaml
+   - type: dockerimage
+     image: eclipe/maven-jdk8:latest
      memoryLimit: 512M
 ----
 
 This limit will be applied to every container of the given component.
+
+For `cheEditor` and `chePlugin` component types, RAM limits can be described in plugin descriptor file (typically, named `meta.yaml`).
+In this case, devfile values have precendence, i.e. value from descriptor will be overriden by devfile one.
+If none of them are specified, system-wide defaults will be applied (see description of CHE_WORKSPACE_SIDECAR_DEFAULT__MEMORY__LIMIT__MB system property).
+
+
+=== Specifying container memory request for components
+
+To specify a container(s) memory request for `chePlugin` or  `cheEditor`, use the `memoryRequest` parameter:
+
+[source,yaml]
+----
+  components:
+   - alias: exec-plugin
+     type: chePlugin
+     id: eclipse/che-machine-exec-plugin/0.0.1
+     memoryLimit: 1Gi
+     memoryRequest: 512M
+   - type: dockerimage
+     image: eclipe/maven-jdk8:latest
+     memoryLimit: 512M
+     memoryRequest: 256M
+----
+
+This limit will be applied to every container of the given component.
+
+For `cheEditor` and `chePlugin` component types, RAM requests can be described in plugin descriptor file (typically, named `meta.yaml`).
+In this case, devfile values have precendence, i.e. value from descriptor will be overriden by devfile one.
+If none of them are specified, system-wide defaults will be applied (see description of CHE_WORKSPACE_SIDECAR_DEFAULT__MEMORY__REQUEST__MB system property).
+
+
+=== Specifying container CPU limit for components
+
+To specify a container(s) CPU limit for `chePlugin` or `cheEditor`, use the `cpuLimit` parameter:
+
+[source,yaml]
+----
+  components:
+   - alias: exec-plugin
+     type: chePlugin
+     id: eclipse/che-machine-exec-plugin/0.0.1
+     cpuLimit: 1.5
+   - type: dockerimage
+     image: eclipe/maven-jdk8:latest
+     cpuLimit: 750m
+----
+
+This limit will be applied to every container of the given component.
+
+For `cheEditor` and `chePlugin` component types, CPU limits can be described in plugin descriptor file (typically, named `meta.yaml`).
+In this case, devfile values have precendence, i.e. value from descriptor will be overriden by devfile one.
+If none of them are specified, system-wide defaults will be applied (see description of CHE_WORKSPACE_SIDECAR_DEFAULT__CPU__LIMIT__CORES system property).
+
+
+=== Specifying container CPU request for components
+
+To specify a container(s) CPU request for `chePlugin` or `cheEditor`, use the `cpuRequest` parameter:
+
+[source,yaml]
+----
+  components:
+   - alias: exec-plugin
+     type: chePlugin
+     id: eclipse/che-machine-exec-plugin/0.0.1
+     cpuLimit: 1.5
+     cpuRequest: 0.225
+   - type: dockerimage
+     image: eclipe/maven-jdk8:latest
+     cpuLimit: 750m
+     cpuRequest: 450m
+----
+
+This limit will be applied to every container of the given component.
+
+For `cheEditor` and `chePlugin` component types, CPU requests can be described in plugin descriptor file (typically, named `meta.yaml`).
+In this case, devfile values have precendence, i.e. value from descriptor will be overriden by devfile one.
+If none of them are specified, system-wide defaults will be applied (see description of CHE_WORKSPACE_SIDECAR_DEFAULT__CPU__REQUEST__CORES system property).
 
 === Environment variables
 


### PR DESCRIPTION
### What does this PR do?

Adds documentation about new RAM & CPU resource limits of Che plugins.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15306