### PR TITLE
Link to system variables.

### DIFF
--- a/src/main/pages/che-7/installation-guide/con_che-configmaps-and-their-behavior.adoc
+++ b/src/main/pages/che-7/installation-guide/con_che-configmaps-and-their-behavior.adoc
@@ -24,8 +24,7 @@ To add custom properties to the {prod-short} server, such as environment variabl
 
 For example, to override the default memory limit for workspaces, add the `CHE_WORKSPACE_DEFAULT\__MEMORY__LIMIT__MB` property to `customCheProperties`:
 
-[subs="+attributes"]
-[source,yaml]
+[source,yaml,subs="+attributes"]
 ----
 apiVersion: org.eclipse.che/v1
 kind: CheCluster
@@ -42,10 +41,13 @@ spec:
     customCheProperties:
       CHE_WORKSPACE_DEFAULT__MEMORY__LIMIT__MB: "2048"
   auth:
-...
+# [...]
 ----
 
 Previous versions of the {prod-short} Operator had a configMap named `custom` to fulfill this role. If the {prod-short} Operator finds a `configMap` with the name `custom`, it adds the data it contains into the `customCheProperties` field, redeploys {prod-short}, and deletes the `custom` `configMap`.
+
+See link:{site-baseurl}che-7/configuring-system-variables/[Configuring system variables] for a list of all available parameters.
+
 
 ifeval::["{project-context}" == "che"]
 == {prod-short} installed using a Helm Chart


### PR DESCRIPTION
### What does this PR do?

* Adds a link to [Configuring system variables](https://www.eclipse.org/che/docs/che-7/configuring-system-variables/) to [Advanced configuration options](https://www.eclipse.org/che/docs/che-7/advanced-configuration-options/)
* Minor syntax fix.

### What issues does this PR fix or reference?

Fixes https://github.com/eclipse/che/issues/15191
