### PR TITLE
Remove logs from troublesh.

### DIFF
--- a/src/main/_data/sidebars/che_7_docs.yml
+++ b/src/main/_data/sidebars/che_7_docs.yml
@@ -173,9 +173,6 @@ entries:
       - title: Overview
         url: che-7/troubleshooting-che
         output: web
-      - title: Viewing workspace logs
-        url: che-7/viewing-che-workspaces-logs
-        output: web
       - title: Troubleshooting slow workspaces
         url: che-7/troubleshooting-slow-workspaces
         output: web

--- a/src/main/pages/che-7/end-user-guide/assembly_troubleshooting-che.adoc
+++ b/src/main/pages/che-7/end-user-guide/assembly_troubleshooting-che.adoc
@@ -18,10 +18,15 @@ summary:
 
 This section provides troubleshooting procedures for most frequent issues an user can came in conflict with.
 
-* link:{site-baseurl}che-7/viewing-che-workspaces-logs[Viewing workspace logs]
 * link:{site-baseurl}che-7/troubleshooting-slow-workspaces[Troubleshooting slow workspaces]
 * link:{site-baseurl}che-7/troubleshooting-network-problems[Troubleshooting network problems]
 * link:{site-baseurl}che-7/starting-a-che-workspace-in-debug-mode[Starting a workspace in debug mode]
 * link:{site-baseurl}che-7/restarting-a-che-workspace-in-debug-mode-after-start-failure[Restarting a workspace in debug mode after start failure]
+
+
+[discrete]
+== Additional resources
+
+* link:{site-baseurl}che-7/viewing-che-workspaces-logs[Viewing workspace logs]
 
 :context: {parent-context-of-troubleshooting-che}


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?

Removes **Viewing Che logs** from the End-user Guide (it still remains in the Admin Guide).  It caused downstreaming trouble, which we'll need to debug later.

I at least left a link to the topic in the **Troubleshooting** overview page in the EUG.

Cc @amisevsk 
