### PR TITLE
Update import CA certificate in browser section

### DIFF
--- a/src/main/pages/che-7/contributor-guide/proc_che-usage-with-tls.adoc
+++ b/src/main/pages/che-7/contributor-guide/proc_che-usage-with-tls.adoc
@@ -10,7 +10,7 @@ This section describes how to import root certificate authority into the browser
 [discrete]
 == Google Chrome
 
-. Go to `chrome://settings/certificates`, `Authorities` tab, click `import` and find your generated `rootCA.crt` (or `ca.crt` for OpenShift 4) file.
+. Go to `chrome://settings/certificates`, `Authorities` tab, click `import` and find your generated `ca.crt` file.
 
 +
 image::contributor/che-tls-chrome-import_1.png[link="{imagesdir}/contributor/che-tls-chrome-import_1.png"]
@@ -34,7 +34,7 @@ image::contributor/che-tls-chrome-import_3.png[link="{imagesdir}/contributor/che
 +
 image::contributor/che-tls-firefox-import_1.png[link="{imagesdir}/contributor/che-tls-firefox-import_1.png"]
 
-. Go to `Authorities` tab, click `Import` and find your generated `rootCA.crt` (or `ca.crt` for OpenShift 4) file.
+. Go to `Authorities` tab, click `Import` and find your generated `ca.crt` file.
 
 +
 image::contributor/che-tls-firefox-import_2.png[link="{imagesdir}/contributor/che-tls-firefox-import_2.png"]
@@ -55,7 +55,7 @@ image::contributor/che-tls-firefox-import_4.png[link="{imagesdir}/contributor/ch
 
 . Open _Keychain Access_.
 
-. Make sure you're on _System_ keychain and drop your `rootCA.crt` (or `ca.crt` for OpenShift 4) file there.
+. Make sure you're on _System_ keychain and drop your `ca.crt` file there.
 
 . Double-click your imported CA, go to _Trust_ and select _When using this certificate_: `Always Trust`.
 


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Update certificate file name in import to browser section.

### What issues does this PR fix or reference?
https://github.com/eclipse/che-docs/pull/1175