### PR TITLE
Remove Kubernetes

### DIFF
--- a/src/main/pages/che-7/administration-guide/con_image-puller-overview.adoc
+++ b/src/main/pages/che-7/administration-guide/con_image-puller-overview.adoc
@@ -3,16 +3,16 @@
 [id="image-puller-overview_{context}"]
 = Image Puller overview
 
-Slow starts of {prod} workspaces may be caused by waiting for the underlying cluster to pull images used in workspaces from remote registries. As such, pre-pulling images can improve start times significantly. The _Kubernetes Image Puller_ can be used to pre-pull images and shorten workspace start times.
+Slow starts of {prod} workspaces may be caused by waiting for the underlying cluster to pull images used in workspaces from remote registries. As such, pre-pulling images can improve start times significantly. The _Image Puller_ can be used to pre-pull images and shorten workspace start times.
 
-The Kubernetes Image Puller is an additional deployment that runs alongside {prod}. Given a list of images to pre-pull, the application runs inside a cluster and creates a _DaemonSet_ that pulls the images on each node.
+The Image Puller is an additional deployment that runs alongside {prod}. Given a list of images to pre-pull, the application runs inside a cluster and creates a _DaemonSet_ that pulls the images on each node.
 
 The application can be deployed via Helm or by processing and applying OpenShift templates.
 
 The Kubernetes Image Puller pulls its configuration from a `ConfigMap` with the following available parameters:
 
 [id="image-puller-configuration"]
-.Image Puller parameters
+.Image Puller default parameters
 [options="header"]
 |===
 |Parameter |Usage |Default

--- a/src/main/pages/che-7/administration-guide/proc_deploying-image-puller-using-openshift-templates.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_deploying-image-puller-using-openshift-templates.adoc
@@ -3,7 +3,7 @@
 [id="deploying-image-puller-using-openshift-templates_{context}"]
 = Deploying Image Puller using OpenShift templates
 
-The Kubernetes Image Puller repository contains OpenShift templates for deploying on OpenShift.
+The Image Puller repository contains OpenShift templates for deploying on OpenShift.
 
 ifeval::["{project-context}" == "che"]
 Alternatively, you can use link:{site-baseurl}che-7/caching-images-for-faster-workspace-start/#deploying-the-kubernetes-image-puller-using-helm_caching-images-for-faster-workspace-start[Helm for deploying the Kubernetes Image Puller to OpenShift].


### PR DESCRIPTION
### What does this PR do?
Since we decided on using `Image Puller` to make the docs more agnostic (and avoid unnecessary Kubernetes to OpenShift replacement during donwstreaming), I've removed the mentions of Kubernetes.  

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to. 