### PR TITLE
Removing the statement that external db requires external keycloak setup

### DIFF
--- a/src/main/pages/che-7/administration-guide/con_external-database-setup.adoc
+++ b/src/main/pages/che-7/administration-guide/con_external-database-setup.adoc
@@ -29,8 +29,6 @@ For a business-critical setup, configure an external database with the following
 * High Availability (HA)
 * Point In Time Recovery (PITR)
 
-When using an external PostgreSQL database, it is also necessary to use an external {identity-provider}.
-
 Configure an external PostgreSQL instance on-premises or use a cloud service, such as Amazon Relational Database Service (Amazon RDS). With Amazon RDS, it is possible to deploy production databases in a Multi-Availability Zone configuration for a resilient disaster recovery strategy with daily and on-demand snapshots.
 
 The recommended configuration of the example database is:


### PR DESCRIPTION
### What does this PR do?
Removing the statement that external db requires external keycloak setup

### What issues does this PR fix or reference?
N/A

### Specify the version of the product this PR applies to. 
7.x