### PR TITLE
Fix broken links for installation on Kind cluster

### DIFF
--- a/src/main/pages/che-7/overview/proc_installing-che-on-kind-using-chectl.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-kind-using-chectl.adoc
@@ -15,7 +15,7 @@ This section describes how to install {prod-short} on https://github.com/kuberne
 
 .Procedure
 
-For Eclipse Che installation, Kind cluster should have ingress backend and persitent volumes stoage backend. If these requirements are met, one may go directly to step `8`.
+For Eclipse Che installation, Kind cluster should have ingress backend and persitent volumes storage backend. If these requirements are met, one may go directly to step `8`.
 
 Following instruction is a way of configuring Kind cluster to have all needed for Eclipse Che components:
 

--- a/src/main/pages/che-7/overview/proc_installing-che-on-kind-using-chectl.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-on-kind-using-chectl.adoc
@@ -15,14 +15,38 @@ This section describes how to install {prod-short} on https://github.com/kuberne
 
 .Procedure
 
+For Eclipse Che installation, Kind cluster should have ingress backend and persitent volumes stoage backend. If these requirements are met, one may go directly to step `8`.
+
+Following instruction is a way of configuring Kind cluster to have all needed for Eclipse Che components:
+
 . Install https://github.com/kubernetes-csi/csi-driver-host-path[csi-driver-host-path] in the kind cluster:
++
+Install snapshotter CRDs as described in the https://github.com/kubernetes-csi/csi-driver-host-path/blob/master/docs/deploy-1.17-and-later.md#volumesnapshot-crds-and-snapshot-controller-installation[docs]:
++
+[subs="+quotes"]
+----
+$ SNAPSHOTTER_VERSION=v2.1.1
+
+# Apply VolumeSnapshot CRDs
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+
+# Create snapshot controller
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+----
+Value of the latest `SNAPSHOTTER_VERSION` could be found on https://github.com/kubernetes-csi/external-snapshotter/releases[corresponding release page].
++
+Then deploy:
 +
 [subs="+quotes"]
 ----
 $ git clone https://github.com/kubernetes-csi/csi-driver-host-path && cd csi-driver-host-path
-$ ./deploy/kubernetes-__<version>__/deploy-hostpath.sh
+$ ./deploy/kubernetes-__<version>__/deploy.sh
 $ kubectl apply -f examples/csi-storageclass.yaml
 ----
+Kubernetes version could be obtained via `kubectl version` command (see `Server Version`).
 
 . Set `csi-hostpath-sc` as the default `StorageClass`:
 +
@@ -34,15 +58,18 @@ $ kubectl patch storageclass standard -p '{"metadata": {"annotations": {"storage
 . Install the https://kubernetes.github.io/ingress-nginx/deploy/[NGINX Ingress Controller]:
 +
 ----
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud-generic.yaml
+$ VERSION=0.30.0
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-${VERSION}/deploy/static/mandatory.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-${VERSION}/deploy/static/provider/cloud-generic.yaml
 ----
 
 . Install the https://metallb.universe.tf/[MetalLB] load balancer:
 +
 [subs="+quotes"]
 ----
-$ kubectl apply -f https://raw.githubusercontent.com/google/metallb/v__<version>__/manifests/metallb.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/namespace.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.3/manifests/metallb.yaml
+$ kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
 ----
 +
 [NOTE]
@@ -94,7 +121,7 @@ $ kubectl apply -f metallb-config.yaml
 ----
 $ kubectl get svc -n ingress-nginx
 NAME            TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
-ingress-nginx   LoadBalancer   10.107.194.26   172.17.255.1   80:32033/TCP,443:30428/TCP   19h
+ingress-nginx   LoadBalancer   10.107.194.26   172.17.250.1   80:32033/TCP,443:30428/TCP   19h
 ----
 
 . Run `{prod-cli}`, using the external IP of the `ingress-nginx` Service as an https://nip.io[nip.io] URL:
@@ -103,4 +130,8 @@ ingress-nginx   LoadBalancer   10.107.194.26   172.17.255.1   80:32033/TCP,443:3
 ----
 $ {prod-cli} server:start --installer operator --platform k8s --domain 172.17.250.1.nip.io
 ----
-
++
+[NOTE]
+====
+In some cases, after all the steps above, it is still not possible to reach Eclipse Che from host machine. If you encounter such problem please refer to Kind cluster docs or forums on how to make an endpoint available outside Kind cluster for your system and/or network configuration.
+====


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Updates Eclipse Che installation process on Kind Kubernetes cluster.
Some broken links fixed, added some warnings and explanations.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16792
https://github.com/eclipse/che/issues/16794
