### PR TITLE
Rename SSL trust-store procedure.

### DIFF
--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -194,7 +194,7 @@ entries:
     output: web
     folderitems:
       - title: Overview
-        url: che-7/configuring-che-overview
+        url: che-7/configuring-che
         output: web
       - title: Configuring the Che installation
         url: che-7/configuring-the-che-installation

--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -211,8 +211,8 @@ entries:
       - title: Installing Che using storage classes
         url: che-7/installing-che-using-storage-classes
         output: web
-      - title: Adding self-signed SSL certificates to Che
-        url: che-7/adding-self-signed-SSL-certificates-to-che
+      - title: Mounting custom SSL certificates to Che workspace Pods
+        url: che-7/mounting-custom-ssl-certificates-to-che-workspace-pods
         output: web
   - title: Installing Che in restricted environment
     url: che-7/installing-che-in-restricted-environment

--- a/src/main/pages/che-7/installation-guide/assembly_configuring-che-overview.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_configuring-che-overview.adoc
@@ -1,20 +1,20 @@
 ---
-title: Configuring Che overview
+title: Configuring Che
 keywords:
 tags: []
 sidebar: che_7_docs
-permalink: che-7/configuring-che-overview/
+permalink: che-7/configuring-che/
 folder: che-7/installation-guide
 summary:
 ---
 
-:parent-context-of-configuring-che-overview: {context}
+:parent-context-of-configuring-che: {context}
 
 
-[id="configuring-che-overview_{context}"]
-= Configuring Che overview
+[id="configuring-che_{context}"]
+= Configuring Che
 
-:context: configuring-che-overview
+:context: configuring-che
 
 The following chapter describes configuration methods and options for {prod}, with some user stories as example.
 
@@ -22,22 +22,17 @@ The two first sections describe the methods available to configure {prod}.
 
 * link:{site-baseurl}che-7/configuring-the-che-installation[Configuring the {prod-short} installation] describes configuration options to install {prod} using the Operator.
 
-
 * link:{site-baseurl}che-7/advanced-configuration-options-for-the-che-server-component[Advanced configuration options for {prod-short} server component] describes advanced configuration methods to use when the previous method is not applicable.
 
 The next sections describe some specific user stories.
 
 * link:{site-baseurl}che-7/configuring-namespace-strategies[Configuring namespace strategies]
 
-* link:{site-baseurl}che-7/deploying-che-with-support-for-git-repositories-with-self-signed-certificates[Deploying Che with support for Git repositories with self-signed certificates]
+* link:{site-baseurl}che-7/deploying-che-with-support-for-git-repositories-with-self-signed-certificates[Deploying {prod-short} with support for Git repositories with self-signed certificates]
+
+* link:{site-baseurl}che-7/installing-che-using-storage-classes[Installing {prod-short} using storage classes]
+
+* link:{site-baseurl}che-7/mounting-custom-ssl-certificates-to-che-workspace-pods[Mounting custom SSL certificates to {prod-short} workspace Pods]
 
 
-* link:{site-baseurl}che-7/installing-che-using-storage-classes[Installing Che using storage classes]
-
-
-* link:{site-baseurl}che-7/adding-self-signed-SSL-certificates-to-che[Adding self-signed SSL certificates to {prod-short}]
-
-
-
-:context: {parent-context-of-configuring-che-overview}
-
+:context: {parent-context-of-configuring-che}

--- a/src/main/pages/che-7/installation-guide/proc_mounting-custom-ssl-certificates-to-che-workspace-pods.adoc
+++ b/src/main/pages/che-7/installation-guide/proc_mounting-custom-ssl-certificates-to-che-workspace-pods.adoc
@@ -1,16 +1,18 @@
 ---
-title: Adding self-signed SSL certificates to Che
+title: Mounting custom SSL certificates to Che workspace Pods
 keywords:
 tags: []
 sidebar: che_7_docs
-permalink: che-7/adding-self-signed-SSL-certificates-to-che/
+permalink: che-7/mounting-custom-ssl-certificates-to-che-workspace-pods/
+redirect_from:
+  - che-7/adding-self-signed-SSL-certificates-to-che
 folder: che-7/installation-guide
 summary:
 ---
 :page-liquid:
 
-[id="adding-self-signed-SSL-certificates-to-che_{context}"]
-= Adding self-signed SSL certificates to {prod-short}
+[id="mounting-custom-ssl-certificates-to-{prod-id-short}-workspace-pods_{context}"]
+= Mounting custom SSL certificates to {prod-short} workspace Pods
 
 When a {prod-short} user attempts to authenticate with {identity-provider} that is using OpenShift OAuth, the authentication fails if the {identity-provider} does not know the certificates needed for authorization.
 


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTION.md) before submitting a PR.

### What does this PR do?
* Renames Adding custom public SSL certificates to Che trust-store needs to  Mounting custom SSL certificates to Che workspaces Pods.
* Adds respective redirect.

### What issues does this PR fix or reference?

Fixes https://github.com/eclipse/che/issues/17082
