### PR TITLE
Merge instructions to install certificates on macOS

### DIFF
--- a/src/main/pages/che-7/installation-guide/proc_importing-self-signed-tls-certificates-to-browsers.adoc
+++ b/src/main/pages/che-7/installation-guide/proc_importing-self-signed-tls-certificates-to-browsers.adoc
@@ -54,7 +54,7 @@ endif::[]
 . After adding the {prod-short} certificate to the browser, the address bar displays the closed lock icon next to the URL, indicating a secure connection.
 
 
-== Adding certificates to Google Chrome on macOS
+== Adding certificates to Google Chrome and Safari on macOS
 
 .Procedure
 
@@ -63,21 +63,10 @@ endif::[]
 .. Click the lock icon on the left of the address bar.
 .. Click *Certificates*.
 .. Select the certificate to use and drag and drop its displayed large icon to the desktop.
-. Double-click the exported certificate to import it into Google Chrome.
-
-
-== Adding certificates to Keychain Access for use with Safari on macOS
-
-.Procedure
-
-. Navigate to URL where {prod-short} is deployed.
-. Save the certificate:
-.. Click the lock icon on the right of the window title bar.
-.. Select the certificate to use and drag and drop its displayed large icon to the desktop.
 . Open the *Keychain Access* application.
 . Select the *System* keychain and drag and drop the saved certificate file to it.
 . Double-click the imported CA, then go to *Trust* and select *When using this certificate*: *Always Trust*.
-. Restart Safari for the added certificated to take effect.
+. Restart the browser for the added certificated to take effect.
 
 
 == Adding certificates to Firefox


### PR DESCRIPTION
### What does this PR do?

Merge the 2 sections to install a certificate on macOS (Google Chrome and Safari).

### What issues does this PR fix or reference?

Google Chrome instructions were not correct: double clicking doesn't add the certificate to Chrome but starts the process to add it into keychain. On Safari too the procedure is to add the certificate to the system keychain.

### Specify the version of the product this PR applies to. 

Che 7.x
