### PR TITLE
Fixing quotes and double quotes and some other stuff

### DIFF
--- a/src/main/pages/che-7/administration-guide/proc_authenticating-to-the-che-server-using-openid.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_authenticating-to-the-che-server-using-openid.adoc
@@ -1,4 +1,4 @@
-[id='authenticating-to-the-{prod-id-short}-server-using-openid_{context}']
+[id="authenticating-to-the-{prod-id-short}-server-using-openid_{context}"]
 = Authenticating to the {prod-short} server using OpenID
 
 OpenID authentication on the {prod-short} server implies the presence of an external OpenID Connect provider and has the following main steps:

--- a/src/main/pages/che-7/administration-guide/ref_configuring-system-variables.adoc
+++ b/src/main/pages/che-7/administration-guide/ref_configuring-system-variables.adoc
@@ -5,8 +5,8 @@ The following document describes all possible configuration properties of {prod-
 Simplest way to override default values on operator-based deployments is to update Custom Resource of `CleCluster`
 by adding or editing `customCheProperties` field, which expects a map as in following example:
 
+.Example of changing default value of CHE_WORKSPACE_DEFAULT__MEMORY__LIMIT__MB to 2048:
 
-+Example of changing default value of CHE_WORKSPACE_DEFAULT__MEMORY__LIMIT__MB to 2048:+
 [source,yaml]
 ----
 apiVersion: org.eclipse.che/v1
@@ -26,6 +26,5 @@ spec:
   auth:
 ...
 ----
-
 
 include::examples/system-variables.adoc[]

--- a/src/main/pages/che-7/contributor-guide/assembly_branding-che-theia.adoc
+++ b/src/main/pages/che-7/contributor-guide/assembly_branding-che-theia.adoc
@@ -8,9 +8,10 @@ folder: che-7/contributor-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-branding-che-theia: {context}
 
-[id='branding-che-theia']
+[id="branding-che-theia"]
 = Branding Che-Theia
 
 :context: branding-che-theia

--- a/src/main/pages/che-7/contributor-guide/assembly_che-extensibility-reference.adoc
+++ b/src/main/pages/che-7/contributor-guide/assembly_che-extensibility-reference.adoc
@@ -8,9 +8,10 @@ folder: che-7/contributor-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-che-extensibility-reference: {context}
 
-[id='{prod-id-short}-extensibility-reference']
+[id="{prod-id-short}-extensibility-reference"]
 = {prod-short} extensibility reference
 
 :context: che-extensibility-reference

--- a/src/main/pages/che-7/contributor-guide/assembly_developing-che-theia-plug-ins.adoc
+++ b/src/main/pages/che-7/contributor-guide/assembly_developing-che-theia-plug-ins.adoc
@@ -8,9 +8,10 @@ folder: che-7/contributor-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-developing-che-theia-plug-ins: {context}
 
-[id='developing-che-theia-plug-ins']
+[id="developing-che-theia-plug-ins"]
 = Developing Che-Theia plug-ins
 
 :context: developing-che-theia-plug-ins

--- a/src/main/pages/che-7/contributor-guide/assembly_publishing-che-theia-plug-ins.adoc
+++ b/src/main/pages/che-7/contributor-guide/assembly_publishing-che-theia-plug-ins.adoc
@@ -8,9 +8,10 @@ folder: che-7/contributor-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-publishing-che-theia-plug-ins: {context}
 
-[id='publishing-che-theia-plug-ins']
+[id="publishing-che-theia-plug-ins"]
 = Publishing Che-Theia plug-ins
 
 :context: publishing-che-theia-plug-ins

--- a/src/main/pages/che-7/contributor-guide/assembly_setup-che-in-tls-mode-with-self-signed-certificate.adoc
+++ b/src/main/pages/che-7/contributor-guide/assembly_setup-che-in-tls-mode-with-self-signed-certificate.adoc
@@ -8,10 +8,10 @@ folder: che-7/contributor-guide
 summary:
 ---
 
-
+:page-liquid:
 :parent-context-of-setup-che-in-tls-mode: {context}
 
-[id='setup-{prod-id-short}-in-tls-mode_{context}']
+[id="setup-{prod-id-short}-in-tls-mode_{context}"]
 = Setup Che in TLS mode with self-signed certificates
 
 :context: setup-{prod-id-short}-in-tls-mode-with-self-signed-certificate

--- a/src/main/pages/che-7/contributor-guide/assembly_testing-che-theia-plug-ins.adoc
+++ b/src/main/pages/che-7/contributor-guide/assembly_testing-che-theia-plug-ins.adoc
@@ -8,9 +8,10 @@ folder: che-7/contributor-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-testing-che-theia-plug-ins: {context}
 
-[id='testing-che-theia-plug-ins']
+[id="testing-che-theia-plug-ins"]
 = Testing Che-Theia plug-ins
 
 :context: testing-che-theia-plug-ins
@@ -44,7 +45,7 @@ image::extensibility/hosted-instance-output.png[link="{imagesdir}/extensibility/
 
 == Controlling a hosted Che-Theia instance
 
-You can control the state of the hosted instance directly from the main instance. Click *Hosted Plugin* element in the status bar, and a context menu with the available actions is displayed. You can stop and restart the running hosted Che-Theia instance from the context menu. When a hosted instance is stopped, use the context menu to start it again. 
+You can control the state of the hosted instance directly from the main instance. Click *Hosted Plugin* element in the status bar, and a context menu with the available actions is displayed. You can stop and restart the running hosted Che-Theia instance from the context menu. When a hosted instance is stopped, use the context menu to start it again.
 
 image::extensibility/controlling-hosted-che-theia.png[]
 

--- a/src/main/pages/che-7/end-user-guide/assembly_adding-che-plug-in-registry-vs-code-extension-to-a-workspace.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_adding-che-plug-in-registry-vs-code-extension-to-a-workspace.adoc
@@ -1,6 +1,6 @@
 :parent-context-of-adding-che-plug-in-registry-vs-code-extension-to-a-workspace: {context}
 
-[id='adding-{prod-id-short}-plug-in-registry-vs-code-extension-to-a-workspace_{context}']
+[id="adding-{prod-id-short}-plug-in-registry-vs-code-extension-to-a-workspace_{context}"]
 = Adding a plug-in registry VS Code extension to a workspace
 
 :context: adding-che-plug-in-registry-vs-code-extension-to-a-workspace

--- a/src/main/pages/che-7/end-user-guide/assembly_che-theia-ide-basics.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_che-theia-ide-basics.adoc
@@ -8,9 +8,10 @@ folder: che-7/end-user-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-che-theia-ide-basics: {context}
 
-[id='che-theia-ide-basics']
+[id="che-theia-ide-basics"]
 = Che-Theia IDE basics
 
 :context: che-theia-ide-basics

--- a/src/main/pages/che-7/end-user-guide/assembly_configuring-oauth-authorization.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_configuring-oauth-authorization.adoc
@@ -8,9 +8,10 @@ folder: che-7/end-user-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-configuring-oauth-authorization: {context}
 
-[id='configuring-oauth-authorization']
+[id="configuring-oauth-authorization"]
 = Configuring OAuth authorization
 
 :context: configuring-oauth-authorization

--- a/src/main/pages/che-7/end-user-guide/assembly_converting-a-che-6-workspace-to-a-che-7-devfile.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_converting-a-che-6-workspace-to-a-che-7-devfile.adoc
@@ -7,14 +7,14 @@ permalink: che-7/converting-a-che-6-workspace-to-a-che-7-devfile/
 redirect_from:
   - factories-getting-started.html
 folder: che-7/end-user-guide
-summary: 
+summary:
 ---
 
 // using-developer-environments-workspaces
-
+:page-liquid:
 :parent-context-of-converting-a-che-6-workspace-to-a-che-7-devfile: {context}
 
-[id='converting-a-{prod-id-short}-{prod-prev-ver}-workspace-to-a-{prod-id-short}-{prod-ver}-devfile']
+[id="converting-a-{prod-id-short}-{prod-prev-ver}-workspace-to-a-{prod-id-short}-{prod-ver}-devfile"]
 = Converting a {prod-short} {prod-prev-ver} workspace to a {prod-short} {prod-ver} devfile
 
 :context: converting-a-che-6-workspace-to-a-che-7-devfile

--- a/src/main/pages/che-7/end-user-guide/assembly_creating-a-workspace-from-code-sample.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_creating-a-workspace-from-code-sample.adoc
@@ -8,14 +8,15 @@ folder: che-7/end-user-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-creating-a-workspace-from-code-sample: {context}
 
-[id='creating-a-workspace-from-code-sample_{context}']
+[id="creating-a-workspace-from-code-sample_{context}"]
 = Creating a workspace from code sample
 
 :context: creating-a-workspace-from-code-sample
 
-Every stack includes a sample codebase, which is defined by the devfile of the stack. 
+Every stack includes a sample codebase, which is defined by the devfile of the stack.
 This section explains how to create a workspace from this code sample in a sequence of three procedures.
 
 . xref:creating-a-workspace-from-user-dashboard_{context}[Creating a workspace from the user dashboard].

--- a/src/main/pages/che-7/end-user-guide/assembly_customizing-developer-environments.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_customizing-developer-environments.adoc
@@ -8,9 +8,10 @@ folder: che-7/end-user-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-customizing-developer-environments: {context}
 
-[id='customizing-developer-environments']
+[id="customizing-developer-environments"]
 = Customizing developer environments
 
 :context: customizing-developer-environments

--- a/src/main/pages/che-7/end-user-guide/assembly_defining-custom-commands-for-che-theia.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_defining-custom-commands-for-che-theia.adoc
@@ -1,18 +1,19 @@
 ---
 title: Defining custom commands for Che-Theia
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/defining-custom-commands-for-che-theia/
 folder: che-7/end-user-guide
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-defining-custom-commands-for-che-theia: {context}
 
 // che-theia-ide-basics
 
-[id='defining-custom-commands-for-che-theia']
+[id="defining-custom-commands-for-che-theia"]
 = Defining custom commands for Che-Theia
 
 :context: defining-custom-commands-for-che-theia

--- a/src/main/pages/che-7/end-user-guide/assembly_importing-a-kubernetes-application-into-a-workspace.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_importing-a-kubernetes-application-into-a-workspace.adoc
@@ -1,16 +1,17 @@
 ---
 title: Importing a Kubernetes application into a workspace
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/importing-a-kubernetes-application-into-a-che-workspace/
 folder: che-7/end-user-guide
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-importing-a-kubernetes-application-into-a-workspace: {context}
 
-[id='importing-a-kubernetes-application-into-a-workspace']
+[id="importing-a-kubernetes-application-into-a-workspace"]
 = Importing a Kubernetes application into a workspace
 
 :context: importing-a-kubernetes-application-into-a-workspace

--- a/src/main/pages/che-7/end-user-guide/assembly_making-a-workspace-portable-using-a-devfile.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_making-a-workspace-portable-using-a-devfile.adoc
@@ -8,9 +8,10 @@ folder: che-7/end-user-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-making-a-workspace-portable-using-a-devfile: {context}
 
-[id='making-a-workspace-portable-using-a-devfile_{context}']
+[id="making-a-workspace-portable-using-a-devfile_{context}"]
 = Making a workspace portable using a devfile
 
 :context: making-a-workspace-portable-using-a-devfile

--- a/src/main/pages/che-7/end-user-guide/assembly_navigating-che-using-the-dashboard.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_navigating-che-using-the-dashboard.adoc
@@ -7,9 +7,10 @@ permalink: che-7/navigating-che-using-the-dashboard/
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-navigating-che-using-the-dashboard: {context}
 
-[id='navigating-{prod-id-short}-using-the-dashboard_{context}']
+[id="navigating-{prod-id-short}-using-the-dashboard_{context}"]
 = Navigating {prod-short} using the Dashboard
 
 :context: navigating-che-using-the-dashboard
@@ -17,7 +18,7 @@ summary:
 The *Dashboard* is accessible on your cluster from a URL like `http://__<che-instance>__.__<IP-address>__.nip.io/dashboard/`.
 This section describes how to access this URL on
 ifeval::["{project-context}" == "che"]
-Minishift and 
+Minishift and
 endif::[]
 OpenShift.
 

--- a/src/main/pages/che-7/end-user-guide/assembly_publishing-a-vs-code-extension-into-the-che-plug-in-registry.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_publishing-a-vs-code-extension-into-the-che-plug-in-registry.adoc
@@ -1,6 +1,6 @@
 :parent-context-of-publishing-a-vs-code-extension-into-the-che-plug-in-registry: {context}
 
-[id='publishing-a-vs-code-extension-into-the-{prod-id-short}-plug-in-registry_{context}']
+[id="publishing-a-vs-code-extension-into-the-{prod-id-short}-plug-in-registry_{context}"]
 = Publishing a VS Code extension into the {prod-short} plug-in registry
 
 :context: publishing-a-vs-code-extension-into-the-che-plug-in-registry

--- a/src/main/pages/che-7/end-user-guide/assembly_running-an-existing-workspace-from-the-user-dashboard.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_running-an-existing-workspace-from-the-user-dashboard.adoc
@@ -1,11 +1,11 @@
 :parent-context-of-running-an-existing-workspace-from-the-user-dashboard: {context}
 
-[id='running-an-existing-workspace-from-the-user-dashboard_{context}']
+[id="running-an-existing-workspace-from-the-user-dashboard_{context}"]
 = Running an existing workspace from the User Dashboard
 
 :context: running-an-existing-workspace-from-the-user-dashboard
 
-This section describes how to run an existing workspace from the User Dasboard
+This section describes how to run an existing workspace from the User Dasboard.
 
 include::proc_running-an-existing-workspace-from-the-user-dashboard-using-the-run-button.adoc[leveloffset=+1]
 

--- a/src/main/pages/che-7/end-user-guide/assembly_troubleshooting-for-che-end-users.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_troubleshooting-for-che-end-users.adoc
@@ -1,38 +1,29 @@
 ---
 title: Troubleshooting for Che end users
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/troubleshooting-for-che-end-users/
 folder: che-7/end-user-guide
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-troubleshooting-for-che-end-users: {context}
 
-[id='troubleshooting-for-{prod-id-short}-end-users_{context}']
+[id="troubleshooting-for-{prod-id-short}-end-users_{context}"]
 = Troubleshooting for {prod-short} end users
 
 :context: troubleshooting-for-che-end-users
 
 
-This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. Can include more than one paragraph. Consider using the information from the user story.
 
-.Prerequisites
-
-* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
-* You can also link to other modules or assemblies the user must follow before starting this assembly.
-* Delete the section title and bullets if the assembly has no prerequisites.
-
-
-Include modules here.
-
-
-
-== Related information
+////
+. Additional information
 
 * A bulleted list of links to other material closely related to the contents of the concept module.
 * For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+////
 
 :context: {parent-context-of-troubleshooting-for-che-end-users}

--- a/src/main/pages/che-7/end-user-guide/assembly_using-a-visual-studio-code-extension-in-che.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_using-a-visual-studio-code-extension-in-che.adoc
@@ -1,16 +1,17 @@
 ---
 title: Using a Visual Studio Code extension in Che
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/using-a-visual-studio-code-extension-in-che/
 folder: che-7/end-user-guide
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-using-a-visual-studio-code-extension-in-che: {context}
 
-[id='using-a-visual-studio-code-extension-in-{prod-id-short}']
+[id="using-a-visual-studio-code-extension-in-{prod-id-short}"]
 = Using a Visual Studio Code extension in {prod-short}
 
 :context: using-a-visual-studio-code-extension-in-che
@@ -19,9 +20,9 @@ Starting with {prod} {prod-ver}, Visual Studio Code (VS Code) extensions can be 
 
 This document describes:
 
-* Use of a VS Code extension in {prod-short} with workspaces
-* {prod-short} Plug-ins panel
-* How to publish a VS Code extension in the {prod-short} plug-in registry (to share the extension with other {prod-short} users)
+* Use of a VS Code extension in {prod-short} with workspaces.
+* {prod-short} Plug-ins panel.
+* How to publish a VS Code extension in the {prod-short} plug-in registry (to share the extension with other {prod-short} users).
 +
 ** The extension-hosting sidecar container and the use of the extension in a devfile are optional for this.
 ** How to review the compatibility of the VS Code extensions to be informed whether a specific API is supported or has not been implemented yet.

--- a/src/main/pages/che-7/end-user-guide/assembly_using-alternative-ides-in-che.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_using-alternative-ides-in-che.adoc
@@ -1,16 +1,17 @@
 ---
 title: Using alternative IDEs in Che
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/using-alternative-ides-in-che/
 folder: che-7/end-user-guide
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-using-alternative-ides-in-che: {context}
 
-[id='using-alternative-ides-in-{prod-id-short}']
+[id="using-alternative-ides-in-{prod-id-short}"]
 = Using alternative IDEs in {prod-short}
 
 :context: using-alternative-ides-in-che
@@ -35,14 +36,14 @@ Extending {prod} developer workspaces using different IDEs (integrated developme
 
 .Bringing custom IDE built from Eclipse Theia
 
-* Creating your own custom IDE based on Eclipse Theia
-* Adding {prod-short}-specific tools to your custom IDE
-* Packaging your custom IDE into the available editors for {prod-short}
+* Creating your own custom IDE based on Eclipse Theia.
+* Adding {prod-short}-specific tools to your custom IDE.
+* Packaging your custom IDE into the available editors for {prod-short}.
 // TODO: all bullets needs links to docs
 
 .Bringing your completely different web IDE into {prod-short}
 
-* Packaging your custom IDE into the available editors for {prod-short}
-// TODO: bullet needs a lonk to docs
+* Packaging your custom IDE into the available editors for {prod-short}.
+// TODO: bullet needs a link to docs
 
 :context: {parent-context-of-using-alternative-ides-in-che}

--- a/src/main/pages/che-7/end-user-guide/assembly_version-control.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_version-control.adoc
@@ -1,18 +1,19 @@
 ---
 title: Version Control
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/version-control/
 folder: che-7/end-user-guide
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-version-control: {context}
 
 // che-theia-ide-basics
 
-[id='version-control']
+[id="version-control"]
 = Version Control
 
 :context: version-control

--- a/src/main/pages/che-7/end-user-guide/assembly_what-is-a-che-theia-plug-in.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_what-is-a-che-theia-plug-in.adoc
@@ -1,16 +1,17 @@
 ---
 title: What is a Che-Theia plug-in
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/what-is-a-che-theia-plug-in/
 folder: che-7/end-user-guide
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-what-is-a-che-theia-plug-in: {context}
 
-[id='what-is-a-che-theia-plug-in']
+[id="what-is-a-che-theia-plug-in"]
 = What is a Che-Theia plug-in
 
 :context: what-is-a-che-theia-plug-in
@@ -26,7 +27,6 @@ Extending Che-Theia using plug-ins can enable the following capabilities:
 * *Themes:* Build custom themes, extend the UI, or customize icon themes.
 * *Snippets, formatters, and syntax highlighting:* Enhance comfort of use with supported programming languages.
 * *Keybindings:* Add new keymaps and popular keybindings to make the environment feel natural.
-
 
 == Features and benefits of Che-Theia plug-ins
 

--- a/src/main/pages/che-7/end-user-guide/proc_changing-the-configuration-of-an-existing-workspace-from-the-user-dashboard.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_changing-the-configuration-of-an-existing-workspace-from-the-user-dashboard.adoc
@@ -1,4 +1,4 @@
-[id='changing-the-configuration-of-an-existing-workspace-from-the-user-dashboard_{context}']
+[id="changing-the-configuration-of-an-existing-workspace-from-the-user-dashboard_{context}"]
 = Changing the configuration of an existing workspace from the User Dashboard
 
 This section describes how to change the configuration of an existing workspace from the User Dashboard.

--- a/src/main/pages/che-7/installation-guide/assembly_advanced-configuration-options.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_advanced-configuration-options.adoc
@@ -8,9 +8,10 @@ folder: che-7/installation-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-advanced-configuration-options: {context}
 
-[id='advanced-configuration-options_{context}']
+[id="advanced-configuration-options_{context}"]
 = Advanced configuration options
 
 :context: advanced-configuration-options

--- a/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
@@ -1,16 +1,17 @@
 ---
 title: Installing Che in restricted environment
 keywords: air-gap, airgap, offline
-tags: 
+tags:
 sidebar: che_7_docs
 permalink: che-7/installing-che-in-restricted-environment/
 folder: che-7/installation-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-installing-che-in-restricted-environment: {context}
 
-[id='installing-{prod-id-short}-in-restricted-environment_{context}']
+[id="installing-{prod-id-short}-in-restricted-environment_{context}"]
 = Installing {prod-short} in offline mode
 
 :context: installing-{prod-id-short}-in-restricted-environment

--- a/src/main/pages/che-7/installation-guide/assembly_upgrading-che-on-openshift-4-using-the-openshift-web-console.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_upgrading-che-on-openshift-4-using-the-openshift-web-console.adoc
@@ -1,11 +1,11 @@
 :parent-context-of-upgrading-che-on-openshift-4-using-the-openshift-web-console: {context}
 
-[id='upgrading-{prod-id-short}-on-openshift-4-using-the-openshift-web-console_{context}']
+[id="upgrading-{prod-id-short}-on-openshift-4-using-the-openshift-web-console_{context}"]
 = Upgrading {prod-short} on OpenShift 4 using the web console
 
 :context: upgrading-che-on-openshift-4-using-the-operator
 
-This section describes how to upgrade from {prod-short} {prod-prev-ver} to {prod-short} {prod-ver} on OpenShift 4 using the OpenShift web console. This method is using the Operator from OperatorHub. 
+This section describes how to upgrade from {prod-short} {prod-prev-ver} to {prod-short} {prod-ver} on OpenShift 4 using the OpenShift web console. This method is using the Operator from OperatorHub.
 
 include::proc_preparing-the-upgrade-of-che-on-openshift-using-the-operator.adoc[leveloffset=+1]
 

--- a/src/main/pages/che-7/installation-guide/assembly_upgrading-che.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_upgrading-che.adoc
@@ -8,9 +8,10 @@ folder: che-7/installation-guide
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-upgrading-che: {context}
 
-[id='upgrading-{prod-id-short}_{context}']
+[id="upgrading-{prod-id-short}_{context}"]
 = Upgrading {prod-short}
 
 :context: ugrading-{prod-id-short}

--- a/src/main/pages/che-7/overview/assembly_che-architecture.adoc
+++ b/src/main/pages/che-7/overview/assembly_che-architecture.adoc
@@ -9,10 +9,9 @@ summary:
 ---
 
 :page-liquid:
-
 :parent-context-of-che-architectural-elements: {context}
 
-[id='{prod-id-short}-architectural-elements']
+[id="{prod-id-short}-architectural-elements"]
 = {prod-short} architectural elements
 
 :context: che-architectural-elements

--- a/src/main/pages/che-7/overview/assembly_che-quick-starts.adoc
+++ b/src/main/pages/che-7/overview/assembly_che-quick-starts.adoc
@@ -10,9 +10,10 @@ folder: che-7/overview
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-che-quick-starts: {context}
 
-[id='{prod-id-short}-quick-starts_{context}']
+[id="{prod-id-short}-quick-starts_{context}"]
 = {prod-short} quick-starts
 
 :context: che-quick-starts

--- a/src/main/pages/che-7/overview/assembly_che-workspace-components.adoc
+++ b/src/main/pages/che-7/overview/assembly_che-workspace-components.adoc
@@ -1,6 +1,6 @@
 :parent-context-of-che-workspace-components: {context}
 
-[id='{prod-id-short}-workspace-components_{context}']
+[id="{prod-id-short}-workspace-components_{context}"]
 = {prod-short} workspace components
 
 :context: che-workspace-components

--- a/src/main/pages/che-7/overview/assembly_che-workspace-configuration.adoc
+++ b/src/main/pages/che-7/overview/assembly_che-workspace-configuration.adoc
@@ -1,6 +1,6 @@
 :parent-context-of-che-workspace-configuration: {context}
 
-[id='{prod-id-short}-workspace-configuration_{context}']
+[id="{prod-id-short}-workspace-configuration_{context}"]
 = {prod-short} workspace configuration
 
 :context: che-workspace-configuration

--- a/src/main/pages/che-7/overview/assembly_che-workspace-controller.adoc
+++ b/src/main/pages/che-7/overview/assembly_che-workspace-controller.adoc
@@ -1,16 +1,17 @@
 ---
 title: Che workspace controller
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/che-workspace-controller/
 folder: che-7/overview
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-che-workspace-controller: {context}
 
-[id='{prod-id-short}-workspace-controller_{context}']
+[id="{prod-id-short}-workspace-controller_{context}"]
 = {prod-short} workspace controller
 
 :context: che-workspace-controller

--- a/src/main/pages/che-7/overview/assembly_che-workspaces-architecture.adoc
+++ b/src/main/pages/che-7/overview/assembly_che-workspaces-architecture.adoc
@@ -1,16 +1,17 @@
 ---
 title: Che workspaces architecture
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/che-workspaces-architecture/
 folder: che-7/overview
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-che-workspaces-architecture: {context}
 
-[id='{prod-id-short}-workspaces-architecture_{context}']
+[id="{prod-id-short}-workspaces-architecture_{context}"]
 = {prod-short} workspaces architecture
 
 :context: che-workspaces-architecture

--- a/src/main/pages/che-7/overview/assembly_deploying-che-on-kubernetes-on-aws.adoc
+++ b/src/main/pages/che-7/overview/assembly_deploying-che-on-kubernetes-on-aws.adoc
@@ -9,10 +9,10 @@ summary:
 ---
 
 // che-quick-starts
-
+:page-liquid:
 :parent-context-of-deploying-che-on-kubernetes-on-aws: {context}
 
-[id='deploying-{prod-id-short}-on-kubernetes-on-aws_{context}']
+[id="deploying-{prod-id-short}-on-kubernetes-on-aws_{context}"]
 = Deploying {prod-short} on Kubernetes on AWS
 
 :context: deploying-che-on-kubernetes-on-aws

--- a/src/main/pages/che-7/overview/assembly_installing-che-on-google-cloud-platform.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-che-on-google-cloud-platform.adoc
@@ -1,16 +1,17 @@
 ---
 title: Installing Che on Google Cloud Platform
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/installing-che-on-google-cloud-platform/
 folder: che-7/overview
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-installing-che-on-google-cloud-platform: {context}
 
-[id='installing-{prod-id-short}-on-google-cloud-platform_{context}']
+[id="installing-{prod-id-short}-on-google-cloud-platform_{context}"]
 = Installing {prod-short} on Google Cloud Platform
 
 :context: installing-che-on-google-cloud-platform

--- a/src/main/pages/che-7/overview/assembly_installing-che-on-microsoft-azure.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-che-on-microsoft-azure.adoc
@@ -1,21 +1,26 @@
 ---
 title: Installing Che on Microsoft Azure
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/installing-eclipse-che-on-microsoft-azure/
 folder: che-7/installation-guide
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-installing-che-on-microsoft-azure: {context}
 
-[id='installing-{prod-id-short}-on-microsoft-azure_{context}']
+[id="installing-{prod-id-short}-on-microsoft-azure_{context}"]
 = Installing {prod-short} on Microsoft Azure
 
 :context: installing-che-on-microsoft-azure
 
-include::proc_preparing-azure-for-installing-che.adoc[leveloffset=+1] 
+Microsoft Azure is a cloud computing service created by Microsoft for building, testing, deploying, and managing applications and services through Microsoft-managed data centers.
+
+This section provides information about installing, enabling, and basic use of {prod-short} on Microsoft Azure.
+
+include::proc_preparing-azure-for-installing-che.adoc[leveloffset=+1]
 
 include::proc_installing-ingress-on-kubernetes.adoc[leveloffset=+1]
 
@@ -30,5 +35,3 @@ include::proc_installing-cert-manager.adoc[leveloffset=+1]
 include::proc_installing-che-on-azure-using-the-chectl-command.adoc[leveloffset=+1]
 
 :context: {parent-context-of-installing-che-on-microsoft-azure}
-
-

--- a/src/main/pages/che-7/overview/assembly_installing-che-on-openshift-3-using-the-operator.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-che-on-openshift-3-using-the-operator.adoc
@@ -1,21 +1,31 @@
 ---
 title: Installing Che on OpenShift 3 using the Operator
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/installing-che-on-openshift-3-using-the-operator/
 folder: che-7/overview
-summary: 
+summary:
 ---
 
 // che-quick-starts
-
+:page-liquid:
 :parent-context-of-installing-che-on-openshift-3-using-the-operator: {context}
 
-[id='installing-{prod-id-short}-on-openshift-3-using-the-operator_{context}']
+[id="installing-{prod-id-short}-on-openshift-3-using-the-operator_{context}"]
 = Installing {prod-short} on OpenShift 3 using the Operator
 
 :context: installing-{prod-id-short}-on-openshift-3-using-the-operator
+
+Operators are a method of packaging, deploying, and managing a Kubernetes application which also provide the following:
+
+* Repeatability of installation and upgrade.
+
+* Constant health checks of every system component.
+
+* Over-the-air (OTA) updates for OpenShift components and ISV content.
+
+* A place to encapsulate knowledge from field engineers and spread it to all users.
 
 This chapter describes how to install {prod-short} on OpenShift 3, with the CLI management tool, using the Operator method.
 

--- a/src/main/pages/che-7/overview/assembly_installing-che-on-openshift-4-from-operatorhub.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-che-on-openshift-4-from-operatorhub.adoc
@@ -1,23 +1,34 @@
 ---
 title: Installing Che on OpenShift 4 from OperatorHub
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/installing-che-on-openshift-4-from-operatorhub/
 folder: che-7/overview
-summary: 
+summary:
 ---
 
 // che-quick-starts
-
+:page-liquid:
 :parent-context-of-installing-che-on-openshift-4-from-operatorhub: {context}
 
-[id='installing-{prod-id-short}-on-openshift-4-from-operatorhub_{context}']
+[id="installing-{prod-id-short}-on-openshift-4-from-operatorhub_{context}"]
 = Installing {prod-short} on OpenShift 4 from OperatorHub
 
 :context: installing-{prod-id-short}-on-openshift-4-from-operatorhub
 
+Operators are a method of packaging, deploying, and managing a Kubernetes application which also provide the following:
+
+* Repeatability of installation and upgrade.
+
+* Constant health checks of every system component.
+
+* Over-the-air (OTA) updates for OpenShift components and ISV content.
+
+* A place to encapsulate knowledge from field engineers and spread it to all users.
+
 On OpenShift, {prod} can be installed using the OperatorHub Catalog present in the OpenShift web console.
+
 Following steps are described:
 
 * xref:creating-the-{prod-id-short}-project-in-openshift-4-web-console_{context}[].
@@ -36,7 +47,7 @@ Following steps are described:
 
 * xref:enabling-ssl-on-openshift-4_{context}[].
 
-* xref:logging-in-to-{prod-id-short}-on-openshift-for-the-first-time-using-oauth_{context}[] 
+* xref:logging-in-to-{prod-id-short}-on-openshift-for-the-first-time-using-oauth_{context}[].
 
 * xref:logging-in-to-{prod-id-short}-on-openshift-for-the-first-time-registering-as-a-new-user_{context}[].
 
@@ -61,4 +72,3 @@ include::proc_logging-in-to-che-on-openshift-for-the-first-time-using-oauth.adoc
 include::proc_logging-in-to-che-on-openshift-for-the-first-time-registering-as-a-new-user.adoc[leveloffset=+1]
 
 :context: {parent-context-of-installing-che-on-openshift-4-from-operatorhub}
-

--- a/src/main/pages/che-7/overview/assembly_installing-the-chectl-management-tool.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-the-chectl-management-tool.adoc
@@ -8,9 +8,10 @@ folder: che-7/overview
 summary:
 ---
 
+:page-liquid:
 :parent-context-of-installing-the-chectl-management-tool: {context}
 
-[id='installing-the-{prod-cli}-management-tool_{context}']
+[id="installing-the-{prod-cli}-management-tool_{context}"]
 = Installing the {prod-cli} management tool
 
 :context: installing-the-{prod-cli}-management-tool

--- a/src/main/pages/che-7/overview/assembly_introduction-to-eclipse-che.adoc
+++ b/src/main/pages/che-7/overview/assembly_introduction-to-eclipse-che.adoc
@@ -1,6 +1,6 @@
 ---
 title: Introduction to Eclipse Che
-keywords: 
+keywords:
 tags: [Che]
 sidebar: che_7_docs
 permalink: che-7/introduction-to-eclipse-che/
@@ -8,38 +8,38 @@ redirect_from:
   - che-7/index.html
   - index.html
 folder: che-7/overview
-summary: 
+summary:
 ---
 
+:page-liquid:
 :parent-context-of-introduction-to-eclipse-che: {context}
 
-[id='introduction-to-eclipse-che_{context}']
+[id="introduction-to-eclipse-che_{context}"]
 = Introduction to {prod}
 
 :context: introduction-to-eclipse-che
 
-{prod} is a Kubernetes-native IDE and developer collaboration platform. It provides: 
+{prod} is a Kubernetes-native IDE and developer collaboration platform. It provides:
 
-* Centralized developer environments running on Kubernetes 
-* Multi-container workspaces for each developer that can be replicated with a single click through {prod} 
+* Centralized developer environments running on Kubernetes
+* Multi-container workspaces for each developer that can be replicated with a single click through {prod}
 factories
-* Pre-built stacks with the ability to create custom stacks for any language or runtime  
-* Enterprise integration via Keycloak for AD/LDAP  
-* Browser-based IDEs; integration with Che-Theia or any other web IDE (like Jupyter) 
+* Pre-built stacks with the ability to create custom stacks for any language or runtime
+* Enterprise integration via Keycloak for AD/LDAP
+* Browser-based IDEs; integration with Che-Theia or any other web IDE (like Jupyter)
 * Support of most recent tooling protocols: Language Server Protocol, Debug Adapter Protocol
 * Plug-in mechanism compatible with Visual Studio Code extensions
 * An SDK for creating custom cloud developer platforms
-
 
 [id="getting-started-with-{prod-id-short}"]
 == Getting started with {prod-short}
 
 Get started with {prod} by:
 
-* Following the link:{site-baseurl}che-7/running-che-locally[quick-start guide] to get {prod} installed locally on your computer
-* Learning more about {prod}: xref:what-is-eclipse-{prod-id-short}[What is {prod}] and link:{site-baseurl}che-7/high-level-{prod-id-short}-architecture[Architecture overview]
+* Following the link:{site-baseurl}che-7/running-che-locally[quick-start guide] to get {prod} installed locally on your computer.
+* Learning more about {prod}: xref:what-is-eclipse-{prod-id-short}[What is {prod}] and link:{site-baseurl}che-7/high-level-{prod-id-short}-architecture[Architecture overview].
 // TODO: link:che-features-and-benefits.html[Features and benefits of {prod}]
-* Discovering {prod} capabilities
+* Discovering {prod} capabilities.
 
 
 == Joining the community
@@ -56,15 +56,13 @@ Interested in joining the community? Join us on the following channels:
 [id="what-is-eclipse-{prod-id-short}"]
 == What is {prod}
 
-{prod} is a Kubernetes-native IDE and developer collaboration platform. 
+{prod} is a Kubernetes-native IDE and developer collaboration platform.
 
 As an open-source project, the core goals of {prod} are to:
 
 * *Accelerate project and developer onboarding:* As a zero-install development environment that runs in your browser, {prod} makes it easy for anyone to join your team and contribute to a project.
 * **Remove inconsistency between developer environments:** No more: “But it works on my machine.” Your code works exactly the same way in everyone’s environment.
 * *Provide built-in security and enterprise readiness:* As {prod} becomes a viable replacement for VDI solutions, it must be secure and it must support enterprise requirements, such as role-based access control and the ability to remove all source code from developer machines.
-
-
 
 To achieve those core goals, {prod} provides:
 
@@ -73,7 +71,6 @@ To achieve those core goals, {prod} provides:
 * *Extensible platform:* Bring your own IDE. Define, configure, and extend the tools that you need for your application by using plug-ins, which are compatible with Visual Studio Code extensions.
 * *Enterprise Integration:* Multi-user capabilities, including Keycloak for authentication and integration with LDAP or AD.
 
-
 === Workspace model
 
 {prod-short} defines the workspace to be the project code files and all of their dependencies necessary to edit, build, run, and debug them. {prod-short} treats the IDE and the development runtime as dependencies of the workspace. These items are embedded and always included with the workspace. This differentiates {prod-short} from classical workspace definitions, which may include the project code, but require the developer to bind their IDE to their workstation and use it to provide a runtime locally.
@@ -81,7 +78,6 @@ To achieve those core goals, {prod} provides:
 Workspaces are isolated from one another and are responsible for managing the lifecycle of their components.
 
 Developers using {prod} use their containers directly in their developer workspaces. *{prod-short} workspaces are Kubernetes pods, which allow to replicate the application runtimes (and its microservices) used in production* and provide a “dev mode” layer on top of those, adding intellisense and IDE toolings.
-
 
 === Browser-based IDEs
 
@@ -126,15 +122,13 @@ For situations in which the default IDE does not cover the use cases of the user
 
 {prod} uses Che-Theia as its default browser-based IDE. Che-Theia provides a framework to build web IDEs. It is built in TypeScript and gives contributors a programming model that is flexible, relies on state-of-the-art tooling protocols, and makes it faster to build new tools.
 
-In {prod}, the dependencies needed for the tools running in the user's workspace are available when needed. This means that a Che-Theia plug-in provides its dependencies, its back-end services (which could be running in a sidecar container connected to the user’s workspace), and the IDE UI extension. {prod-short} packages all these elements together, so that the user does not have to configure different tools together. 
+In {prod}, the dependencies needed for the tools running in the user's workspace are available when needed. This means that a Che-Theia plug-in provides its dependencies, its back-end services (which could be running in a sidecar container connected to the user’s workspace), and the IDE UI extension. {prod-short} packages all these elements together, so that the user does not have to configure different tools together.
 
 ==== Visual Studio Code extension compatibility
-
 
 {prod} rationalizes the effort for a contributor who wants to build a plug-in and distribute it to different developer communities and tools. For that purpose, {prod} features a plug-in API compatible with extension points from Visual Studio Code. As a result, it is easy to bring an existing plug-in from Visual Studio Code into {prod}. The main difference is in the way the plug-ins are packaged. On {prod}, plug-ins are delivered with their own dependencies in their own container.
 
 video::HbTKDlOL1eo[youtube]
-
 
 === Enterprise integration
 
@@ -142,8 +136,7 @@ video::HbTKDlOL1eo[youtube]
 
 * Every {prod} user gets a centralized developer workspace that can be easily defined, administered, and managed.
 
-* As a Kubernetes-native application, {prod} provides state-of-the-art monitoring and tracing capabilities, integrating with link:https://prometheus.io/[Prometheus] and link:https://grafana.com/[Grafana]. 
-
+* As a Kubernetes-native application, {prod} provides state-of-the-art monitoring and tracing capabilities, integrating with link:https://prometheus.io/[Prometheus] and link:https://grafana.com/[Grafana].
 
 //include::con_introductory-videos.adoc[leveloffset=+1]
 
@@ -151,10 +144,9 @@ video::HbTKDlOL1eo[youtube]
 
 include::ref_che-7-known-issues.adoc[leveloffset=+1]
 
-
-// [id='related-information-{context}']
+// [id="related-information-{context}"]
 // == Related information
-// 
+//
 // * A bulleted list of links to other material closely related to the contents of the concept module.
 // * For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 // * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/src/main/pages/che-7/overview/assembly_preparing-google-cloud-platform-for-installing-che.adoc
+++ b/src/main/pages/che-7/overview/assembly_preparing-google-cloud-platform-for-installing-che.adoc
@@ -1,7 +1,11 @@
 :parent-context-of-preparing-google-cloud-platform-for-installing-che: {context}
 
-[id='preparing-google-cloud-platform-for-installing-che_{context}']
+[id="preparing-google-cloud-platform-for-installing-che_{context}"]
 = Preparing Google Cloud Platform for installing {prod-short}
+
+Google Cloud Platform (GCP) is a suite of cloud computing services that provides infrastructure as a service, platform as a service, and serverless computing environments.
+
+This section provides information about how to set up the GCP environment for installing {prod}.
 
 :context: preparing-google-cloud-platform-for-installing-che
 

--- a/src/main/pages/che-7/overview/proc_configuring-dns-on-azure.adoc
+++ b/src/main/pages/che-7/overview/proc_configuring-dns-on-azure.adoc
@@ -1,4 +1,4 @@
-[id='configuring-DNS-on-azure_{context}']
+[id="configuring-DNS-on-azure_{context}"]
 = Configuring DNS on Azure
 
 .Procedure
@@ -9,7 +9,7 @@ To configure DNS on Azure:
 +
 image::installation/dns-zone-in-microsoft-azure.png[link="{imagesdir}/installation/dns-zone-in-microsoft-azure.png"]
 
-. Create a new zone. 
+. Create a new zone.
 +
 .. In the *Resource group* drop-down list, click *eclipseCheResourceGroup*.
 +

--- a/src/main/pages/che-7/overview/proc_creating-a-service-account-secret-on-azure.adoc
+++ b/src/main/pages/che-7/overview/proc_creating-a-service-account-secret-on-azure.adoc
@@ -1,4 +1,4 @@
-[id='creating-a-service-account-secret-on-azure_{context}']
+[id="creating-a-service-account-secret-on-azure_{context}"]
 = Creating a Service Account Secret on Azure
 
 The secret must be in the *cert-manager* namespace. Otherwise the secret cannot be found, and cert-manager reports errors.

--- a/src/main/pages/che-7/overview/proc_enabling-the-tls-dns-challenge-on-azure.adoc
+++ b/src/main/pages/che-7/overview/proc_enabling-the-tls-dns-challenge-on-azure.adoc
@@ -1,4 +1,4 @@
-[id='enabling-the-TLS-DNS-challenge-on-azure_{context}']
+[id="enabling-the-TLS-DNS-challenge-on-azure_{context}"]
 = Enabling the TLS and DNS challenge on Azure
 
 To use Azure DNS and TLS, permissions must be granted to have cert-manager managing the DNS challenge for the _Let’s Encrypt_ service.

--- a/src/main/pages/che-7/overview/proc_installing-cert-manager.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-cert-manager.adoc
@@ -1,4 +1,4 @@
-[id='installing-cert-manager-on-azure_{context}']
+[id="installing-cert-manager-on-azure_{context}"]
 = Installing cert-manager on Azure
 
 
@@ -47,10 +47,10 @@ spec:
             name: azuredns-config
             key: CLIENT_SECRET
           # Azure subscription Id that can be obtained with command:
-          # $ az account show  | jq -r '.id' 
+          # $ az account show  | jq -r '.id'
           subscriptionID: <SUBSCRIPTION_ID>
           # Azure AD tenant Id that can be obtained with command:
-          # $ az account show  | jq -r '.tenantId' 
+          # $ az account show  | jq -r '.tenantId'
           tenantID: <TENANT_ID>
           resourceGroupName: eclipseCheResourceGroup
           # The DNS Zone to use
@@ -97,7 +97,7 @@ The cert-manager logs should contain information about the DNS challenge.
 . Obtain the logs using the following command (here, `cert-manager-8d478bb45-2924h` is the name of the cert-manager pod):
 +
 ----
-$  kubectl logs -f -n cert-manager cert-manager-8d478bb45-2924h 
+$  kubectl logs -f -n cert-manager cert-manager-8d478bb45-2924h
 ----
 
 . Ensure that the certificate is ready:

--- a/src/main/pages/che-7/overview/proc_installing-che-on-azure-using-the-chectl-command.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-azure-using-the-chectl-command.adoc
@@ -1,13 +1,13 @@
 :page-liquid:
 
-[id='installing-{prod-id-short}-on-azure-using-the-chectl-command_{context}']
+[id="installing-{prod-id-short}-on-azure-using-the-chectl-command_{context}"]
 = Installing {prod-short} on Azure using the chectl command
 
 .Prerequisites
 
 * The `chectl` management tool is installed. See link:{site-baseurl}che-7/installing-the-chectl-management-tool/[Installing the `chectl` management tool].
 * link:https://helm.sh/[Helm] version 2.15 or higher
- 
+
 .Procedure
 
 * To install {prod-short}, run the following `chectl` command:

--- a/src/main/pages/che-7/overview/proc_preparing-azure-for-installing-che.adoc
+++ b/src/main/pages/che-7/overview/proc_preparing-azure-for-installing-che.adoc
@@ -1,4 +1,4 @@
-[id='preparing-azure-for-installing-che_{context}']
+[id="preparing-azure-for-installing-che_{context}"]
 = Preparing Azure for installing {prod-short}
 
 

--- a/src/main/pages/che-7/overview/ref_che-7-known-issues.adoc
+++ b/src/main/pages/che-7/overview/ref_che-7-known-issues.adoc
@@ -1,4 +1,4 @@
-[id='{prod-id-short}-known-issues']
+[id="{prod-id-short}-known-issues"]
 = {prod-short} {prod-ver}.3 known issues
 
 This section contains information about selected existing issues known at the time of the {prod} {prod-ver}.3 release that affect user experience.
@@ -7,21 +7,19 @@ This section contains information about selected existing issues known at the ti
 
 When installing {prod} in the `default` namespace, the proper security contexts and file permissions are not set appropriately, causing the installation to fail.  Users should avoid installing {prod} in the `default` namespace and instead create a new namespace, for example, `che`, to contain the {prod} installation.
 
-Issue: link:https://github.com/eclipse/che/issues/14426[]
-
+Issue description: link:https://github.com/eclipse/che/issues/14426[]
 
 == Language-support plug-ins potential malfunction
 
 Some language-support plug-ins (in particular Java, Python, and C#) may experience issues detecting newly cloned projects. When experiencing problems with features such as code assist, try refreshing the page in the browser (press kbd:[F5]).
 
-Issue: link:https://github.com/eclipse/che/issues/13427[]
-
+Issue description: link:https://github.com/eclipse/che/issues/13427[]
 
 == Bright fonts are not set in dark theme in Firefox
 
 When using the {prod} dark theme in Firefox, workspace content is rendered using a black-color font. This makes the content unreadable.
 
-Issue: link:https://github.com/eclipse/che/issues/13442[]
+Issue description: link:https://github.com/eclipse/che/issues/13442[]
 
 == Workspace start failures when StorageClass configured with `volumeBindingMode` set to `WaitForFirstConsumer` on OpenShift older than 4.2
 
@@ -32,10 +30,10 @@ To work around the issue, use one the following:
 * Reconfigure {prod} and remove `FailedScheduling` from the `che.infra.kubernetes.workspace_unrecoverable_events` property value (in the `che.properties` file or deployment configuration)
 * Upgrade the OpenShift installation to version 4.2 or higher.
 
-Issue: link:https://github.com/eclipse/che/issues/14670[]
+Issue description: link:https://github.com/eclipse/che/issues/14670[]
 
 == Other issues
 
-* link:https://github.com/eclipse/che/issues/13717[Prevent Operator removal while it still has some CRs to manage]
+* link:https://github.com/eclipse/che/issues/13717[Prevent Operator removal while it still has some CRs to manage].
 
 See the full list of link:https://github.com/eclipse/che/issues?&q=is%3Aopen+is%3Aissue+label%3Atarget%2Fche7+label%3Akind%2Fbug[{prod-short} {prod-ver} issues on GitHub].


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

* Substituting single quotes for double ones.
* Adding :page-liquid: attribute to the pages that have an entry in the navigation bar.
* Fixing typos, markup and missing `.` in some modules.
* Adding intro for:
                            * OpenShift 3,4 OperatorHub installation method
                            * Microsoft Azure assembly
                            * Google cloud platform assembly   
