### PR TITLE
Fix docs release tagging script

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -98,6 +98,10 @@ if [[ $TRIGGER_RELEASE -eq 1 ]]; then
 
   # or, just tag the release... which any fool can do, apparently
   git checkout "${BRANCH}"
+  
+  echo $VERSION > VERSION
+  git commit -sm "Release version ${VERSION}" VERSION
+
   git tag "${VERSION}"
   git push origin "${VERSION}"
 fi


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Add fix for release script to correctly create release tags.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17596

### Specify the version of the product this PR applies to. 
7.17.2