### PR TITLE
Fix broken quickstarts links

### DIFF
--- a/src/main/pages/che-7/overview/assembly_installing-che-on-codeready-containers.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-che-on-codeready-containers.adoc
@@ -3,7 +3,7 @@ title: Installing Che on CodeReady Containers
 keywords:
 tags: []
 sidebar: che_7_docs
-permalink: che-7/installing-che-on-codeready-containers
+permalink: che-7/installing-che-on-codeready-containers/
 folder: che-7/overview
 summary:
 ---

--- a/src/main/pages/che-7/overview/assembly_installing-che-on-docker-desktop.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-che-on-docker-desktop.adoc
@@ -3,7 +3,7 @@ title: Installing Che on Docker Desktop
 keywords:
 tags: []
 sidebar: che_7_docs
-permalink: che-7/installing-che-on-docker-desktop
+permalink: che-7/installing-che-on-docker-desktop/
 folder: che-7/overview
 summary:
 ---

--- a/src/main/pages/che-7/overview/assembly_installing-che-on-kind.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-che-on-kind.adoc
@@ -3,7 +3,7 @@ title: Installing Che on kind
 keywords:
 tags: []
 sidebar: che_7_docs
-permalink: che-7/installing-che-on-kind
+permalink: che-7/installing-che-on-kind/
 folder: che-7/overview
 summary:
 ---

--- a/src/main/pages/che-7/overview/assembly_installing-che-on-minikube.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-che-on-minikube.adoc
@@ -3,7 +3,7 @@ title: Installing Che on Minikube
 keywords:
 tags: []
 sidebar: che_7_docs
-permalink: che-7/installing-che-on-minikube
+permalink: che-7/installing-che-on-minikube/
 folder: che-7/overview
 summary:
 ---

--- a/src/main/pages/che-7/overview/assembly_installing-che-on-minishift.adoc
+++ b/src/main/pages/che-7/overview/assembly_installing-che-on-minishift.adoc
@@ -3,7 +3,7 @@ title: Installing Che on Minishift
 keywords:
 tags: []
 sidebar: che_7_docs
-permalink: che-7/installing-che-on-minishift
+permalink: che-7/installing-che-on-minishift/
 folder: che-7/overview
 summary:
 ---


### PR DESCRIPTION
Signed-off-by: Adrien DELSALLE <ad.delsalle@gmail.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTION.md) before submitting a PR.

### What does this PR do?
Fix the broken quickstarts links by adding a trailing slash in permalinks.
I'm not a asciidoc specialist but I can't see other reason comparing working and broken links

### Specify the version of the product this PR applies to. 
Che-7