### PR TITLE
More cleanup after organizations removal

### DIFF
--- a/src/main/pages/che-7/administration-guide/assembly_authorizing-users.adoc
+++ b/src/main/pages/che-7/administration-guide/assembly_authorizing-users.adoc
@@ -22,14 +22,11 @@ User authorization in {prod-short} is based on the permissions model. Permission
 Permissions can be applied to the following entities:
 
 * Workspace
-* Organization
 * System
 
 All permissions can be managed using the provided REST API. The APIs are documented using Swagger at `pass:c,a,q[{prod-url}/swagger/#!/permissions]`.
 
 include::con_che-workspace-permissions.adoc[leveloffset=+1]
-
-include::con_che-organization-permissions.adoc[leveloffset=+1]
 
 include::con_che-system-permissions.adoc[leveloffset=+1]
 


### PR DESCRIPTION
More cleanup after organizations removal.

This leaves us with following occurence of `organization` (grep without s suffix):

```grep -nire "organization" src/main/pages/
src/main/pages/che-7/extensions/assembly_telemetry.adoc:75:$ docker build -t registry/organization/che-workspace-telemetry-example:latest
src/main/pages/che-7/extensions/assembly_telemetry.adoc:76:$ docker push registry/organization/che-workspace-telemetry-example:latest
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:265:[id="organizations-workspace-limits"]
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:266:.Organizations workspace limits 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:271: `+CHE_LIMITS_ORGANIZATION_WORKSPACES_RAM+`,"`+-1+`","The total amount of RAM that a single organization (team) is allowed to allocate to running workspaces. An organization owner can allocate this RAM however they see fit across the team's workspaces." 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:272: `+CHE_LIMITS_ORGANIZATION_WORKSPACES_COUNT+`,"`+-1+`","The maximum number of workspaces that a organization is allowed to own. The organization will be presented an error message if they try to create additional workspaces. This applies to the total number of both running and stopped workspaces." 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:273: `+CHE_LIMITS_ORGANIZATION_WORKSPACES_RUN_COUNT+`,"`+-1+`","The maximum number of running workspaces that a single organization is allowed. If the organization has reached this threshold and they try to start an additional workspace, they will be prompted with an error message. The organization will need to stop a running workspace to activate another." 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:277:[id="organizations-notifications-settings"]
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:278:.Organizations notifications settings 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:283: `+CHE_ORGANIZATION_EMAIL_MEMBER__ADDED__SUBJECT+`,"`+You'vebeen added to a Che Organization+`","Organization notifications sunjects and templates" 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:284: `+CHE_ORGANIZATION_EMAIL_MEMBER__ADDED__TEMPLATE+`,"`+st-html-templates/user_added_to_organization+`","Organizationnotifications sunjects and templates" 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:285: `+CHE_ORGANIZATION_EMAIL_MEMBER__REMOVED__SUBJECT+`,"`+You'vebeen removed from a Che Organization+`","" 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:286: `+CHE_ORGANIZATION_EMAIL_MEMBER__REMOVED__TEMPLATE+`,"`+st-html-templates/user_removed_from_organization+`","" 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:287: `+CHE_ORGANIZATION_EMAIL_ORG__REMOVED__SUBJECT+`,"`+CheOrganization deleted+`","" 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:288: `+CHE_ORGANIZATION_EMAIL_ORG__REMOVED__TEMPLATE+`,"`+st-html-templates/organization_deleted+`","" 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:289: `+CHE_ORGANIZATION_EMAIL_ORG__RENAMED__SUBJECT+`,"`+CheOrganization renamed+`","" 
src/main/pages/che-7/installation-guide/examples/system-variables.adoc:290: `+CHE_ORGANIZATION_EMAIL_ORG__RENAMED__TEMPLATE+`,"`+st-html-templates/organization_renamed+`","" 
src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc:37:Consider the network topology of the environment to determine how best to accomplish this. For example, on a network owned by a company or an organization, the network administrators must ensure that traffic bound from the cluster can be routed to Ingress and Route host names. In other cases, for example, on AWS, create a proxy configuration allowing the traffic to leave the node to reach an external-facing Load Balancer.
src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc:69:./build.sh --organization _<my-org>_ \
src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc:100:./build.sh --organization _<my-org>_ \
src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc:197:| `<my-organization>`
src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc:198:| organization of the container-image registry
src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc:216:    airGapContainerRegistryOrganization: '__<my-organization>__'
src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc:220:Setting these values uses `<my-internal-registry>` and `<my-organization>` for all images. This means that the Operator expects the offline plug-in and devfile registries to be available at:
src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc:224:__<my-internal-registry>__/__<my-organization>__/my-offline-plug-in-registry:__<ver>__
src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc:225:__<my-internal-registry>__/__<my-organization>__/my-offline-plug-in-registry:__<ver>__
src/main/pages/che-7/installation-guide/ref_checluster-custom-resource-fields-reference.adoc:36:`airGapContainerRegistryOrganization`: omit: Optional repository name of an alternative container registry to pull images from. This value overrides the container registry organization defined in all the default container images involved in a {prod-short} deployment. This is particularly useful to install {prod-short} in an air-gapped environment.
src/main/pages/che-7/end-user-guide/ref_devfile-reference.adoc:559:* `CHE_WORKSPACE_NAMESPACE`: The {prod-short} {orch-namespace} of the current workspace. This environment variable is the name of the user or organization that the workspace belongs to. Note that this is different from
src/main/pages/che-7/end-user-guide/assembly_publishing-a-vs-code-extension-into-the-che-plug-in-registry.adoc:12:The user of {prod-short} can use a workspace devfile to use any plug-in, also known as Visual Studio Code (VS Code) extension. This plug-in can be added to the plug-in registry, then easily reused by anyone in the same organization with access to that workspaces installation.
src/main/pages/che-7/administration-guide/proc_building-a-custom-devfile-registry.adoc:22:.File organization for a devfile
src/main/pages/che-7/administration-guide/proc_building-a-custom-plug-in-registry.adoc:22:.File organization for a plugin
src/main/pages/che-7/administration-guide/proc_assigning-che-permissions.adoc:9:* organization
src/main/pages/che-7/administration-guide/proc_listing-che-permissions.adoc:15:* organization
src/main/pages/che-7/administration-guide/proc_workspaces-requirements.adoc:90:Community plug-ins are available in the link:https://github.com/eclipse/che-plugin-registry[che-plugin-registry GitHub repository] in folder `v3/plugins/$\{organization}/$\{name}/$\{version}/`.
src/main/pages/che-7/administration-guide/proc_workspaces-requirements.adoc:92:For non-community or customized plug-ins, the `meta.yaml` files are available on the local Kubernetes cluster at `$\{pluginRegistryEndpoint}/v3/plugins/$\{organization}/$\{name}/$\{version}/meta.yaml`.
src/main/pages/che-7/overview/assembly_installing-che-on-codeready-containers.adoc:21:WARNING: Remember that single-node OpenShift clusters are suited only for testing or single-user development. Do *NOT* use such clusters to run {prod-short} for organizations or developer teams.
src/main/pages/che-7/overview/assembly_installing-che-on-docker-desktop.adoc:21:WARNING: Remember that Docker Desktop is suited only for testing or single-user development. Do *NOT* use such clusters to run {prod-short} for organizations or developer teams.
src/main/pages/che-7/overview/assembly_che-quick-starts.adoc:26:* *Multi-user*: Authenticated {prod-short} suited for organizations and developer teams
src/main/pages/che-7/overview/assembly_che-quick-starts.adoc:36:WARNING: Single-node clusters are suited only for testing or single-user development. Do *not* use such clusters to run {prod-short} for organizations or developer teams.
src/main/pages/che-7/overview/assembly_installing-che-on-minishift.adoc:21:WARNING: Remember that single-node OpenShift clusters are suited only for testing or single-user development. Do *NOT* use such clusters to run {prod-short} for organizations or developer teams.
src/main/pages/che-7/overview/assembly_installing-che-on-minikube.adoc:21:WARNING: Remember that single-node Kubernetes clusters are suited only for testing or single-user development. Do *NOT* use such clusters to run {prod-short} for organizations or developer teams.```
