### PR TITLE
Add antora and vale containers in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,16 @@ spec:
       command:
       - cat
       tty: true
+    - name: antora
+      image: docker.io/antora/antora
+      command:
+      - cat
+      tty: true
+    - name: vale
+      image: docker.io/jdkato/vale
+      command:
+      - cat
+      tty: true
   volumes:
   - configMap:
       name: known-hosts


### PR DESCRIPTION
It seems Jenkins with multibranch [1] is using the content of Jenkinsfile in the branch to define the stages, but still the content of Jenkinsfile from master to define `che-docs-pod`. 
Give that situation, it is necessary to have new containers defined in master to be able to build properly  https://github.com/eclipse/che-docs/pull/1291.

[1] https://www.jenkins.io/doc/book/pipeline/multibranch/
