### PR TITLE
Use repo URL attributes for flexibility

### DIFF
--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -60,7 +60,7 @@ asciidoc_attributes: &asciidoc_attributes
   image-puller-tag: latest
   image-puller: quay.io/eclipse/kubernetes-image-puller
 
-# URLs for the Downstream synergy
+# URLs
   link-installing-an-instance: link:{site-baseurl}che-7/che-quick-starts/[Che 'quick-starts']
   link-accessing-a-git-repository-via-https: link:{site-baseurl}che-7/version-control/#accessing-a-git-repository-via-https_version-control[Accessing a Git repository via HTTPS]
   link-adding-tls-certificates: link:{site-baseurl}che-7/installing-che-in-tls-mode-with-self-signed-certificates[Installing {prod-short} in TLS mode with self-signed certificates]
@@ -72,6 +72,13 @@ asciidoc_attributes: &asciidoc_attributes
   link-limits-for-user-workspaces: link:{site-baseurl}che-7/advanced-configuration-options-for-the-che-server-component/#users-workspace-limits[Limits for user workspaces]
   link-postgres-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/postgres
   link-server-identity-provider-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/keycloak
+  url-devfile-registry-repo: https://github.com/eclipse/che-devfile-registry
+  url-plug-in-registry-repo: https://github.com/eclipse/che-plugin-registry
+  # intentionally blank:
+  repo-path: ''
+
+# stack names
+  nodejs-stack: nodejs
 
   oc4-ver: 4.4
   ocp: OpenShift{nbsp}Container{nbsp}Platform

--- a/src/main/pages/che-7/administration-guide/proc_adding-a-devfile-at-runtime.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_adding-a-devfile-at-runtime.adoc
@@ -10,43 +10,48 @@ To add a devfile:
 
 . Check out the devfile registry sources.
 +
+[subs="attributes+"]
 ----
-$ git clone https://github.com/eclipse/che-devfile-registry; \
-  cd che-devfile-registry
+$ git clone {url-devfile-registry-repo}; \
+  cd {repo-path}che-devfile-registry
 ----
 
 . Create a `devfile.yaml` and `meta.yaml` in some local folder. This can be done from scratch or by copying from an existing devfile.
 +
+[subs="+attributes"]
 ----
 $ STACK="new-stack"; \
-  mkdir -p devfiles/${STACK}; cp devfiles/nodejs/* devfiles/${STACK}/
+  mkdir -p devfiles/${STACK}; cp devfiles/{nodejs-stack}/* devfiles/${STACK}/
 ----
 
-. If copying from an existing devfile, make changes to the devfile to suit your needs. Make sure your new devfile has a unique `displayName` and `description`.
+. If copying from an existing devfile, make changes to the devfile to suit your needs. Make sure the new devfile has a unique `displayName` and `description`.
 
 . Get the name of the Pod that hosts the devfile registry container. To do this, filter the `component=devfile-registry` label:
 +
+[subs="+attributes"]
 ----
-$ DEVFILE_REG_POD=$(kubectl get -o custom-columns=NAME:.metadata.name \
+$ DEVFILE_REG_POD=$({orch-cli} get -o custom-columns=NAME:.metadata.name \
   --no-headers pod -l component=devfile-registry)
 ----
 
-. Regenerate the registry's `index.json` file to include your new devfile.
+. Regenerate the registry's `index.json` file to include the new devfile.
 +
+[subs="+attributes"]
 ----
-$ cd che-devfile-registry; \
+$ cd {repo-path}che-devfile-registry; \
   "$(pwd)/build/scripts/check_mandatory_fields.sh" devfiles; \
   "$(pwd)/build/scripts/index.sh" > index.json
 ----
 
-. Copy the new `index.json`, `devfile.yaml` and `meta.yaml` files from your new local devfile folder to the container.
+. Copy the new `index.json`, `devfile.yaml` and `meta.yaml` files from the new local devfile folder to the container.
 +
+[subs="+attributes"]
 ----
-$ cd che-devfile-registry; \
+$ cd {repo-path}che-devfile-registry; \
   LOCAL_FILES="$(pwd)/${STACK}/meta.yaml $(pwd)/${STACK}/devfile.yaml $(pwd)/index.json"; \
-  kubectl exec ${DEVFILE_REG_POD} -i -t -- mkdir -p /var/www/html/devfiles/${STACK}; \
+  {orch-cli} exec ${DEVFILE_REG_POD} -i -t -- mkdir -p /var/www/html/devfiles/${STACK}; \
   for f in $LOCAL_FILES; do e=${f/$(pwd)\//}; echo "Upload ${f} -> /var/www/html/devfiles/${e}"
-    kubectl cp "${f}" ${DEVFILE_REG_POD}:/var/www/html/devfiles/${e}; done
+    {orch-cli} cp "${f}" ${DEVFILE_REG_POD}:/var/www/html/devfiles/${e}; done
 ----
 
-. The new devfile can now be used from the existing {prod-short} instance's devfile registry. To discover it, go to the {prod-short} dashboard, then click the `Workspaces` link. From there, click `Add Workspace` to see the updated list of available devfiles.
+. The new devfile can now be used from the existing {prod-short} instance of the devfile registry. To discover it, go to the {prod-short} dashboard, then click the *Workspaces* link. From there, click *Add Workspace* to see the updated list of available devfiles.

--- a/src/main/pages/che-7/administration-guide/proc_adding-a-plug-in-at-runtime.adoc
+++ b/src/main/pages/che-7/administration-guide/proc_adding-a-plug-in-at-runtime.adoc
@@ -10,9 +10,10 @@ To add a plug-in:
 
 . Check out the plugin registry sources.
 +
+[subs="+attributes"]
 ----
-$ git clone https://github.com/eclipse/che-plugin-registry; \
-  cd che-plugin-registry
+$ git clone {url-plug-in-registry-repo}; \
+  cd {repo-path}che-plugin-registry
 ----
 
 . Create a `meta.yaml` in some local folder. This can be done from scratch or by copying from an existing plug-in's `meta.yaml` file.
@@ -23,7 +24,7 @@ $ PLUGIN="v3/plugins/new-org/new-plugin/0.0.1"; \
   echo "${PLUGIN##*/}" > ${PLUGIN}/../latest.txt
 ----
 
-. If copying from an existing plug-in, make changes to the `meta.yaml` file to suit your needs. Make sure your new plug-in has a unique `title`, `displayName` and `description`. Update the `firstPublicationDate` to today's date.
+. If copying from an existing plug-in, make changes to the `meta.yaml` file to suit your needs. Make sure the new plug-in has a unique `title`, `displayName` and `description`. Update the `firstPublicationDate` to today's date.
 
 . These fields in `meta.yaml` must match the path defined in `PLUGIN` above.
 +
@@ -35,15 +36,17 @@ version: 0.0.1
 
 . Get the name of the Pod that hosts the plug-in registry container. To do this, filter the `component=plugin-registry` label:
 +
+[subs="+attributes"]
 ----
-$ PLUGIN_REG_POD=$(kubectl get -o custom-columns=NAME:.metadata.name \
+$ PLUGIN_REG_POD=$({orch-cli} get -o custom-columns=NAME:.metadata.name \
   --no-headers pod -l component=plugin-registry)
 ----
 
-. Regenerate the registry's `index.json` file to include your new plug-in.
+. Regenerate the registry's `index.json` file to include the new plug-in.
 +
+[subs="+attributes"]
 ----
-$ cd che-plugin-registry; \
+$ cd {repo-path}che-plugin-registry; \
     "$(pwd)/build/scripts/generate_latest_metas.sh" v3 && \
     "$(pwd)/build/scripts/check_plugins_location.sh" v3 && \
     "$(pwd)/build/scripts/set_plugin_dates.sh" v3 && \
@@ -51,14 +54,15 @@ $ cd che-plugin-registry; \
     "$(pwd)/build/scripts/index.sh" v3 > v3/plugins/index.json
 ----
 
-. Copy the new `index.json` and `meta.yaml` files from your new local plug-in folder to the container.
+. Copy the new `index.json` and `meta.yaml` files from the new local plug-in folder to the container.
 +
+[subs="+attributes"]
 ----
-$ cd che-plugin-registry; \
+$ cd {repo-path}che-plugin-registry; \
   LOCAL_FILES="$(pwd)/${PLUGIN}/meta.yaml $(pwd)/v3/plugins/index.json"; \
-  kubectl exec ${PLUGIN_REG_POD} -i -t -- mkdir -p /var/www/html/${PLUGIN}; \
+  {orch-cli} exec ${PLUGIN_REG_POD} -i -t -- mkdir -p /var/www/html/${PLUGIN}; \
   for f in $LOCAL_FILES; do e=${f/$(pwd)\//}; echo "Upload ${f} -> /var/www/html/${e}"; \
-    kubectl cp "${f}" ${PLUGIN_REG_POD}:/var/www/html/${e}; done
+    {orch-cli} cp "${f}" ${PLUGIN_REG_POD}:/var/www/html/${e}; done
 ----
 
-. The new plug-in can now be used from the existing {prod-short} instance's plug-in registry. To discover it, go to the {prod-short} dashboard, then click the `Workspaces` link. From there, click the gear icon to configure one of your workspaces. Select the `Plugins` tab to see the updated list of available plug-ins.
+. The new plug-in can now be used from the existing {prod-short} instance of the plug-in registry. To discover it, go to the {prod-short} dashboard, then click the *Workspaces* link. From there, click the gear icon to configure one of your workspaces. Select the *Plugins* tab to see the updated list of available plug-ins.


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?

Switches to using attributes for plug-in and devfile registry repos.

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/RHDEVDOCS-1538

### Specify the version of the product this PR applies to. 

Che 7.x