### PR TITLE
Fix SSL certificates generation steps

### DIFF
--- a/src/main/pages/che-7/contributor-guide/proc_deploy-che-with-self-signed-tls-on-kubernetes.adoc
+++ b/src/main/pages/che-7/contributor-guide/proc_deploy-che-with-self-signed-tls-on-kubernetes.adoc
@@ -12,7 +12,7 @@ This section describes how to deploy {prod-short} with self-signed TLS certifica
 == Prerequisites
 
 * A running Kubernetes instance, version 1.9 or higher
-* link:{site-baseurl}che-7/setup-che-in-tls-mode-with-self-signed-certificate/#generating-self-signed-certificates_setup-che-in-tls-mode-with-self-signed-certificate[Have all required keys/certificates generated]
+* link:{site-baseurl}che-7/setup-che-in-tls-mode-with-self-signed-certificate/#generating-self-signed-certificates_setup-che-in-tls-mode[Have all required keys/certificates generated]
 
 
 [discrete]
@@ -41,7 +41,6 @@ $ kubectl create secret tls che-tls --key=domain.key --cert=domain.crt -n che
 +
 [subs="+quotes"]
 ----
-$ cp rootCA.crt ca.crt
 $ kubectl create secret generic self-signed-certificate --from-file=ca.crt -n che
 ----
 
@@ -51,5 +50,5 @@ $ kubectl create secret generic self-signed-certificate --from-file=ca.crt -n ch
 +
 [subs="+quotes,+attributes"]
 ----
-$ {prod-cli} server:start --platform=minikube --installer=helm --tls --self-signed-cert
+$ {prod-cli} server:start --platform=minikube --installer=operator --tls --self-signed-cert
 ----

--- a/src/main/pages/che-7/contributor-guide/proc_deploy-che-with-self-signed-tls-on-openhift-using-operator.adoc
+++ b/src/main/pages/che-7/contributor-guide/proc_deploy-che-with-self-signed-tls-on-openhift-using-operator.adoc
@@ -12,7 +12,7 @@ This section describes how to deploy {prod-short} with self-signed TLS certifica
 == Prerequisites
 
 * A running OpenShift instance, version 3.11 or higher
-* link:{site-baseurl}che-7/setup-che-in-tls-mode-with-self-signed-certificate/#generating-self-signed-certificates_setup-che-in-tls-mode-with-self-signed-certificate[Have all required keys/certificates generated]
+* link:{site-baseurl}che-7/setup-che-in-tls-mode-with-self-signed-certificate/#generating-self-signed-certificates_setup-che-in-tls-mode[Have all required keys/certificates generated]
 
 [discrete]
 == Procedure
@@ -52,7 +52,6 @@ $ oc create namespace che
 +
 [subs="+quotes,+attributes"]
 ----
-$ cp rootCA.crt ca.crt
 $ oc create secret generic self-signed-certificate --from-file=ca.crt -n=che
 ----
 

--- a/src/main/pages/che-7/contributor-guide/proc_generating-self-signed-certificates.adoc
+++ b/src/main/pages/che-7/contributor-guide/proc_generating-self-signed-certificates.adoc
@@ -26,13 +26,16 @@ $( minikube ip ).nip.io
 apps-crc.testing
 ----
 
-* Find out `openssl.cnf` file location on target machine
+* Find out `openssl.cnf` file location on target machine.
+  Usual openssl configuration file location is given below.
 
 +
 [subs="+quotes"]
 ----
-# Fedora 31
+# Fedora, Red Hat, CentOS
 /etc/pki/tls/openssl.cnf
+# Debian, Ubuntu, Mint, Arch
+/etc/ssl/openssl.cnf
 ----
 
 [discrete]
@@ -43,7 +46,7 @@ apps-crc.testing
 +
 [subs="+quotes"]
 ----
-$ CA_CN=eclipse-che-signer
+$ CA_CN="Local Eclipse Che Signer"
 $ DOMAIN=*.<expected.domain.com>
 $ OPENSSL_CNF=<path_to_openssl.cnf>
 ----
@@ -52,12 +55,12 @@ $ OPENSSL_CNF=<path_to_openssl.cnf>
 [subs="+quotes"]
 ----
 # Example with minikube on Fedora 31
-$ CA_CN=eclipse-che-signer
+$ CA_CN="Local Eclipse Che Signer"
 $ DOMAIN=\*.$( minikube ip ).nip.io
 $ OPENSSL_CNF=/etc/pki/tls/openssl.cnf
 
 # Example with crc on OSX
-$ export CA_CN=eclipse-che-signer
+$ export CA_CN="Local Eclipse Che Signer"
 $ export DOMAIN=*.apps-crc.testing
 $ export OPENSSL_CNF=/System/Library/OpenSSL/openssl.cnf
 ----
@@ -67,27 +70,26 @@ $ export OPENSSL_CNF=/System/Library/OpenSSL/openssl.cnf
 +
 [subs="+quotes"]
 ----
-$ openssl genrsa -out rootCA.key 4096
+$ openssl genrsa -out ca.key 4096
 ----
 
 
-. Generate root certificate.
+. Generate root CA certificate.
 
 +
 [subs="+quotes"]
 ----
 $ openssl req -x509 \
   -new -nodes \
-  -key rootCA.key \
+  -key ca.key \
   -sha256 \
   -days 1024 \
-  -out rootCA.crt \
-  -subj /CN=${CA_CN} \
+  -out ca.crt \
+  -subj /CN="${CA_CN}" \
   -reqexts SAN \
   -extensions SAN \
   -config <(cat ${OPENSSL_CNF} \
-      <(printf '[SAN]\nbasicConstraints=critical, CA:TRUE\nkeyUsage=keyCertSign, cRLSign, digitalSignature, keyEncipherment'))
-
+      <(printf '[SAN]\nbasicConstraints=critical, CA:TRUE\nkeyUsage=keyCertSign, cRLSign, digitalSignature'))
 ----
 
 
@@ -99,17 +101,17 @@ $ openssl req -x509 \
 $ openssl genrsa -out domain.key 2048
 ----
 
-. Generate domain csr.
+. Generate certificate signing request for the domain.
 
 +
 [subs="+quotes"]
 ----
 $ openssl req -new -sha256 \
     -key domain.key \
-    -subj "/O=EclipseChe/CN=${DOMAIN}" \
+    -subj "/O=Local Eclipse Che/CN=${DOMAIN}" \
     -reqexts SAN \
     -config <(cat ${OPENSSL_CNF} \
-        <(printf "\n[SAN]\nsubjectAltName=DNS:${DOMAIN}\nbasicConstraints=critical, CA:FALSE\nkeyUsage=keyCertSign, digitalSignature, keyEncipherment\nextendedKeyUsage=serverAuth")) \
+        <(printf "\n[SAN]\nsubjectAltName=DNS:${DOMAIN}\nbasicConstraints=critical, CA:FALSE\nkeyUsage=digitalSignature, keyEncipherment, keyAgreement, dataEncipherment\nextendedKeyUsage=serverAuth")) \
     -out domain.csr
 ----
 
@@ -120,16 +122,16 @@ $ openssl req -new -sha256 \
 [subs="+quotes"]
 ----
 $ openssl x509 \
--req \
--sha256 \
--extfile <(printf "subjectAltName=DNS:${DOMAIN}\nbasicConstraints=critical, CA:FALSE\nkeyUsage=keyCertSign,                       digitalSignature, keyEncipherment\nextendedKeyUsage=serverAuth") \
--days 365 \ 
--in domain.csr \
--CA rootCA.crt \
--CAkey rootCA.key \
--CAcreateserial -out domain.crt
+    -req \
+    -sha256 \
+    -extfile <(printf "subjectAltName=DNS:${DOMAIN}\nbasicConstraints=critical, CA:FALSE\nkeyUsage=digitalSignature, keyEncipherment, keyAgreement, dataEncipherment\nextendedKeyUsage=serverAuth") \
+    -days 365 \
+    -in domain.csr \
+    -CA ca.crt \
+    -CAkey ca.key \
+    -CAcreateserial -out domain.crt
 ----
 
 
 After executing those steps, it will be possible to use domain.crt and domain.key for Route/Ingress TLS
-and link:{site-baseurl}che-7/setup-che-in-tls-mode-with-self-signed-certificate/#che-usage-with-tls_setup-che-in-tls-mode-with-self-signed-certificate[rootCA.crt for importing into browsers].
+and link:{site-baseurl}che-7/setup-che-in-tls-mode-with-self-signed-certificate/#che-usage-with-tls_setup-che-in-tls-mode-with-self-signed-certificate[ca.crt for importing into browsers].


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Makes self-signed certificate generation process correct.

Also fixes a few links in the TLS page.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16366

### Specify the version of the product this PR applies to.
 - current Eclipse Che version (`7.10`)
 - some past versions (if Google Chrome browser is used)
 - all next versions