### PR TITLE
Applying proper YAML notification

### DIFF
--- a/src/main/pages/che-7/end-user-guide/assembly_using-artifact-repositories-in-a-restricted-environment.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_using-artifact-repositories-in-a-restricted-environment.adoc
@@ -9,7 +9,6 @@ summary:
 ---
 
 :page-liquid:
-
 :parent-context-of-using-artifact-repositories-in-a-restricted-environment: {context}
 
 [id="using-artifact-repositories-in-a-restricted-environment_{context}"]

--- a/src/main/pages/che-7/end-user-guide/proc_using-npm-artifact-repositories.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_using-npm-artifact-repositories.adoc
@@ -9,7 +9,6 @@ summary:
 ---
 
 :page-liquid:
-
 :parent-context-of-using-npm-artifact-repositories: {context}
 
 [id="using-npm-artifact-repositories_{context}"]
@@ -30,20 +29,21 @@ To be able to reference the certificate in a devfile, get a copy of the certific
 
 . An example configuration for the use of an internal repository with a self-signed certificate:
 +
+[source,yaml]
 ----
   - mountSources: true
     endpoints:
       - name: nodejs
         port: 3000
-    memoryLimit: 512Mi
-    type: dockerimage
-    alias: nodejs
-    image: quay.io/eclipse/che-nodejs10-ubi:nightly
+    memoryLimit: '512Mi'
+    type: 'dockerimage'
+    alias: 'nodejs'
+    image: 'quay.io/eclipse/che-nodejs10-ubi:nightly'
     env:
       -name: NODE_EXTRA_CA_CERTS  
-       value: &#39;/projects/config/tls.crt&#39;
-     - name: NPM_CONFIG_REGISTRY  
-       value: &#39;https://snexus-airgap.apps.acme.com/repository/npm-proxy/&#39;
+       value: '/projects/config/tls.crt'
+     - name: NPM_CONFIG_REGISTRY 
+       value: 'https://snexus-airgap.apps.acme.com/repository/npm-proxy/'
 ----
 
 // .Additional resources


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

* adding missing [source,yaml] gambit
* applying double `'` for everything except `booleans`, `integer`, and `name`