### PR TITLE
Update assembly_eclipse-che4z.adoc

### DIFF
--- a/src/main/pages/che-7/extensions/assembly_eclipse-che4z.adoc
+++ b/src/main/pages/che-7/extensions/assembly_eclipse-che4z.adoc
@@ -42,10 +42,10 @@ The Eclipse Che4z extension includes the following components:
 
 === COBOL Language Support
 
-COBOL Language Support standardizes the communication between language tools and the code editor using the Language Server Protocol (LSP).
+COBOL Language Support enhances the COBOL programming experience on your IDE. The extension leverages the language server protocol to provide autocomplete, highlighting and diagnostic features for COBOL code and copybooks. The COBOL Language Support extension can also connect to a mainframe using a Zowe CLI z/OSMF profile to automatically retrieve copybooks used in your programs and store them in your workspace.
 
 The Che4z package includes a bitlang https://marketplace.visualstudio.com/items?itemName=bitlang.cobol[COBOL
-extension] which provides an enhanced experience while working with a COBOL Language Support, giving the ability to leverage syntax highlighting.
+extension] which provides an enhanced experience while working with a COBOL Language Support, providing the ability to leverage syntax coloring.
 
 ==== Features:
 
@@ -53,6 +53,7 @@ extension] which provides an enhanced experience while working with a COBOL Lang
 ** Syntax highlighting
 ** Real time syntax validation
 ** Content assist
+* Automatic copybook retrieval
 
 https://github.com/eclipse/che-che4z-lsp-for-cobol/issues[image:https://img.shields.io/github/issues-raw/eclipse/che-che4z-lsp-for-cobol?style=flat-square[GitHub issues]]
 https://join.slack.com/t/che4z/shared_invite/enQtNzk0MzA4NDMzOTIwLWIzMjEwMjJlOGMxNmMyNzQ1NWZlMzkxNmQ3M2VkYWNjMmE0MGQ0MjIyZmY3MTdhZThkZDg3NGNhY2FmZTEwNzQ[image:https://img.shields.io/badge/chat-on%20Slack-blue?style=flat-square[slack]]
@@ -65,12 +66,17 @@ https://join.slack.com/t/che4z/shared_invite/enQtNzk0MzA4NDMzOTIwLWIzMjEwMjJlOGM
 
 === Zowe Explorer
 
-Zowe Explorer is a VS Code extension powered by Zowe CLI that streamlines interaction with mainframe data sets, USS files, and jobs
+Zowe Explorer is an extension powered by Zowe CLI that streamlines interaction with mainframe data sets, USS files, and jobs. The extension is designed to function along with other extensions and plug-ins to deliver a richer experience.
+
+You can learn more about the Zowe Explorer by watching the https://www.youtube.com/embed/G_WCsFZIWt4[Getting Started] and https://www.youtube.com/embed/X4oSHrI4oN4[Work with Data Sets] tutorial videos.
 
 ==== Features:
-* Access z/OS Datasets, z/OS Unix file system and submit JCL
-* View and download job output
-* Issue TSO commands
+* Access z/OS Datasets and z/OS Unix file systems, and submit JCLs.
+* Create, edit, and work with z/OSMF compatible profiles.
+* Store your credentials securely with Secure Credentials Store plug-in.
+* View and download job output.
+* Issue TSO commands.
+* Install additional extensions.
 
 https://github.com/zowe/vscode-extension-for-zowe/issues[image:https://img.shields.io/github/issues-raw/zowe/vscode-extension-for-zowe?style=flat-square[GitHub issues]]
 https://openmainframeproject.slack.com/[image:https://img.shields.io/badge/chat-on%20Slack-blue?style=flat-square[slack]]
@@ -79,8 +85,8 @@ https://openmainframeproject.slack.com/[image:https://img.shields.io/badge/chat-
 * How can we improve Zowe Explorer? https://github.com/zowe/vscode-extension-for-zowe/issues[Let us know on our Git repository]
 
 ==== Blogs:
-* https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe[Beginner’s Guide: How to access mainframe via Zowe in 10 easy steps] *
-* https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe[Zowe blog]
+* https://medium.com/zowe/beginners-guide-how-to-access-mainframe-via-zowe-in-10-easy-steps-fbec14ed6ed2[Beginner’s Guide: How to access mainframe via Zowe in 10 easy steps] *
+* https://medium.com/zowe[Zowe blog]
 
 === HLASM Language Support
 


### PR DESCRIPTION
Signed-off-by: Zeibura Kathau <zeibura.kathau@broadcom.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTION.md) before submitting a PR.

### What does this PR do?
- Update the Che4z page on Che 7 docs to reflect new features in COBOL Language Support and Zowe Explorer
- Fix two links under Zowe Explorer which should point to the Zowe blog rather than the VS Code marketplace.

### What issues does this PR fix or reference?
#16990

### Specify the version of the product this PR applies to. 
Che 7