### PR TITLE
Jekyll configuration: process only files with a front matter header.

### DIFF
--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -75,6 +75,7 @@ asciidoc_attributes: &asciidoc_attributes
   experimental: ''
 
 asciidoc: {}
+  require_front_matter_header: true
 asciidoctor:
   base_dir: :docdir
   safe: unsafe


### PR DESCRIPTION
Jekyll configuration: add require_front_matter_header: true 
See https://github.com/asciidoctor/jekyll-asciidoc#configuration - Since version 2.0.0 of jekyll-asciidoc plugin, all non-hidden AsciiDoc files are processed by default, even those without a front matter header.