### PR TITLE
che #16689 Adding a note about unsupported images that mount voulmes for pre-pulling via kubernetes-image-puller

### DIFF
--- a/src/main/pages/che-7/administration-guide/con_image-puller-overview.adoc
+++ b/src/main/pages/che-7/administration-guide/con_image-puller-overview.adoc
@@ -7,7 +7,7 @@ Slow starts of {prod} workspaces may be caused by waiting for the underlying clu
 
 The Image Puller is an additional deployment that runs alongside {prod}. Given a list of images to pre-pull, the application runs inside a cluster and creates a _DaemonSet_ that pulls the images on each node.
 
-NOTE: The minimal requirement for an image to be pre-pulled is the availability of the `sleep` command, which means that `FROM scratch` images (for example, 'che-machine-exec') are currently not supported.
+NOTE: The minimal requirement for an image to be pre-pulled is the availability of the `sleep` command, which means that `FROM scratch` images (for example, 'che-machine-exec') are currently not supported. Also, images that mount volumes in the dockerfile are not supported for pre-pulling on OpenShift.
 Also, images that mount volumes in the dockerfile are not supported for pre-pulling on OpenShift.
 
 The application can be deployed via Helm or by processing and applying OpenShift templates.

--- a/src/main/pages/che-7/administration-guide/con_image-puller-overview.adoc
+++ b/src/main/pages/che-7/administration-guide/con_image-puller-overview.adoc
@@ -8,7 +8,6 @@ Slow starts of {prod} workspaces may be caused by waiting for the underlying clu
 The Image Puller is an additional deployment that runs alongside {prod}. Given a list of images to pre-pull, the application runs inside a cluster and creates a _DaemonSet_ that pulls the images on each node.
 
 NOTE: The minimal requirement for an image to be pre-pulled is the availability of the `sleep` command, which means that `FROM scratch` images (for example, 'che-machine-exec') are currently not supported. Also, images that mount volumes in the dockerfile are not supported for pre-pulling on OpenShift.
-Also, images that mount volumes in the dockerfile are not supported for pre-pulling on OpenShift.
 
 The application can be deployed via Helm or by processing and applying OpenShift templates.
 

--- a/src/main/pages/che-7/administration-guide/con_image-puller-overview.adoc
+++ b/src/main/pages/che-7/administration-guide/con_image-puller-overview.adoc
@@ -8,6 +8,7 @@ Slow starts of {prod} workspaces may be caused by waiting for the underlying clu
 The Image Puller is an additional deployment that runs alongside {prod}. Given a list of images to pre-pull, the application runs inside a cluster and creates a _DaemonSet_ that pulls the images on each node.
 
 NOTE: The minimal requirement for an image to be pre-pulled is the availability of the `sleep` command, which means that `FROM scratch` images (for example, 'che-machine-exec') are currently not supported.
+Also, images that mount volumes in the dockerfile are not supported for pre-pulling on OpenShift.
 
 The application can be deployed via Helm or by processing and applying OpenShift templates.
 


### PR DESCRIPTION
### What does this PR do?
Adding a note about unsupported images that mount voulmes for pre-pulling via kubernetes-image-puller

### What issues does this PR fix or reference?
Related to eclipse/che#16689

### Specify the version of the product this PR applies to. 
7.12 and below