### PR TITLE
Include steps for getting workspaces logs in end-user guide

### DIFF
--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -179,12 +179,24 @@ entries:
       - title: Using npm artifact repositories
         url: che-7/using-npm-artifact-repositories
         output: web
-  - title: Troubleshooting for Che end users
-    url: che-7/troubleshooting-for-che-end-users
-    output: web
   - title: The Developer Workspace Button
     url: che-7/the-developer-workspace-button
     output: web
+  - title: Troubleshooting for Che end users
+    output: web
+    folderitems:
+      - title: Overview
+        url: che-7/troubleshooting-for-che-end-users
+        output: web
+      - title: Viewing workspace logs
+        url: che-7/viewing-che-workspaces-logs
+        output: web
+      - title: Starting a workspace in debug mode
+        url: che-7/starting-a-workspace-in-debug-mode
+        output: web
+      - title: Switching the storage type used for workspaces
+        url: che-7/using-different-storage-for-workspaces
+        output: web
 
 
 # Installation Guide

--- a/src/main/pages/che-7/contributor-guide/proc_overriding-ram-of-a-che-theia-plug-in.adoc
+++ b/src/main/pages/che-7/contributor-guide/proc_overriding-ram-of-a-che-theia-plug-in.adoc
@@ -19,7 +19,7 @@ NOTE: Using this notation, units that contain the character `i`, denote a number
 .Limiting RAM use for a plug-in
 [example]
 ====
-Example of an attribute that sets the RAM limit for the link:https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml[YAML language server plug-in] to 768 mebibytes (1073741824 bytes) and RAM request to 500 megabytes:
+Example of an attribute that sets the RAM limit for the link:https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/redhat/vscode-yaml/0.8.0/meta.yaml[YAML language server plug-in] to 768 mebibytes (1073741824 bytes) and RAM request to 500 megabytes:
 
 [source,yaml]
 ----
@@ -34,7 +34,7 @@ components:
 .Limiting CPU use for a plug-in
 [example]
 ====
-Example of an attribute that sets the CPU limit for the link:https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/redhat/vscode-yaml/0.3.0/meta.yaml[YAML language server plug-in] to 1.5 cores and CPU request to 500 millicores:
+Example of an attribute that sets the CPU limit for the link:https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/redhat/vscode-yaml/0.8.0/meta.yaml[YAML language server plug-in] to 1.5 cores and CPU request to 500 millicores:
 
 [source,yaml]
 ----

--- a/src/main/pages/che-7/end-user-guide/assembly_starting-a-workspace-in-debug-mode.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_starting-a-workspace-in-debug-mode.adoc
@@ -1,0 +1,33 @@
+---
+title: Starting a workspace in debug mode
+keywords:
+tags: []
+sidebar: che_7_docs
+permalink: che-7/starting-a-workspace-in-debug-mode/
+folder: che-7/end-user-guide
+summary:
+---
+
+:page-liquid:
+ifdef::context[:parent-context-of-starting-a-workspace-in-debug-mode: {context}]
+
+ifndef::context[]
+[id="starting-a-workspace-in-debug-mode"]
+endif::[]
+ifdef::context[]
+[id="starting-a-workspace-in-debug-mode_{context}"]
+endif::[]
+= Starting a workspace in debug mode
+
+:context: starting-a-workspace-in-debug-mode
+
+If you encounter issues starting a workspace, it may be helpful to start the workspace with debug logging enabled. Starting a workspace in debug mode will show logs from workspace components that are typically hidden during workspace startup.
+
+include::proc_restarting-a-che-workspace-in-debug-mode-after-start-failure.adoc[leveloffset=+1]
+
+include::proc_starting-a-che-workspace-in-debug-mode.adoc[leveloffset=+1]
+
+
+ifdef::parent-context-of-starting-a-workspace-in-debug-mode[:context: {parent-context-of-starting-a-workspace-in-debug-mode}]
+ifndef::parent-context-of-starting-a-workspace-in-debug-mode[:!context:]
+

--- a/src/main/pages/che-7/end-user-guide/assembly_starting-a-workspace-in-debug-mode.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_starting-a-workspace-in-debug-mode.adoc
@@ -9,14 +9,9 @@ summary:
 ---
 
 :page-liquid:
-ifdef::context[:parent-context-of-starting-a-workspace-in-debug-mode: {context}]
+:parent-context-of-starting-a-workspace-in-debug-mode: {context}
 
-ifndef::context[]
-[id="starting-a-workspace-in-debug-mode"]
-endif::[]
-ifdef::context[]
 [id="starting-a-workspace-in-debug-mode_{context}"]
-endif::[]
 = Starting a workspace in debug mode
 
 :context: starting-a-workspace-in-debug-mode
@@ -27,7 +22,4 @@ include::proc_restarting-a-che-workspace-in-debug-mode-after-start-failure.adoc[
 
 include::proc_starting-a-che-workspace-in-debug-mode.adoc[leveloffset=+1]
 
-
-ifdef::parent-context-of-starting-a-workspace-in-debug-mode[:context: {parent-context-of-starting-a-workspace-in-debug-mode}]
-ifndef::parent-context-of-starting-a-workspace-in-debug-mode[:!context:]
-
+:context: {parent-context-of-starting-a-workspace-in-debug-mode}

--- a/src/main/pages/che-7/end-user-guide/assembly_troubleshooting-for-che-end-users.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_troubleshooting-for-che-end-users.adoc
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting for Che end users
+title: Overview
 keywords:
 tags: []
 sidebar: che_7_docs
@@ -16,10 +16,10 @@ summary:
 
 :context: troubleshooting-for-che-end-users
 
-include::proc_restarting-a-che-workspace-in-debug-mode-after-start-failure.adoc[leveloffset=+1]
+For information about debugging issues when running {prod} workspaces, see the following sections:
 
-include::proc_starting-a-che-workspace-in-debug-mode.adoc[leveloffset=+1]
-
-include::proc_using-different-types-of-storage.adoc[leveloffset=+1]
+* link:{site-baseurl}che-7/viewing-{prod-id-short}-workspaces-logs[Viewing {prod-short} workspace logs]
+* link:{site-baseurl}che-7/starting-a-workspace-in-debug-mode/[Starting a {prod-short} workspace in debug mode]
+* link:{site-baseurl}che-7/using-different-storage-for-workspaces/[Switching the storage type used for workspaces]
 
 :context: {parent-context-of-troubleshooting-for-che-end-users}

--- a/src/main/pages/che-7/end-user-guide/assembly_using-different-storage-for-workspaces.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_using-different-storage-for-workspaces.adoc
@@ -1,5 +1,5 @@
 ---
-title: Using different storage for workspaces 
+title: Using different storage for workspaces
 keywords:
 tags: []
 sidebar: che_7_docs
@@ -9,20 +9,13 @@ summary:
 ---
 
 :page-liquid:
-ifdef::context[:parent-context-of-using-different-storage-for-workspaces: {context}]
+:parent-context-of-using-different-storage-for-workspaces: {context}
 
-ifndef::context[]
-[id="using-different-storage-for-workspaces"]
-endif::[]
-ifdef::context[]
 [id="using-different-storage-for-workspaces_{context}"]
-endif::[]
 = Using different storage for workspaces
 
 :context: using-different-storage-for-workspaces
 
 include::con_storage-types-for-workspaces.adoc[leveloffset=+1]
 
-ifdef::parent-context-of-using-different-storage-for-workspaces[:context: {parent-context-of-using-different-storage-for-workspaces}]
-ifndef::parent-context-of-using-different-storage-for-workspaces[:!context:]
-
+:context: {parent-context-of-using-different-storage-for-workspaces}

--- a/src/main/pages/che-7/end-user-guide/assembly_using-different-storage-for-workspaces.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_using-different-storage-for-workspaces.adoc
@@ -1,0 +1,28 @@
+---
+title: Using different storage for workspaces 
+keywords:
+tags: []
+sidebar: che_7_docs
+permalink: che-7/using-different-storage-for-workspaces/
+folder: che-7/end-user-guide
+summary:
+---
+
+:page-liquid:
+ifdef::context[:parent-context-of-using-different-storage-for-workspaces: {context}]
+
+ifndef::context[]
+[id="using-different-storage-for-workspaces"]
+endif::[]
+ifdef::context[]
+[id="using-different-storage-for-workspaces_{context}"]
+endif::[]
+= Using different storage for workspaces
+
+:context: using-different-storage-for-workspaces
+
+include::con_storage-types-for-workspaces.adoc[leveloffset=+1]
+
+ifdef::parent-context-of-using-different-storage-for-workspaces[:context: {parent-context-of-using-different-storage-for-workspaces}]
+ifndef::parent-context-of-using-different-storage-for-workspaces[:!context:]
+

--- a/src/main/pages/che-7/end-user-guide/con_storage-types-for-workspaces.adoc
+++ b/src/main/pages/che-7/end-user-guide/con_storage-types-for-workspaces.adoc
@@ -7,11 +7,11 @@ Since 7.17.0 Eclipse Che supports three types of storage with different capabili
 
 .Persistent storage
 
-This kind of storage gives you an ability to store your changes directly in the mounted Persistent Volume. In this case your changes will be totally safe and Kubernetes infrastructure takes care of it (storage backend in particular), but the price for that is slow I/O, especially with a huge amount of small files. For example, some NodeJS projects may have many dependencies and node_modules is filled with thousands of small files.  
+Persistent storage saves your changes directly in a mounted Persistent Volume. This option has the benefit of saving directly to a persistent store, but may encounter issues related to the storage plugin used for the Persistent Volume such as slow I/O or synchronization conflicts when modifying a large number of files. An example of when such an error can occur is when downloading dependencies for a NodeJS project, as the `node_modules` folder can contain thousands of small files.
 
 NOTE: Speed of I/O varies depending on the link:https://kubernetes.io/docs/concepts/storage/storage-classes/[Storage Classes] configured in the environment.
 
-For now this is the default mode for any new workspace, no additional attributes are required. If you want to explicitly make this setting visible in your workspace configuration you can add:
+This is the default mode for new workspace, and thus applies when the workspace configuration does not specify otherwise. If you want to explicitly make this setting visible in your workspace configuration you can add:
 [source,yaml]
 ----
 attributes:
@@ -20,11 +20,10 @@ attributes:
 
 .Ephemeral Storage
 
-With this kind of storage, files are mounted to the link:https://kubernetes.io/docs/concepts/storage/volumes/#emptydir[`emptyDir`] volume. As the name says, it is initially empty. When a Pod is removed from a node for any reason, the data in the `emptyDir` is deleted forever. This means that all the changes will be lost once the workspace is stopped or restarted for any reason.
+Ephemeral storage uses an link:https://kubernetes.io/docs/concepts/storage/volumes/#emptydir[`emptyDir`] volume to store workspace files. Such volumes exist only while the Kubernetes Pod they are attached to is running; if the pod is removed for any reason, all files stored in the volume are lost. While ephemeral storage provides fast I/O, it is necessary to ensure all changes are pushed to a remote repository, such as GitHub.
 
-WARNING: To save the changes, commit and push to the remote before stopping an ephemeral workspace. Otherwise, all the changes will be lost.
+WARNING: To save the changes, commit and push any changes to a remote repository before stopping an ephemeral workspace. Otherwise, all the changes will be lost.
 
-Thus, you need to take care of committing and pushing your changes to the remote before stopping a workspace. At the same time Ephemeral mode gives you faster I/O, as a result it will work fast for any kind of project. To enable this storage type add the following to your workspace configuration:
 [source,yaml]
 ----
 attributes:
@@ -48,18 +47,15 @@ attributes:
 |44m 53s
 |===
 
-.Asynchronous storage (Experimental)
+.Asynchronous storage (experimental)
 
-This is a combination of the above two. The initial workspace container will mount an `emptyDir`, however, the changes will be restored on workspace start and a backup is performed on workspace stop. This storage type also offers fast I/O (similar to the ephemeral mode) and workspace project changes are persisted.
+This is a combination of persistent and ephemeral storage. The workspace container will mount an emptyDir volume that is synchronized asynchronously with a persistent volume that stores workspace files. It has the benefits of fast I/O while allowing for persistence between workspace runs.
 
-Synchronization is powered by link:https://rsync.samba.org/[`rsync`] via the link:https://www.openssh.com/[SSH] protocol. When a workspace is configured with an asynchronous storage type, the link:https://github.com/che-incubator/workspace-data-sync/[workspace-data-sync] plugin is automatically added to the workspace configuration. The plugin runs `rsync` command on workspace start to restore changes if they exist. When a workspace is stopped, it sends changes to the permanent storage. The `rsync` process can take some time -  for relatively small projects the restore procedure is completed fast and you can see project source files and folders immediately after Che Theia is initialized. If `rsync` takes a longer time, the synchronization process is shown in Che Theia UI status bar area. (link:https://github.com/eclipse/che-theia/tree/master/extensions/eclipse-che-theia-file-sync-tracker][Extension in Che Theia repository]).
+Synchronization is powered by link:https://rsync.samba.org/[`rsync`] via the link:https://www.openssh.com/[SSH] protocol. When a workspace is configured with an asynchronous storage type, the link:https://github.com/che-incubator/workspace-data-sync/[workspace-data-sync] plugin is automatically added to the workspace configuration. This plugin will run `rsync` on workspace start to restore changes if they exist. When a workspace is stopped, it will synchronize changes with the backing permanent storage. The rsync process can take some time, so a workspace may be slower than when using persistent or ephemeral storage. For large projects, synchronization progress is shown in the Che Theia UI status bar. (link:https://github.com/eclipse/che-theia/tree/master/extensions/eclipse-che-theia-file-sync-tracker][Extension in Che Theia repository]).
 
 image::troubleshooting/status-bar-file-sync.png[link="{imagesdir}/troubleshooting/status-bar-file-sync.png",Files synchronization progress]
-'''
-NOTE:  Currently, this mode has some limitations, such as:
-supports only with ‘common’ PVC strategy;
-only  ‘per-user’ namespace strategy is supported;
-a user can simultaneously  run only 1 workspace with asynchronous storage
+
+NOTE: This mode has some limitations: it requires the {prod-short} server to be configured with the ‘common’ PVC strategy and the 'per-user' namespace strategy, and at most one workspace per user can run concurrently.
 
 To configure asynchronous storage for your workspace add the following to workspace configuration:
 [source,yaml]
@@ -69,11 +65,11 @@ attributes:
  persistVolumes: 'false'
 ----
 
-Aslo two new properties added to `che.properties` that can be used to configure behavior of a client like Che UserDashboard:
+The following properties can be set in `che.properties` to configure the behavior of a client such as the User Dashboard:
 
-`che.workspace.storage.available_types`: this configuration property defines available values for storage types that clients like Dashboard should propose for users during workspace creation/update. Available values: 'persistent’,'ephemeral', 'async'. You can use several type comma separate (e.g. `che.workspace.storage.available_types=persistent,ephemeral,async`)
+`che.workspace.storage.available_types`: this configuration property defines a comma-separated list of available values for storage types that clients like Dashboard should propose for users during workspace creation/update. Available values: 'persistent’,'ephemeral', 'async' (e.g. `che.workspace.storage.available_types=persistent,ephemeral,async`).
 
-`che.workspace.storage.preferred_type`: this configuration property defines a default value for storage type that clients like Dashboard should propose for users during workspace creation/update. The 'async' value not recommended as a default type since it's still experimental (e.g. `che.workspace.storage.preferred_type=persistent`)
+`che.workspace.storage.preferred_type`: this configuration property defines the default storage type that clients like the User Dashboard should propose for users during workspace creation/update. The 'async' value not recommended as a default type since it's still experimental (e.g. `che.workspace.storage.preferred_type=persistent`)
 
 The Storage Type switcher is available on the *Create Custom Workspace* page of the User Dashboard:
 

--- a/src/main/pages/che-7/end-user-guide/con_storage-types-for-workspaces.adoc
+++ b/src/main/pages/che-7/end-user-guide/con_storage-types-for-workspaces.adoc
@@ -1,15 +1,7 @@
----
-title: Using different type of storage 
-keywords:
-tags: []
-sidebar: che_7_docs
-permalink: che-7/using-different-type-of-storage/
-folder: che-7/end-user-guide
-summary:
----
 
-[id="using-different-type-of-storage_{context}"]
-= Using different type of storage 
+
+[id="storage-types-for-workspaces_{context}"]
+= Storage types for workspaces
 
 Since 7.17.0 Eclipse Che supports three types of storage with different capabilities: persistent storage, ephemeral and asynchronous.
 

--- a/src/main/pages/che-7/installation-guide/examples/system-variables.adoc
+++ b/src/main/pages/che-7/installation-guide/examples/system-variables.adoc
@@ -1,4 +1,4 @@
-[id="che-server"]
+[id="LChe-server"]
 .Che server 
 
 ,=== 
@@ -46,7 +46,7 @@
  `+CHE_WORKSPACE_STOP_ROLE_ENABLED+`,"`+true+`","If true, 'stop-workspace' role with the edit privileges will be granted to the 'che' ServiceAccount if OpenShift OAuth is enabled. This configuration is mainly required for workspace idling when the OpenShift OAuth is enabled." 
 ,=== 
 
-[id="templates"]
+[id="LTemplates"]
 .Templates 
 
 ,=== 
@@ -55,7 +55,7 @@
  `+CHE_TEMPLATE_STORAGE+`,"`+${che.home}/templates+`","Folder that contains JSON files with code templates and samples" 
 ,=== 
 
-[id="authentication-parameters"]
+[id="LAuthentication-parameters"]
 .Authentication parameters 
 
 ,=== 
@@ -75,7 +75,7 @@
  `+CHE_OAUTH_OPENSHIFT_VERIFY__TOKEN__URL+`,"`+NULL+`","ConfigurationofOpenShiftOAuth client. Used to obtain OpenShift OAuth token." 
 ,=== 
 
-[id="internal"]
+[id="LInternal"]
 .Internal 
 
 ,=== 
@@ -96,7 +96,7 @@
  `+DB_SCHEMA_FLYWAY_SCRIPTS_LOCATIONS+`,"`+classpath:che-schema+`","DBinitializationandmigrationconfiguration" 
 ,=== 
 
-[id="kubernetes-infra-parameters"]
+[id="LKubernetes-Infra-parameters"]
 .Kubernetes Infra parameters 
 
 ,=== 
@@ -143,7 +143,7 @@
  `+CHE_INFRA_KUBERNETES_RUNTIMES__CONSISTENCY__CHECK__PERIOD__MIN+`,"`+-1+`","Defines the period with which runtimes consistency checks will be performed. If runtime has inconsistent state then runtime will be stopped automatically. Value must be more than 0 or `-1`, where `-1` means that checks won't be performed at all. It is disabled by default because there is possible {prod-short} Server configuration when {prod-short} Server doesn't have an ability to interact with Kubernetes API when operation is not invoked by user. It DOES work on the following configurations: - workspaces objects are created in the same namespace where {prod-short} Server is located; - cluster-admin service account token is mount to {prod-short} Server pod; It DOES NOT work on the following configurations: - {prod-short} Server communicates with Kubernetes API using token from OAuth provider;" 
 ,=== 
 
-[id="openshift-infra-parameters"]
+[id="LOpenShift-Infra-parameters"]
 .OpenShift Infra parameters 
 
 ,=== 
@@ -155,7 +155,7 @@
  `+CHE_SINGLEPORT_WILDCARD__DOMAIN_IPLESS+`,"`+false+`","Enable single port custom DNS without inserting the IP" 
 ,=== 
 
-[id="experimental-properties"]
+[id="LExperimental-properties"]
 .Experimental properties 
 
 ,=== 
@@ -167,7 +167,8 @@
  `+CHE_WORKSPACE_PLUGIN__BROKER_WAIT__TIMEOUT__MIN+`,"`+3+`","Defines the timeout in minutes that limits the max period of result waiting for plugin broker." 
  `+CHE_WORKSPACE_PLUGIN__REGISTRY__URL+`,"`+https://che-plugin-registry.prod-preview.openshift.io/v3+`","Workspace tooling plugins registry endpoint. Should be a valid HTTP URL. `+Example: http://che-plugin-registry-eclipse-che.192.168.65.2.nip.io+` In case {prod-short} plugins tooling is not needed value 'NULL' should be used" 
  `+CHE_WORKSPACE_DEVFILE__REGISTRY__URL+`,"`+https://che-devfile-registry.prod-preview.openshift.io/+`","Devfile Registry endpoint. Should be a valid HTTP URL. `+Example: http://che-devfile-registry-eclipse-che.192.168.65.2.nip.io+` In case {prod-short} plugins tooling is not needed value 'NULL' should be used" 
- `+CHE_WORKSPACE_PERSIST__VOLUMES_DEFAULT+`,"`+true+`","Defines a default value for persist volumes that clients like Dashboard should propose for users during workspace creation. Possible values: true or false In case of true - PersistentVolumeClaims are used by declared volumes by user and plugins. `true` value is supposed not to be set explicitly in Devfile attributes since it's default fixed behaviour. In case of false - emptyDir is used instead of PVCs. Note that data will be lost after workspace restart." 
+ `+CHE_WORKSPACE_STORAGE_AVAILABLE__TYPES+`,"`+persistent,ephemeral,async+`","The configuration property that defines available values for storage types that clients like Dashboard should propose for users during workspace creation/update. Available values:   - 'persistent': Persistent Storage slow I/O but persistent.   - 'ephemeral': Ephemeral Storage allows for faster I/O but may have limited storage       and is not persistent.   - 'async': Experimental feature: Asynchronous storage is combination of Ephemeral       and Persistent storage. Allows for faster I/O and keep your changes, will backup on stop       and restore on start workspace.       Will work only if:           - che.infra.kubernetes.pvc.strategy='common'           - che.limits.user.workspaces.run.count=1           - che.infra.kubernetes.namespace.allow_user_defined=false           - che.infra.kubernetes.namespace.default contains <username>      in other cases remove 'async' from the list." 
+ `+CHE_WORKSPACE_STORAGE_PREFERRED__TYPE+`,"`+persistent+`","The configuration property that defines a default value for storage type that clients like Dashboard should propose for users during workspace creation/update. The 'async' value not recommended as default type since it's experimental" 
  `+CHE_SERVER_SECURE__EXPOSER+`,"`+default+`","Configures in which way secure servers will be protected with authentication. Suitable values:   - 'default': jwtproxy is configured in a pass-through mode.       So, servers should authenticate requests themselves.   - 'jwtproxy': jwtproxy will authenticate requests.       So, servers will receive only authenticated ones." 
  `+CHE_SERVER_SECURE__EXPOSER_JWTPROXY_TOKEN_ISSUER+`,"`+wsmaster+`","Jwtproxy issuer string, token lifetime and optional auth page path to route unsigned requests to." 
  `+CHE_SERVER_SECURE__EXPOSER_JWTPROXY_TOKEN_TTL+`,"`+8800h+`","Jwtproxyissuer string, token lifetime and optional auth page path to route unsigned requests to." 
@@ -177,7 +178,7 @@
  `+CHE_SERVER_SECURE__EXPOSER_JWTPROXY_CPU__LIMIT+`,"`+0.5+`","Jwtproxyissuerstring,tokenlifetimeand optional auth page path to route unsigned requests to." 
 ,=== 
 
-[id="configuration-of-major-websocket-endpoint"]
+[id="LConfiguration-of-major-websocket-endpoint"]
 .Configuration of major "/websocket" endpoint 
 
 ,=== 
@@ -188,7 +189,7 @@
  `+CHE_CORE_JSONRPC_PROCESSOR__QUEUE__CAPACITY+`,"`+100000+`","Configuration of queue used to process Json RPC messages." 
 ,=== 
 
-[id="configuration-of-major-websocket-minor-endpoint"]
+[id="LConfiguration-of-major-websocket-minor-endpoint"]
 .Configuration of major "/websocket-minor" endpoint 
 
 ,=== 
@@ -200,7 +201,7 @@
  `+CHE_METRICS_PORT+`,"`+8087+`","Port the the http server endpoint that would be exposed with Prometheus metrics" 
 ,=== 
 
-[id="cors-settings"]
+[id="LCORS-settings"]
 .CORS settings 
 
 ,=== 
@@ -210,7 +211,7 @@
  `+CHE_CORS_ALLOW__CREDENTIALS+`,"`+false+`","'cors.support.credentials' indicates if it allows processing of requests with credentials (in cookies, headers, TLS client certificates)" 
 ,=== 
 
-[id="factory-defaults"]
+[id="LFactory-defaults"]
 .Factory defaults 
 
 ,=== 
@@ -220,7 +221,7 @@
  `+CHE_FACTORY_DEFAULT__PLUGINS+`,"`+eclipse/che-machine-exec-plugin/nightly+`","Editorand plugin which will be used for factories which are created from remote git repository which doesn't contain any `+{prod-short}+`-specific workspace descriptors (like .devfile of .factory.json) Multiple plugins must be comma-separated, for example: pluginFooPublisher/pluginFooName/pluginFooVersion,pluginBarPublisher/pluginBarName/pluginBarVersion" 
 ,=== 
 
-[id="devfile-defaults"]
+[id="LDevfile-defaults"]
 .Devfile defaults 
 
 ,=== 
@@ -233,7 +234,7 @@
  `+CHE_INFRA_KUBERNETES_ASYNC_STORAGE_IMAGE+`,"`+quay.io/eclipse/che-workspace-data-sync-storage:latest#+`","Docker image for the {prod-short} async storage" 
 ,=== 
 
-[id="che-system"]
+[id="LChe-system"]
 .Che system 
 
 ,=== 
@@ -243,7 +244,7 @@
  `+CHE_SYSTEM_ADMIN__NAME+`,"`+admin+`","Grant system permission for 'che.admin.name' user. If the user already exists it'll happen on component startup, if not - during the first login when user is persisted in the database." 
 ,=== 
 
-[id="workspace-limits"]
+[id="LWorkspace-limits"]
 .Workspace limits 
 
 ,=== 
@@ -254,7 +255,7 @@
  `+CHE_LIMITS_WORKSPACE_RUN_TIMEOUT+`,"`+0+`","The length of time in milliseconds that a workspace will run, regardless of activity, before the system will suspend it.  Set this property if you want to automatically stop workspaces after a period of time.  The default is zero, meaning that there is no run timeout." 
 ,=== 
 
-[id="users-workspace-limits"]
+[id="LUsers-workspace-limits"]
 .Users workspace limits 
 
 ,=== 
@@ -265,7 +266,7 @@
  `+CHE_LIMITS_USER_WORKSPACES_RUN_COUNT+`,"`+1+`","The maximum number of running workspaces that a single user is allowed to have. If the user has reached this threshold and they try to start an additional workspace, they will be prompted with an error message. The user will need to stop a running workspace to activate another." 
 ,=== 
 
-[id="organizations-workspace-limits"]
+[id="LOrganizations-workspace-limits"]
 .Organizations workspace limits 
 
 ,=== 
@@ -277,7 +278,7 @@
  `+CHE_MAIL_FROM__EMAIL__ADDRESS+`,"`+che@noreply.com+`","Address that will be used as from email for email notifications" 
 ,=== 
 
-[id="organizations-notifications-settings"]
+[id="LOrganizations-notifications-settings"]
 .Organizations notifications settings 
 
 ,=== 
@@ -293,7 +294,7 @@
  `+CHE_ORGANIZATION_EMAIL_ORG__RENAMED__TEMPLATE+`,"`+st-html-templates/organization_renamed+`","" 
 ,=== 
 
-[id="multi-user-specific-openshift-infrastructure-configuration"]
+[id="LMulti-user-specific-OpenShift-infrastructure-configuration"]
 .Multi-user-specific OpenShift infrastructure configuration 
 
 ,=== 
@@ -302,7 +303,7 @@
  `+CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER+`,"`+NULL+`","Alias of the Openshift identity provider registered in Keycloak, that should be used to create workspace OpenShift resources in Openshift namespaces owned by the current {prod-short} user. Should be set to NULL if `che.infra.openshift.project` is set to a non-empty value. For more information see the following documentation: https://www.keycloak.org/docs/latest/server_admin/index.html#openshift-4" 
 ,=== 
 
-[id="keycloak-configuration"]
+[id="LKeycloak-configuration"]
 .Keycloak configuration 
 
 ,=== 
@@ -313,7 +314,7 @@
  `+CHE_KEYCLOAK_CLIENT__ID+`,"`+che-public+`","Keycloak client id in che.keycloak.realm that is used by dashboard, ide and cli to authenticate users" 
 ,=== 
 
-[id="redhat-che-specific-configuration"]
+[id="LRedHat-Che-specific-configuration"]
 .RedHat Che specific configuration 
 
 ,=== 

--- a/src/main/pages/che-7/overview/proc_creating-a-worskpace-from-the-user-dashboard.adoc
+++ b/src/main/pages/che-7/overview/proc_creating-a-worskpace-from-the-user-dashboard.adoc
@@ -24,7 +24,7 @@ This section describes how to create a workspace from the user dashboard in Host
 
 . In the *RAM* section, adapt the memory available for the workspace runtime environment within the limits defined in the xref:about-hosted-che_hosted-che[terms of service].
 
-. In the *Storage Type* section, choose to have persistent storage attached or not.  For more details, see link:{site-baseurl}che-7/using-different-type-of-storage[Using different type of storage] 
+. In the *Storage Type* section, choose to have persistent storage attached or not.  For more details, see link:{site-baseurl}che-7/using-different-storage-for-workspaces[Using different storage for workspaces]
 
 . In the *Projects* section, choose the projects to integrate in the workspace. For the specific GitHub case, see xref:importing-projects-from-github-in-hosted-che_hosted-che[Importing projects from GitHub in Hosted Che].
 


### PR DESCRIPTION
### What does this PR do?
Adds link to viewing workspace logs to the end-user troubleshooting guide. To make this a tidy change, the end-user troubleshooting section is split into subtopics: 
1. Viewing workspace logs
2. Starting a workspace in debug mode
3. Switching workspace storage types

I also went and fixed a few broken links, and did a quick edit pass on the existing troubleshooting guide.

Each commit in this PR should have a fairly self-explanatory message; feel free to ask if it is unclear.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17459

### Specify the version of the product this PR applies to. 
\>=7.17.x