### PR TITLE
Fix parent-context-of-using-gradle-artifact-repositories

### DIFF
--- a/src/main/pages/che-7/end-user-guide/assembly_using-gradle-artifact-repositories.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_using-gradle-artifact-repositories.adoc
@@ -10,7 +10,7 @@ summary:
 
 :page-liquid:
 
-:parent-context-of-using-maven-artifact-repositories: {context}
+:parent-context-of-using-gradle-artifact-repositories: {context}
 
 [id="using-gradle-artifact-repositories_{context}"]
 = Using Gradle artifact repositories


### PR DESCRIPTION
Fix parent-context-of-using-gradle-artifact-repositories