### PR TITLE
fix contribute factory: link + devfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Eclipse Che documentation project
+[![Contribute](https://che.openshift.io/factory/resources/factory-contribute.svg)](https://che.openshift.io/f?url=https://github.com/eclipse/che-docs)
 
 This repository contains sources for the [documentation for Eclipse Che](https://www.eclipse.org/che/docs/). To contribute to the documentation, see the [Contribution guide](CONTRIBUTION.md). We love pull requests and appreciate contributions that make docs more helpful for users.
 

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -25,6 +25,8 @@ components:
     alias: che-docs-dev
   - id: joaompinto/vscode-asciidoctor/latest
     type: chePlugin
+  - id: ms-vscode/vscode-github-pullrequest/latest
+    type: chePlugin
 
 commands:
   - name: build che-docs

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,39 +1,43 @@
+apiVersion: 1.0.0
 metadata:
-  name: che-docs-in-che
+  generateName: che-docs-
+
+projects:
+  - name: che-docs
+    source:
+      location: 'https://github.com/eclipse/che-docs.git'
+      type: github
+      branch: master
+
 components:
   - mountSources: true
     endpoints:
-      - name: che-docs-web-server
-        attributes:
-          public: 'true'
-          protocol: http
-          path: /
-        port: 4000
       - name: che-docs-livereload-server
-        attributes:
-          public: 'true'
-          protocol: http
-          path: /
         port: 35729
+      - name: che-docs-web-server
+        port: 4000
+        attributes:
+          path: /che-7/introduction-to-eclipse-che/
+    args: ['sleep', 'infinity']
     memoryLimit: 1Gi
     type: dockerimage
     image: 'quay.io/eclipse/che-docs:latest'
     alias: che-docs-dev
   - id: joaompinto/vscode-asciidoctor/latest
     type: chePlugin
-apiVersion: 1.0.0
+
 commands:
   - name: build che-docs
     actions:
       - workdir: /projects/che-docs/src/main
         type: exec
-        command: 'mkdir -p _site && jekyll build --config _config.yml,_config-war.yml'
+        command: 'mkdir -p _site && jekyll clean && jekyll build --config _config.yml,_config-war.yml'
         component: che-docs-dev
   - name: serve che-docs
     actions:
       - workdir: /projects/che-docs/src/main
         type: exec
-        command: 'jekyll serve --incremental --livereload -H 0.0.0.0'
+        command: 'jekyll clean && jekyll serve --incremental --livereload -H 0.0.0.0'
         component: che-docs-dev
   - name: killall ruby
     actions:


### PR DESCRIPTION
### What does this PR do?
- Setting back factory contribute link
- Fixing devfile to be able to start jekyll and have live reload
- Adding GH plugin

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17087

To test it: http://che.openshift.io/f?url=https://github.com/eclipse/che-docs/tree/fix_contribute_factory

Preview: 
![image](https://user-images.githubusercontent.com/650571/83769246-e8804800-a67f-11ea-88b4-0020d6442bf2.png)
