### PR TITLE
Adding GDPR section to the 'removing-user-data' page

### DIFF
--- a/src/main/pages/che-7/administration-guide/assembly_removing-user-data.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_removing-user-data.adoc
@@ -16,6 +16,16 @@ summary:
 
 :context: removing-user-data
 
-To remove all user data, follow instructions for link:{site-baseurl}che-7/uninstalling-che/[Uninstalling {prod}].
+== GDPR
+
+In case user data needs to be deleted, the following API should be used with the `user` or the `admin` authorization token:
+
+```
+curl -X DELETE `http(s)://{che-host}/api/user/{id}`
+```
+
+NOTE: All the user's workspaces should be stopped beforehand. Otherwise, the API request will fail with `500` Error.
+
+To remove the data of all the users, follow instructions for link:{site-baseurl}che-7/uninstalling-che/[Uninstalling {prod}].
 
 :context: {parent-context-of-removing-user-data}


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?
Adding GDPR section to the 'removing-user-data' page

### What issues does this PR fix or reference?
Backporting https://github.com/eclipse/che-docs/pull/455 that has been removed for some reason :shrug: 

### Specify the version of the product this PR applies to. 
7.x