### PR TITLE
Fix a broken link

### DIFF
--- a/src/main/pages/che-7/administration-guide/proc_building-a-custom-devfile-registry.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_building-a-custom-devfile-registry.adoc
@@ -28,7 +28,7 @@ include::examples/{project-context}-clone-the-devfile-registry-repository.adoc[]
     └── meta.yaml
 ----
 
-. Add valid content in the `devfile.yaml` file. For a detailed description of the devfile format, see the {building-a-custom-devfile-registry} section.
+. Add valid content in the `devfile.yaml` file. For a detailed description of the devfile format, see link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile[Making a workspace portable using a Devfile].
 
 . Ensure that the `meta.yaml` file conforms to the following structure:
 +


### PR DESCRIPTION
The attribute didn't exist. Replace by a link that is working.