### PR TITLE
Clarify that certificates imported as Secrets should be ASCII rather than binary

### DIFF
--- a/src/main/pages/che-7/installation-guide/proc_deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc
+++ b/src/main/pages/che-7/installation-guide/proc_deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc
@@ -43,6 +43,7 @@ In the command, substitute `_<host:port>_` for the host and port of the HTTPS co
 ====
 * When `githost` is not specified, the given certificate is used for all HTTPS repositories.
 * The certificate file must be named `ca.crt`.
+* Certificate files are typically stored as Base64 ASCII files e.g. `.pem`, `.crt`, `.ca-bundle`, etc. They can also be encoded as binary data e.g. `.cer`.  All `Secrets` that hold certificate files should use the Base64 ASCII certificate rather than the binary data certificate. 
 ====
 
 . Configure the workspace exposure strategy:

--- a/src/main/pages/che-7/installation-guide/proc_deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc
+++ b/src/main/pages/che-7/installation-guide/proc_deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc
@@ -43,7 +43,7 @@ In the command, substitute `_<host:port>_` for the host and port of the HTTPS co
 ====
 * When `githost` is not specified, the given certificate is used for all HTTPS repositories.
 * The certificate file must be named `ca.crt`.
-* Certificate files are typically stored as Base64 ASCII files e.g. `.pem`, `.crt`, `.ca-bundle`, etc. They can also be encoded as binary data e.g. `.cer`.  All `Secrets` that hold certificate files should use the Base64 ASCII certificate rather than the binary data certificate. 
+* Certificate files are typically stored as Base64 ASCII files, such as. `.pem`, `.crt`, `.ca-bundle`. Also, they can be encoded as binary data, for example, `.cer`.  All `Secrets` that hold certificate files should use the Base64 ASCII certificate rather than the binary data certificate. 
 ====
 
 . Configure the workspace exposure strategy:


### PR DESCRIPTION
### What does this PR do?

Add a note requiring that certificate file secrets be base64 encoded ascii data

### What issues does this PR fix or reference?

eclipse/che#17250

### Specify the version of the product this PR applies to. 
