### PR TITLE
Correct instructions for importing self-signed cert in firefox

### DIFF
--- a/src/main/pages/che-7/installation-guide/proc_importing-self-signed-tls-certificates-to-browsers.adoc
+++ b/src/main/pages/che-7/installation-guide/proc_importing-self-signed-tls-certificates-to-browsers.adoc
@@ -79,6 +79,7 @@ endif::[]
 .. Click the btn:[>] button next to the *Connection not secure* warning.
 .. Click the btn:[More information] button.
 .. Click the btn:[View Certificate] button on the *Security* tab.
+.. Select the second certificate tab.  The certificate Common Name should start with *ingress-operator*
 .. Click the *PEM (cert)* link and save the certificate.
 . Navigate to link:about:preferences[about:preferences], search for `certificates`, and click *View Certificates*.
 . Go to the *Authorities* tab, click the btn:[Import] button, and open the saved certificate file.


### PR DESCRIPTION

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?

Clarify that on firefox you should select the ingress-operator CN cert for firefox import

### What issues does this PR fix or reference?

eclipse/che#17437

### Specify the version of the product this PR applies to. 
