### PR TITLE
Fix the command for creating a key for the GCP SA

### DIFF
--- a/src/main/pages/che-7/overview/proc_creating-a-service-account-secret-on-google-cloud-platform.adoc
+++ b/src/main/pages/che-7/overview/proc_creating-a-service-account-secret-on-google-cloud-platform.adoc
@@ -14,7 +14,7 @@ To access the service account, cert-manager uses a key stored in a Kubernetes Se
 +
 ----
 $ gcloud iam service-accounts keys create key.json \
-  --iam-account mailto:dns01-solver@eclipse-che-1.iam.gserviceaccount.com[_dns01-solver@eclipse-che-1.iam.gserviceaccount.com_]
+    --iam-account dns01-solver@eclipse-che-1.iam.gserviceaccount.com
 ----
 The following is the output of the preceding command:
 +


### PR DESCRIPTION
### What does this PR do?
This PR fixes the command for creating a key for the GCP SA.
This inaccuracy was reported in Eclipse Che MM by @les
Now this command is sync to original doc https://docs.google.com/document/d/1T5N7oB3XDgABAA9mebJWeTeDflKxq5NXDM1QI9mmQfE/edit#
but I assume there may be other places which should be synchronized

### What issues does this PR fix or reference?
N/A

### Specify the version of the product this PR applies to. 
N/A