### PR TITLE
Quickfix for erroneous nbsp attribute processing by Jekyll.

### DIFF
--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -41,6 +41,7 @@ plugins:
   - jekyll-redirect-from
 
 asciidoc_attributes: &asciidoc_attributes
+  nbsp: " "
   project-context: che
   prod: Eclipse{nbsp}Che
   prod2: Eclipse{nbsp}Che


### PR DESCRIPTION
Quickfix for erroneous nbsp attribute processing by Jekyll. 

fixes https://github.com/eclipse/che/issues/17325
