### PR TITLE
External PostgreSQL database need an external {identity-provider}.

### DIFF
--- a/src/main/pages/che-7/administration-guide/con_external-database-setup.adoc
+++ b/src/main/pages/che-7/administration-guide/con_external-database-setup.adoc
@@ -22,10 +22,14 @@ The PostgreSQL database is used by the {prod-short} server for persisting data a
 
 By default, the {prod-short} Operator creates and manages the database deployment.
 
-However, the {prod-short} Operator does not support full life-cycle capabilities, such as backups and recovery. For a business-critical setup, configure an external database with the following recommended disaster-recovery options:
+However, the {prod-short} Operator does not support full life-cycle capabilities, such as backups and recovery.
+
+For a business-critical setup, configure an external database with the following recommended disaster-recovery options:
 
 * High Availability (HA)
 * Point In Time Recovery (PITR)
+
+When using an external PostgreSQL database, it is also necessary to use an external {identity-provider}.
 
 Configure an external PostgreSQL instance on-premises or use a cloud service, such as Amazon Relational Database Service (Amazon RDS). With Amazon RDS, it is possible to deploy production databases in a Multi-Availability Zone configuration for a resilient disaster recovery strategy with daily and on-demand snapshots.
 


### PR DESCRIPTION
When using an external PostgreSQL database, it is also necessary to use an external {identity-provider}.