### PR TITLE
Add keys to _config.yml to support different postgres and keycloak

### DIFF
--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -70,7 +70,7 @@ asciidoc_attributes: &asciidoc_attributes
   link-cli-github: https://github.com/che-incubator/chectl
   link-installing-on-openShift-3-using-the-operator: link:{site-baseurl}che-7/installing-{prod-id-short}-on-openshift-3-using-the-operator[Installing {prod-short} on OpenShift 3 using the Operator]
   link-limits-for-user-workspaces: link:{site-baseurl}che-7/advanced-configuration-options-for-the-che-server-component/#users-workspace-limits[Limits for user workspaces]
-  link-server-postgres-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/postgres
+  link-postgres-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/postgres
   link-server-identity-provider-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/keycloak
 
   oc4-ver: 4.4
@@ -102,7 +102,7 @@ asciidoc_attributes: &asciidoc_attributes
   project-context: che
 
 # Images used in deployment
-  server-postgresql-image-url: docker.io/eclipse/che-postgres
+  postgresql-image-url: docker.io/eclipse/che-postgres
   identity-provider-image-url: docker.io/eclipse/che-keycloak
 
 asciidoc:

--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -59,8 +59,8 @@ asciidoc_attributes: &asciidoc_attributes
   identity-provider2: Keycloak
   image-puller-tag: latest
   image-puller: quay.io/eclipse/kubernetes-image-puller
-  
-# URLs for the Downstream synergy 
+
+# URLs for the Downstream synergy
   link-installing-an-instance: link:{site-baseurl}che-7/che-quick-starts/[Che 'quick-starts']
   link-accessing-a-git-repository-via-https: link:{site-baseurl}che-7/version-control/#accessing-a-git-repository-via-https_version-control[Accessing a Git repository via HTTPS]
   link-adding-tls-certificates: link:{site-baseurl}che-7/installing-che-in-tls-mode-with-self-signed-certificates[Installing {prod-short} in TLS mode with self-signed certificates]
@@ -70,7 +70,9 @@ asciidoc_attributes: &asciidoc_attributes
   link-cli-github: https://github.com/che-incubator/chectl
   link-installing-on-openShift-3-using-the-operator: link:{site-baseurl}che-7/installing-{prod-id-short}-on-openshift-3-using-the-operator[Installing {prod-short} on OpenShift 3 using the Operator]
   link-limits-for-user-workspaces: link:{site-baseurl}che-7/advanced-configuration-options-for-the-che-server-component/#users-workspace-limits[Limits for user workspaces]
-  
+  link-server-postgres-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/postgres
+  link-server-identity-provider-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/keycloak
+
   oc4-ver: 4.4
   ocp: OpenShift{nbsp}Container{nbsp}Platform
   ocp3-ver: 3.11
@@ -98,6 +100,10 @@ asciidoc_attributes: &asciidoc_attributes
   prod2: Eclipse{nbsp}Che
   prod-workspace: che-ws
   project-context: che
+
+# Images used in deployment
+  server-postgresql-image-url: docker.io/eclipse/che-postgres
+  identity-provider-image-url: docker.io/eclipse/che-keycloak
 
 asciidoc:
   require_front_matter_header: true

--- a/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
@@ -122,10 +122,10 @@ The images _essential_ for starting a workspace are infrastructure images that a
 | `docker.io/eclipse/che-server`
 | The main {prod-short} server image
 
-| `docker.io/eclipse/che-postgres`
+| `{server-postgresql-image-url}`
 | The database used by {prod-short}
 
-| `docker.io/eclipse/che-keycloak`
+| `{identity-provider-image-url}`
 | {identity-provider} Pod for user authentication
 
 | `quay.io/eclipse/che-jwtproxy`

--- a/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
@@ -122,7 +122,7 @@ The images _essential_ for starting a workspace are infrastructure images that a
 | `docker.io/eclipse/che-server`
 | The main {prod-short} server image
 
-| `{server-postgresql-image-url}`
+| `{postgresql-image-url}`
 | The database used by {prod-short}
 
 | `{identity-provider-image-url}`

--- a/src/main/pages/che-7/overview/con_che-keycloak.adoc
+++ b/src/main/pages/che-7/overview/con_che-keycloak.adoc
@@ -13,8 +13,8 @@ The {prod-short} server uses {identity-provider} as an OpenID Connect (OIDC) pro
 [cols=2*]
 |===
 | Source code
-| link:https://github.com/eclipse/che/tree/master/dockerfiles/keycloak[{prod-short} Keycloak]
+| link:{link-server-identity-provider-dockerfile-location}[{prod-short} {identity-provider2}]
 
 | Container image
-| `eclipse/che-keycloak`
+| `{identity-provider-image-url}`
 |===

--- a/src/main/pages/che-7/overview/con_che-postgresql.adoc
+++ b/src/main/pages/che-7/overview/con_che-postgresql.adoc
@@ -12,8 +12,8 @@ The {prod-short} server uses the database to persist user configurations (worksp
 [cols=2*]
 |===
 | Source code
-| link:{link-server-postgres-dockerfile-location}[{prod-short} Postgres]
+| link:{link-postgres-dockerfile-location}[{prod-short} Postgres]
 
 | Container image
-| `{server-postgresql-image-url}`
+| `{postgresql-image-url}`
 |===

--- a/src/main/pages/che-7/overview/con_che-postgresql.adoc
+++ b/src/main/pages/che-7/overview/con_che-postgresql.adoc
@@ -12,8 +12,8 @@ The {prod-short} server uses the database to persist user configurations (worksp
 [cols=2*]
 |===
 | Source code
-| link:https://github.com/eclipse/che/tree/master/dockerfiles/postgres[{prod-short} Postgres]
+| link:{link-server-postgres-dockerfile-location}[{prod-short} Postgres]
 
 | Container image
-| `eclipse/che-postgres`
+| `{server-postgresql-image-url}`
 |===


### PR DESCRIPTION
### What does this PR do?
Add replacements:
  - `{server-postgresql-image-url}` - image used for postgres
  - `{link-server-postgres-dockerfile-location}` - link to dockerfile for above
  - `{identity-provider-image-url}` - image used for identity provider
  - `{link-server-identity-provider-dockerfile-location}` - link to dockerfile for above

With values set so as to not change existing docs. This allows alternative implementations to be specified in docs.

I chose to abstract out keycloak to "identity-provider" since in CRW e.g. we use RH SSO.

### What issues does this PR fix or reference?
Necessary for https://issues.redhat.com/browse/RHDEVDOCS-1902

### Specify the version of the product this PR applies to. 
All versions, should be no change in output HTML