### PR TITLE
Added slash

### DIFF
--- a/src/main/pages/che-7/administration-guide/ref_configuring-system-variables.adoc
+++ b/src/main/pages/che-7/administration-guide/ref_configuring-system-variables.adoc
@@ -3,7 +3,7 @@ title: Configuring system variables
 keywords:
 tags: []
 sidebar: che_7_docs
-permalink: che-7/configuring-system-variables
+permalink: che-7/configuring-system-variables/
 folder: che-7/administration-guide
 summary:
 ---


### PR DESCRIPTION
### What does this PR do?
Adds missing slash to `ref_configuring-system-variables.adoc`. Should fix the address.

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to. 