### PR TITLE
document mounting secret as files updates for older clusters

### DIFF
--- a/src/main/pages/che-7/end-user-guide/proc_defining-maven-settings-xml-file-across-workspaces.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_defining-maven-settings-xml-file-across-workspaces.adoc
@@ -56,7 +56,7 @@ data:
 ----
 
 As of {7-15-2-2} version of {prod-short}, the target container annotation has been deprecated. An example of the updated annotation looks as follows:
-+
+
 [source,yaml]
 ----
 apiVersion: v1
@@ -82,3 +82,22 @@ $ kubectl apply -f secret.yaml
 ----
 
 . Start a new workspace. You will see `/home/user/.m2/settings.xml` with your original content in the `maven` container.
+
+=== Openshift 3.11 and Kubernetes <1.13
+
+On Kubernetes versions older than 1.13, it's not possible to have multiple VolumeMounts at same path so having devfile with volume `/home/user/.m2` and secret at `/home/user/.m2/settings.xml` would resolve into the conflict. On these clusters use `/home/user/.m2/repository` as a volume for maven repository in the devfile:
+
+[source,yaml]
+----
+apiVersion: 1.0.0
+metadata:
+  ...
+components:
+ - type: dockerimage
+   alias: maven
+   image: maven:3.11
+   volumes:
+     - name: m2
+       containerPath: /home/user/.m2/repository
+   ...
+----

--- a/src/main/pages/che-7/end-user-guide/proc_mounting-a-secret-as-a-file-into-a-workspace-container.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_mounting-a-secret-as-a-file-into-a-workspace-container.adoc
@@ -5,7 +5,7 @@
 [id="mounting-a-secret-as-a-file-into-a-workspace-container_{context}"]
 = Mounting a secret as a file into a workspace container
 
-WARNING: {prod} uses Kubernetes VolumeMount `subPath` feature to mount files into containers. This is supported and enabled by default since Kubernetes v1.15 and OpenShift 4.
+WARNING: On Kubernetes older than v1.13 and OpenShift older than 4, secrets mounted as file overrides volume mounts defined in the devfile.
 
 This section describes how to mount a secret from the user's {orch-namespace} as a file in single-workspace or multiple-workspace containers of {prod-short}.
 


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTION.md) before submitting a PR.

### What does this PR do?
documents and updates docs with secret mounts as files on older clusters  
https://github.com/eclipse/che/pull/17389

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17213

### Specify the version of the product this PR applies to. 
