### PR TITLE
Fix typo in kubernetes image puller instructions

### DIFF
--- a/src/main/pages/che-7/administration-guide/examples/che-deploying-image-puller-using-openshift-templates_process.adoc
+++ b/src/main/pages/che-7/administration-guide/examples/che-deploying-image-puller-using-openshift-templates_process.adoc
@@ -2,5 +2,5 @@
 ----
 $ oc process -f deploy/openshift/serviceaccount.yaml | oc apply -f -
 $ oc process -f deploy/openshift/configmap.yaml | oc apply -f -
-$ oc process -f deploy/openshift/app.yaml | oc apply -f --
+$ oc process -f deploy/openshift/app.yaml | oc apply -f -
 ----


### PR DESCRIPTION
Signed-off-by: Tom George <tgeorge@redhat.com>

### What does this PR do?

Fixes a typo in the `oc apply` command in the kubernetes image puller documentation.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/16789

### Specify the version of the product this PR applies to. 