### PR TITLE
enviromnent_docs_gen.sh script fix

### DIFF
--- a/tools/enviromnent_docs_gen.sh
+++ b/tools/enviromnent_docs_gen.sh
@@ -76,7 +76,7 @@ parse_content() {
       BUFF="$BUFF $ENV,\"$VALUE\",\"${DESCR_BUFF//\"/\'}\" $NEWLINE"   # apply key value and description buffer
     fi
   done <<< "$RAW_CONTENT"
-  BUFF="$BUFF $TABLE_FOOTER"                            # close last table
+  BUFF="$BUFF$TABLE_FOOTER"                             # close last table
   echo "$BUFF" > $OUTPUT_PATH                           # flush buffer into file
   echo "Processing done. Output file is $OUTPUT_PATH" >&2
 }


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

Fixing:
1. `asciidoctor: WARNING: examples/system-variables.adoc: line 292: unterminated table block`
1. `asciidoctor: WARNING: system-variables.adoc: line 292: unterminated table block`

* Line 76 adds the last NEWLINE into the output file.
* Line 79 adds the table's ending but also an additional `space,` which can cause trouble.

No errors were shown during the build with the fixed script.

![image](https://user-images.githubusercontent.com/48474054/76760785-8e619c00-678e-11ea-827d-49a75246de17.png)

![image](https://user-images.githubusercontent.com/48474054/76760733-7558eb00-678e-11ea-994b-65d5e7d0b949.png)
