### PR TITLE
Devfiles can now have multiple names

### DIFF
--- a/src/main/pages/che-7/end-user-guide/con_a-minimal-devfile.adoc
+++ b/src/main/pages/che-7/end-user-guide/con_a-minimal-devfile.adoc
@@ -5,7 +5,7 @@
 [id="a-minimal-devfile_{context}"]
 = A minimal devfile
 
-The following is the minimum content required in a `devfile.yaml` file:
+The following is the minimum content required in a devfile:
 
 * link:https://redhat-developer.github.io/devfile/devfile#apiversion[apiVersion]
 * link:https://redhat-developer.github.io/devfile/devfile#metadata[metadata name]

--- a/src/main/pages/che-7/end-user-guide/con_what-is-a-devfile.adoc
+++ b/src/main/pages/che-7/end-user-guide/con_what-is-a-devfile.adoc
@@ -14,7 +14,7 @@ A devfile is a file that describes and define a development environment:
 * a list of pre-defined commands
 * projects to clone
 
-Devfiles are YAML files that {prod-short} consumes and transforms into a cloud workspace composed of multiple containers. The devfile can be saved in the root folder of a Git repository, a feature branch of a Git repository, a publicly accessible destination, or as a separate, locally stored artifact. Devfiles saved in Git repository, can use multiple names, such as `devfile.yaml` or `.devfile.yaml`.
+Devfiles are YAML files that {prod-short} consumes and transforms into a cloud workspace composed of multiple containers. The devfile can be saved in the root folder of a Git repository, a feature branch of a Git repository, a publicly accessible destination, or as a separate, locally stored artifact. Devfiles saved in Git repository can use multiple names, such as `devfile.yaml` or `.devfile.yaml`.
 
 When creating a workspace, {prod-short} uses that definition to initiate everything and run all the containers for the required tools and application runtimes. {prod-short} also mounts file-system volumes to make source code available to the workspace.
 

--- a/src/main/pages/che-7/end-user-guide/con_what-is-a-devfile.adoc
+++ b/src/main/pages/che-7/end-user-guide/con_what-is-a-devfile.adoc
@@ -14,7 +14,7 @@ A devfile is a file that describes and define a development environment:
 * a list of pre-defined commands
 * projects to clone
 
-Devfiles are YAML files that {prod-short} consumes and transforms into a cloud workspace composed of multiple containers. The devfile can be saved in the root folder of a Git repository, a feature branch of a Git repository, a publicly accessible destination, or as a separate, locally stored artifact.
+Devfiles are YAML files that {prod-short} consumes and transforms into a cloud workspace composed of multiple containers. The devfile can be saved in the root folder of a Git repository, a feature branch of a Git repository, a publicly accessible destination, or as a separate, locally stored artifact. Devfiles saved in Git repository, can use multiple names, such as `devfile.yaml` or `.devfile.yaml`.
 
 When creating a workspace, {prod-short} uses that definition to initiate everything and run all the containers for the required tools and application runtimes. {prod-short} also mounts file-system volumes to make source code available to the workspace.
 

--- a/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-from-a-feature-branch-of-a-git-repository.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-from-a-feature-branch-of-a-git-repository.adoc
@@ -9,7 +9,7 @@ A {prod-short} workspace can be created by pointing to devfile that is stored in
 
 .Prerequisites
 * A running instance of {prod}. To install an instance of {prod}, see link:{site-baseurl}che-7/che-quick-starts/[{prod-short} quick-starts].
-* The `devfile.yaml` or `.devfile.yaml` file in the root folder of a Git repository on a specific branch of the user's choice available over HTTPS. See link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile/[Making a workspace portable using a devfile] for detailed information about creating and using devfiles.
+* The `devfile.yaml` or `.devfile.yaml` file is located in the root folder of a Git repository, on a specific branch of the user's choice that is accessible over HTTPS. See link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile/[Making a workspace portable using a devfile] for detailed information about creating and using devfiles.
 
 .Procedure
 Execute the workspace by opening the following URL: `pass:c,a,q[{prod-url}/f?url=__<GitHubBranch>__]`

--- a/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-from-a-feature-branch-of-a-git-repository.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-from-a-feature-branch-of-a-git-repository.adoc
@@ -9,7 +9,7 @@ A {prod-short} workspace can be created by pointing to devfile that is stored in
 
 .Prerequisites
 * A running instance of {prod}. To install an instance of {prod}, see link:{site-baseurl}che-7/che-quick-starts/[{prod-short} quick-starts].
-* The `devfile.yaml` file in the root folder of a Git repository on a specific branch of the user's choice available over HTTPS. See link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile/[Making a workspace portable using a devfile] for detailed information about creating and using devfiles.
+* The `devfile.yaml` or `.devfile.yaml` file in the root folder of a Git repository on a specific branch of the user's choice available over HTTPS. See link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile/[Making a workspace portable using a devfile] for detailed information about creating and using devfiles.
 
 .Procedure
 Execute the workspace by opening the following URL: `pass:c,a,q[{prod-url}/f?url=__<GitHubBranch>__]`

--- a/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
@@ -9,7 +9,7 @@ A {prod-short} workspace can be created by pointing to a devfile that is stored 
 
 .Prerequisites
 * A running instance of {prod}. To install an instance of {prod}, see link:{site-baseurl}che-7/che-quick-starts/[{prod-short} quick-starts].
-* The `devfile.yaml` or `.devfile.yaml` file in the root folder of a Git repository available over HTTPS. See link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile/[Making a workspace portable using a devfile] for detailed information about creating and using devfiles.
+* The `devfile.yaml` or `.devfile.yaml` file is located in the root folder of a Git repository that is available over HTTPS. See link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile/[Making a workspace portable using a devfile] for detailed information about creating and using devfiles.
 
 .Procedure
 Run the workspace by opening the following URL: `pass:c,a,q[{prod-url}/f?url=https://__<GitRepository>__]`

--- a/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
@@ -9,7 +9,7 @@ A {prod-short} workspace can be created by pointing to a devfile that is stored 
 
 .Prerequisites
 * A running instance of {prod}. To install an instance of {prod}, see link:{site-baseurl}che-7/che-quick-starts/[{prod-short} quick-starts].
-* The `devfile.yaml` file in the root folder of a Git repository available over HTTPS. See link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile/[Making a workspace portable using a devfile] for detailed information about creating and using devfiles.
+* The `devfile.yaml` or `.devfile.yaml` file in the root folder of a Git repository available over HTTPS. See link:{site-baseurl}che-7/making-a-workspace-portable-using-a-devfile/[Making a workspace portable using a devfile] for detailed information about creating and using devfiles.
 
 .Procedure
 Run the workspace by opening the following URL: `pass:c,a,q[{prod-url}/f?url=https://__<GitRepository>__]`

--- a/src/main/pages/che-7/end-user-guide/proc_generating-workspace-names.adoc
+++ b/src/main/pages/che-7/end-user-guide/proc_generating-workspace-names.adoc
@@ -5,7 +5,7 @@
 [id="generating-workspace-names_{context}"]
 = Generating workspace names
 
-To specify a prefix for automatically generated workspace names, set the `generateName` parameter in the `devfile.yaml` file:
+To specify a prefix for automatically generated workspace names, set the `generateName` parameter in the devfile:
 
 [source,yaml]
 ----


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Since devfile can be named differenty in Git repos, need to mention this in docs.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14548

### Specify the version of the product this PR applies to. 
7.17