### PR TITLE
document subPath limitation

### DIFF
--- a/src/main/pages/che-7/end-user-guide/proc_mounting-a-secret-as-a-file-into-a-workspace-container.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_mounting-a-secret-as-a-file-into-a-workspace-container.adoc
@@ -5,6 +5,8 @@
 [id="mounting-a-secret-as-a-file-into-a-workspace-container_{context}"]
 = Mounting a secret as a file into a workspace container
 
+WARNING: We use Kubernetes VolumeMount `subPath` feature to mount files into containers. This is supported and enabled by default since Kubernetes v1.15 and OpenShift 4.
+
 This section describes how to mount a secret from the user's namespace as a file in single-workspace or multiple-workspace containers of {prod-short}.
 
 .Prerequisites

--- a/src/main/pages/che-7/end-user-guide/proc_mounting-a-secret-as-a-file-into-a-workspace-container.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_mounting-a-secret-as-a-file-into-a-workspace-container.adoc
@@ -5,7 +5,7 @@
 [id="mounting-a-secret-as-a-file-into-a-workspace-container_{context}"]
 = Mounting a secret as a file into a workspace container
 
-WARNING: We use Kubernetes VolumeMount `subPath` feature to mount files into containers. This is supported and enabled by default since Kubernetes v1.15 and OpenShift 4.
+WARNING: {prod} uses Kubernetes VolumeMount `subPath` feature to mount files into containers. This is supported and enabled by default since Kubernetes v1.15 and OpenShift 4.
 
 This section describes how to mount a secret from the user's namespace as a file in single-workspace or multiple-workspace containers of {prod-short}.
 
@@ -75,4 +75,3 @@ data:
 This results in a file named `settings.xml` being mounted at the `/home/user/.m2/` path of the user container named `maven`.
 
 For additional information about Kubernetes annotation items, see: xref:the-use-of-annotations-in-a-process-of-mounting-secret-into-a-workspace-container_{context}[].
-


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTION.md) before submitting a PR.

### What does this PR do?
document limitation of secret mounts as files is supported since k8s 1.15 and OS4

### What issues does this PR fix or reference?
document, but does not fix this limitation https://github.com/eclipse/che/issues/17213

### Specify the version of the product this PR applies to. 
7.15