### PR TITLE
Add assembly for importing self-signed certs to allow direct link

### DIFF
--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -44,6 +44,9 @@ entries:
     - title: Accessing Che from OpenShift Developer Perspective
       url: che-7/accessing-che-from-openshift-developer-perspective
       output: web
+    - title: Importing self-signed certificates to browsers
+      url: che-7/importing-certificates-to-browsers
+      output: web
   - title: Hosted Che
     url: che-7/hosted-che
     output: web

--- a/src/main/pages/che-7/overview/assembly_importing-self-signed-certificates-to-browsers.adoc
+++ b/src/main/pages/che-7/overview/assembly_importing-self-signed-certificates-to-browsers.adoc
@@ -1,0 +1,19 @@
+---
+title: Importing self-signed certificates to browsers
+keywords:
+tags: []
+sidebar: che_7_docs
+permalink: che-7/importing-certificates-to-browsers/
+folder: che-7/overview
+summary:
+---
+:page-liquid:
+:parent-context-of-importing-self-signed-certificates-to-browsers: {context}
+
+[id="importing-self-signed-certificates-to-browsers_{context}"]
+
+= Importing self-signed certificates to browsers
+include::proc_importing-self-signed-tls-certificates-to-browsers.adoc[leveloffset=+1]
+
+:context: {parent-context-of-importing-self-signed-certificates-to-browsers}
+


### PR DESCRIPTION
### What does this PR do?
Create an assembly in quick starts to contain process for importing self-signed certs. This allows it to be linked directly from the Che server when there is a certificate error

### What issues does this PR fix or reference?
Related to https://github.com/eclipse/che/issues/17712

Part of fixing bug introduced by https://github.com/eclipse/che-docs/pull/1451

### Specify the version of the product this PR applies to. 
7.16.x