### PR TITLE
Remove mention about self-signed certificates in OperatorHub install

### DIFF
--- a/src/main/pages/che-7/overview/proc_installing-che-using-the-che-operator-in-openshift-4-web-console.adoc
+++ b/src/main/pages/che-7/overview/proc_installing-che-using-the-che-operator-in-openshift-4-web-console.adoc
@@ -66,7 +66,7 @@ Operators are a method of packaging, deploying, and managing a Kubernetes applic
 . In the *Operator Details* screen, in the *Details* tab, inside of the *Provided APIs* section, click the *Create Instance* link.
 
 . The *Create CheCluster* page contains the configuration of the overall {prod-short} instance to create. It is the `CheCluster` Custom Resource. For an installation using the default configuration, keep the default values.
-To modify the configuration, see link:{site-baseurl}che-7/configuring-the-{prod-id-short}-installation[Configuring the {prod-short} installation]. It is necessary to modify the configuration to use self-signed certificates. See link:{site-baseurl}che-7/installing-{prod-id-short}-in-tls-mode-with-self-signed-certificates/[Installing [prod-short} in TLS mode with self-signed certificates].
+To modify the configuration, see link:{site-baseurl}che-7/configuring-the-{prod-id-short}-installation[Configuring the {prod-short} installation].
 
 . To create the *{prod-checluster}* cluster, click the btn:[Create] button in the lower left corner of the window.
 


### PR DESCRIPTION
Remove mention about self-signed certificates in OperatorHub installation.