### PR TITLE
Rephrasing configuring

### DIFF
--- a/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
+++ b/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
@@ -11,7 +11,7 @@ A default deployment of {prod-short} consist in the application of a parametrize
 
 Role of the {prod} Operator::
 
-* It translates the `CheCluster` Custom Resource into configuration (ConfigMap) usable by each component of the {prod-short} installation.
+* To translate the `CheCluster` Custom Resource into configuration (ConfigMap) usable by each component of the {prod-short} installation.
 
 Role of {orch-name}::
 

--- a/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
+++ b/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
@@ -5,7 +5,7 @@ A default deployment of {prod-short} consist in the application of a parametrize
 
 `CheCluster` Custom Resource:: 
 
-* It is a YAML document describing the configuration of the overall {prod-short} installation.
+* A YAML document describing the configuration of the overall {prod-short} installation.
 * It contains sections to configure each component: `auth`, `database`, `server`, `storage`.
 
 

--- a/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
+++ b/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
@@ -16,7 +16,7 @@ Role of the {prod} Operator::
 Role of {orch-name}::
 
 * To apply the configuration (ConfigMap) for each component.
-* It creates the necessary Pods.
+* To create the necessary Pods.
 * When it detects a change in the configuration of a component, it restarts the Pods accordingly.
 
 .Configuring the main properties of the {prod-short} server component

--- a/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
+++ b/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
@@ -15,7 +15,7 @@ Role of the {prod} Operator::
 
 Role of {orch-name}::
 
-* It applies the configuration (ConfigMap) for each component.
+* To apply the configuration (ConfigMap) for each component.
 * It creates the necessary Pods.
 * When it detects a change in the configuration of a component, it restarts the Pods accordingly.
 

--- a/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
+++ b/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
@@ -17,7 +17,7 @@ Role of {orch-name}::
 
 * To apply the configuration (ConfigMap) for each component.
 * To create the necessary Pods.
-* When it detects a change in the configuration of a component, it restarts the Pods accordingly.
+* When {orch-name} detects a change in the configuration of a component, it restarts the Pods accordingly.
 
 .Configuring the main properties of the {prod-short} server component
 ====

--- a/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
+++ b/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
@@ -6,7 +6,7 @@ A default deployment of {prod-short} consist in the application of a parametrize
 `CheCluster` Custom Resource:: 
 
 * A YAML document describing the configuration of the overall {prod-short} installation.
-* It contains sections to configure each component: `auth`, `database`, `server`, `storage`.
+* Contains sections to configure each component: `auth`, `database`, `server`, `storage`.
 
 
 Role of the {prod} Operator::

--- a/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
+++ b/src/main/pages/che-7/installation-guide/con_understanding-the-checluster-custom-resource.adoc
@@ -1,12 +1,30 @@
 [id="understanding-the-checluster-custom-resource_{context}"]
 = Understanding the `CheCluster` Custom Resource
 
-A default deployment of {prod-short} consist in the application of a parametrized `CheCluster` link:https://docs.openshift.com/container-platform/latest/operators/crds/crd-managing-resources-from-crds.html[Custom Resource] by the {prod} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operator].
-The `CheCluster` Custom Resource is a YAML document describing the configuration of the overall {prod-short} installation.
-The Operator translates the `CheCluster` Custom Resource into configuration usable by each component of the {prod-short} installation: authentication, database, registry, server, storage. 
+A default deployment of {prod-short} consist in the application of a parametrized `CheCluster` Custom Resource by the {prod} Operator.
 
-For instance, to configure the main properties of the {prod-short} server component, the Operator generates a necessary `ConfigMap`, called `che`. And any change in the `ConfigMap` automatically triggers a restart of the {prod-short} Pod.
+`CheCluster` Custom Resource:: 
 
+* It is a YAML document describing the configuration of the overall {prod-short} installation.
+* It contains sections to configure each component: `auth`, `database`, `server`, `storage`.
+
+
+Role of the {prod} Operator::
+
+* It translates the `CheCluster` Custom Resource into configuration (ConfigMap) usable by each component of the {prod-short} installation.
+
+Role of {orch-name}::
+
+* It applies the configuration (ConfigMap) for each component.
+* It creates the necessary Pods.
+* When it detects a change in the configuration of a component, it restarts the Pods accordingly.
+
+.Configuring the main properties of the {prod-short} server component
+====
+. The user applies a `CheCluster` Custom Resource containing some configuration related to the `server`.
+. The Operator generates a necessary ConfigMap, called `che`. 
+. {orch-name} detects change in the ConfigMap and triggers a restart of the {prod-short} Pod.
+====
 
 .Additional resources
 


### PR DESCRIPTION
Rephrasing configuring to address following:



```
And any change in the ConfigMap automatically triggers a restart of the CodeReady Workspaces Pod.`
```

That's not true. It isn't possible to update configmap, operator will revert any changes. I suggest to remove this sentence