### PR TITLE
Enhancing a procedure about SSH pairs and fixing a typo

### DIFF
--- a/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-ssh.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_accessing-a-git-repository-via-ssh.adoc
@@ -3,20 +3,36 @@
 [id="accessing-a-git-repository-via-ssh_{context}"]
 = Accessing a Git repository via SSH
 
+== Generating an SSH key using the {prod-short} command palette
 
-.Prerequisites
+The following section describes a generation of an SSH key using the {prod-short} command palette and its further use in Git provider communication. This SSH key restricts permissions for the specific Git provider; thus, the user has to create a unique SSH key for each Git provider in use.
+
+.Prerequsites
+* A running instance of {prod-short}. To install an instance of {prod}, see link:{site-baseurl}che-7/che-quick-starts/[{prod-short} 'quick-starts'].
+
+* An existing workspace defined on this instance of {prod-short} link:{site-baseurl}che-7/creating-and-configuring-a-new-che-7-workspace/[Creating a workspace from user dashboard].
+
 * Personal link:https://help.github.com/en/articles/types-of-github-accounts[GitHub account] or other Git provider account created.
 
-== Generating an SSH key
+.Procedure
 
-A common SSH key that works with all Git providers is present by default. To start using it, add the public key to the Git provider.
+A common SSH key pair that works with all the Git providers is present by default. To start using it, add the public key to the Git provider.
 
-To generate an SSH key pair that only works with a particular Git provider:
+. Generate an SSH key pair that only works with a particular Git provider:
 
-. Run the *SSH: generate key pair for particular host* command. Do this by pressing kbd:[F1] to open the command dialogue box, then begin typing `generate`. You will be given options for SSH key generation.
-. After the key is generated, click the btn:[View] button and copy the public key from the editor.
-. Add the public key to the Git provider.
+** In the {prod-shot} IDE, press kbd:[F1] to open the Command Palette, or navigate to *View -> Find Command* in the top menu.
++
+The *command palette* can be also activated by pressing kbd:[Ctrl+Shift+p] (or kbd:[Cmd+Shift+p] on macOS).
 
+** Search for *SSH: generate key pair for particular host* by entering `generate` into the search box and pressing kbd:[Enter] once filled.
+
+** Provide the hostname for the SSH key pair such as, for example, `github.com`.
++
+The SSH key pair is generated.
+
+. Click the btn:[View] button and copy the public key from the editor and add it to the Git provider.
++
+As a result of this action, the user can now use another command from the command palette: *Clone git repository* by providing an SSH secured URL.
 
 == Adding the associated public key to a repository or account on GitHub
 

--- a/src/main/pages/che-7/extensions/proc_authenticating-with-openshift-connector-in-eclipse-che.adoc
+++ b/src/main/pages/che-7/extensions/proc_authenticating-with-openshift-connector-in-eclipse-che.adoc
@@ -34,7 +34,7 @@ When using a local instance of OpenShift (such as CodeReady Containers or Minish
 The OpenShift Connector panel is displayed.
 . Log in using the OpenShift Application Explorer. Use one of the following methods:
 ** Click the btn:[Log in to cluster] button in the top left corner of the pane.
-** Press kbd:[F1] to open the Command Palette, or navigate to *View -> Find Command* top in the top menu.
+** Press kbd:[F1] to open the Command Palette, or navigate to *View -> Find Command* in the top menu.
 +
 Search for *OpenShift: Log in to cluster* and press kbd:[Enter].
 . If a *You are already logged in a cluster.* message appears, click *Yes*.


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

* Adding a content to `Accessing a Git repository via SSH`.

* Changing the name of `Generating an SSH key` to `== Generating an SSH key using the {prod-short} command palette` and enhancing its existing content.

* Fixing typo in the `Authetycating...`  procedure of the OpenShift Connector docs.