### PR TITLE
Change docker image references to quay

### DIFF
--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -102,8 +102,8 @@ asciidoc_attributes: &asciidoc_attributes
   project-context: che
 
 # Images used in deployment
-  postgresql-image-url: docker.io/eclipse/che-postgres
-  identity-provider-image-url: docker.io/eclipse/che-keycloak
+  postgresql-image-url: quay.io/eclipse/che-postgres
+  identity-provider-image-url: quay.io/eclipse/che-keycloak
 
 asciidoc:
   require_front_matter_header: true

--- a/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
+++ b/src/main/pages/che-7/installation-guide/assembly_installing-che-in-restricted-environment.adoc
@@ -119,7 +119,7 @@ The images _essential_ for starting a workspace are infrastructure images that a
 .Images essential to starting workspaces
 [cols="2*"]
 |===
-| `docker.io/eclipse/che-server`
+| `quay.io/eclipse/che-server`
 | The main {prod-short} server image
 
 | `{postgresql-image-url}`
@@ -131,8 +131,8 @@ The images _essential_ for starting a workspace are infrastructure images that a
 | `quay.io/eclipse/che-jwtproxy`
 | JWT proxy image for enabling authentication between services. See link:{site-baseurl}che-7/che-workspaces-architecture/#che-workspace-jwt-proxy_che-workspace-components[{prod-short} workspace JWT proxy].
 
-| `docker.io/eclipse/che-unified-plugin-broker` +
-  `docker.io/eclipse/che-init-plugin-broker`
+| `quay.io/eclipse/che-plugin-artifacts-broker` +
+  `quay.io/eclipse/che-plugin-metadata-broker`
 | Images for adding plug-ins to workspaces. See link:{site-baseurl}che-7/che-workspaces-architecture/#che-plug-in-broker_che-workspace-components[{prod-short} plug-ins broker].
 
 | `quay.io/eclipse/che-plugin-registry` +

--- a/src/main/pages/che-7/overview/con_che-plug-in-broker.adoc
+++ b/src/main/pages/che-7/overview/con_che-plug-in-broker.adoc
@@ -23,6 +23,6 @@ A plug-ins broker is defined as a container image (for example, `eclipse/che-plu
 | link:https://github.com/eclipse/che-plugin-broker[{prod-short} Plug-in broker]
 
 | Container image
-| `eclipse/che-init-plugin-broker` +
-`eclipse/che-unified-plugin-broker`
+| `quay.io/eclipse/che-plugin-artifacts-broker` +
+`eclipse/che-plugin-metadata-broker`
 |===


### PR DESCRIPTION

Signed-off-by: Tom George <tgeorge@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?

Change https://www.eclipse.org/che/docs/che-7/installing-che-in-restricted-environment/#essential-images to reference quay.io images, as well as fixing references to the old init-plugin brokers.


### What issues does this PR fix or reference?

eclipse/che#17283

### Specify the version of the product this PR applies to. 
