### PR TITLE
I1687 adding a missing intro

### DIFF
--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -62,6 +62,7 @@ asciidoc_attributes: &asciidoc_attributes
   link-accessing-a-git-repository-via-https: link:{site-baseurl}che-7/version-control/#accessing-a-git-repository-via-https_version-control[Accessing a Git repository via HTTPS]
   link-limits-for-the-workspaces-of-an-user: link:{site-baseurl}che-7/advanced-configuration-options/#limits-for-the-workspaces-of-an-user[Limits for the workspaces of an user]
   link-viewing-the-state-of-the-cluster-deployment-using-openshift-4-cli-tools: link:{site-baseurl}che-7/installing-che-on-openshift-4-from-operatorhub/#viewing-the-state-of-the-che-cluster-deployment-using-openshift-4-cli-tools_installing-che-on-openshift-4-from-operatorhub[Viewing the state of the {prod-short} cluster deployment using OpenShift 4 CLI tools]
+  link-building-a-custom-plug-in-registry: link:{site-baseurl}che-7/building-and-running-a-custom-registry-image/#building-a-custom-devfile-registry_building-and-running-a-custom-registry-image[Building a custom plug-in registry]
 
   imagesdir: /images
   site-baseurl: /

--- a/src/main/pages/che-7/administration-guide/assembly_authorizing-users.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_authorizing-users.adoc
@@ -1,11 +1,11 @@
 ---
 title: Authorizing users
-keywords: 
+keywords:
 tags: []
 sidebar: che_7_docs
 permalink: che-7/authorizing-users/
 folder: che-7/administration-guide
-summary: 
+summary:
 ---
 
 // This assembly is included in the following assemblies:
@@ -39,7 +39,7 @@ include::ref_managesystem-permission.adoc[leveloffset=+1]
 
 include::ref_monitorsystem-permission.adoc[leveloffset=+1]
 
-ifeval::["{project-context} == "che"]
+ifeval::["{project-context}" == "che"]
 include::con_super-privileged-mode.adoc[leveloffset=+1]
 endif::[]
 

--- a/src/main/pages/che-7/administration-guide/proc_building-a-custom-plug-in-registry.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_building-a-custom-plug-in-registry.adoc
@@ -1,11 +1,13 @@
+// building-and-running-a-custom-registry-image
+
 [id="building-a-custom-plug-in-registry_{context}"]
 = Building a custom plug-in registry
 
 This section describes how to build a custom plug-in registry. Following operations are covered:
 
-* getting a copy of the source code necessary to build a custom plug-in registry,
-* adding a new plug-in,
-* building the custom plug-in registry.
+* Getting a copy of the source code necessary to build a custom plug-in registry.
+* Adding a new plug-in.
+* Building the custom plug-in registry.
 
 .Procedure
 

--- a/src/main/pages/che-7/end-user-guide/assembly_publishing-a-vs-code-extension-into-the-che-plug-in-registry.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_publishing-a-vs-code-extension-into-the-che-plug-in-registry.adoc
@@ -5,9 +5,18 @@
 
 :context: publishing-a-vs-code-extension-into-the-che-plug-in-registry
 
-// PUT SOME INTRO HERE
-// TODO: To set up a custom plug-in registry, see the link:[Registries customization] article.
+The user of {prod-short} can use a workspace devfile to use any plug-in, also known as Visual Studio code (VS Code) extension. This plug-in can be added to the plug-in registry, then easily reused by anyone in the same organization with access to that workspaces installation.
+
+Some plug-ins need a runtime dedicated container for code compilation. This fact makes those plug-ins a combination of a runtime sidecar container and a VS Code extension.
+
+The following section describes the portability of a plug-in configuration and associating an extension with a runtime container that the plug-in needs.
 
 include::proc_writing-a-meta-yaml-file-and-adding-it-to-a-plug-in-registry.adoc[leveloffset=+1]
+
+// TODO: remove this condition when the downstream counterpart is fixed - currently commented out
+ifeval::["{project-context}" == "che"]
+.Additional resources
+To set up a custom plug-in registry, see: {link-building-a-custom-plug-in-registry}.
+endif::[]
 
 :context: {parent-context-of-publishing-a-vs-code-extension-into-the-che-plug-in-registry}

--- a/src/main/pages/che-7/end-user-guide/proc_writing-a-meta-yaml-file-and-adding-it-to-a-plug-in-registry.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_writing-a-meta-yaml-file-and-adding-it-to-a-plug-in-registry.adoc
@@ -1,3 +1,5 @@
+// publishing-a-vs-code-extension-into-the-che-plug-in-registry
+
 [id="proc_writing-a-meta-yaml-file-and-adding-it-to-a-plug-in-registry_{context}"]
 = Writing a meta.yaml file and adding it to a plug-in registry
 


### PR DESCRIPTION
Signed-off-by: Michal Maléř mmaler@redhat.com

* Adding the missing intro
* Creating a new attribute for a link substitution (currently this link is in an `ifeval` condition)
* Adding missing context information about "mother assemblies"
* Fixing one broken `ifeval` condition (there was a `"` missing)