### PR TITLE
Set correct self signed certificte secret name for Kubernetes infrastructure

### DIFF
--- a/src/main/pages/che-7/contributor-guide/proc_deploy-che-with-self-signed-tls-on-kubernetes.adoc
+++ b/src/main/pages/che-7/contributor-guide/proc_deploy-che-with-self-signed-tls-on-kubernetes.adoc
@@ -38,7 +38,7 @@ $ kubectl create secret tls che-tls --key=domain.key --cert=domain.crt -n che
 [subs="+quotes"]
 ----
 $ cp rootCA.crt ca.crt
-$ kubectl create secret generic self-signed-cert --from-file=ca.crt -n che
+$ kubectl create secret generic self-signed-certificate --from-file=ca.crt -n che
 ----
 
 

--- a/src/main/pages/che-7/overview/ref_che-deployment-options-using-chectl.adoc
+++ b/src/main/pages/che-7/overview/ref_che-deployment-options-using-chectl.adoc
@@ -42,5 +42,5 @@ OPTIONS
 
   --plugin-registry-url=plug-in-registry-url                                    The URL of the external plug-in registry.
 
-  --self-signed-cert                                                           Authorize usage of self signed certificates for encryption. Note that `self-signed-cert` secret with CA certificate must be created in the configured namespace.
+  --self-signed-cert                                                           Authorize usage of self signed certificates for encryption. Note that `self-signed-certificate` secret with CA certificate must be created in the configured namespace.
 ----


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Fixes mistake in our docs which says to use `self-signed-cert` secret name instead of correct `self-signed-certificate`. By default that would cause Che deployment failure.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16280
Fixes: https://github.com/eclipse/che/issues/16169