### PR TITLE
Added subs=none to prevent rendering of {PLUGIN_REMOTE_ENDPOINT_EXECU…

### DIFF
--- a/src/main/pages/che-7/end-user-guide/proc_defining-a-launch-remote-plug-in-endpoint-using-dockerfile.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_defining-a-launch-remote-plug-in-endpoint-using-dockerfile.adoc
@@ -11,6 +11,7 @@ To start a remote plug-in endpoint, use the `PLUGIN_REMOTE_ENDPOINT_EXECUTABLE` 
 
 * Start a remote plug-in endpoint using the `CMD` command in the Dockerfile:
 +
+[subs="none"]
 ----
 FROM fedora:30
 
@@ -29,6 +30,7 @@ CMD ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
 
 * Start a remote plug-in endpoint using the `ENTRYPOINT` command in the Dockerfile:
 +
+[subs="none"]
 ----
 FROM fedora:30
 


### PR DESCRIPTION
### What does this PR do?
Adds `subs=none` to codeblocks containing {PLUGIN_REMOTE... 
Should stop Asciidoc from trying to render it as attribute and throw this warning:
`asciidoctor: WARNING: skipping reference to missing attribute: plugin_remote_endpoint_executable`

### What issues does this PR fix or reference?
Downstreaming build errors and warnings.

### Specify the version of the product this PR applies to. 