### PR TITLE
Allow CPU limits in dockerimage components

### DIFF
--- a/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
+++ b/src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc
@@ -453,7 +453,7 @@ If none of them are specified, system-wide defaults are applied (see description
 
 === Specifying container CPU limit for components
 
-To specify a container(s) CPU limit for `chePlugin` or `cheEditor`, use the `cpuLimit` parameter:
+To specify a container(s) CPU limit for `chePlugin`, `cheEditor` or `dockerimage` use the `cpuLimit` parameter:
 
 [source,yaml]
 ----
@@ -476,7 +476,7 @@ If none of them are specified, system-wide defaults are applied (see description
 
 === Specifying container CPU request for components
 
-To specify a container(s) CPU request for `chePlugin` or `cheEditor`, use the `cpuRequest` parameter:
+To specify a container(s) CPU request for `chePlugin`, `cheEditor` or `dockerimage` use the `cpuRequest` parameter:
 
 [source,yaml]
 ----


### PR DESCRIPTION
### What does this PR do?
Allow CPU limits in dockerimage components

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16588

### Specify the version of the product this PR applies to. 
7.12