### PR TITLE
Replacing attribute for xrefs, fix in attribute

### DIFF
--- a/modules/administration-guide/partials/assembly_calculating-che-resource-requirements.adoc
+++ b/modules/administration-guide/partials/assembly_calculating-che-resource-requirements.adoc
@@ -1,5 +1,4 @@
 
-
 :parent-context-of-calculating-che-resource-requirements: {context}
 
 [id="calculating-{prod-id-short}-resource-requirements_{context}"]
@@ -22,6 +21,7 @@ include::partial$con_a-workspace-example.adoc[leveloffset=+1]
 * xref:high-level-che-architecture.adoc[]
 * link:https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/[Kubernetes compute resources management documentation]
 * xref:installation-guide:configuring-the-che-installation.adoc[]
+* xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc[]
 * xref:end-user-guide:making-a-workspace-portable-using-a-devfile.adoc[]
 * xref:end-user-guide:making-a-workspace-portable-using-a-devfile.adoc#a-minimal-devfile_{context}[]
 * xref:authenticating-users.adoc[]

--- a/modules/administration-guide/partials/con_che-server.adoc
+++ b/modules/administration-guide/partials/con_che-server.adoc
@@ -17,5 +17,5 @@ The {prod-short} server, also known as *wsmaster*, is the central service of the
 | `eclipse/che-server`
 
 | Environment variables
-| {link-advanced-configuration-options-for-the-che-server}
+| xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc[]
 |===

--- a/modules/administration-guide/partials/con_controller-requirements.adoc
+++ b/modules/administration-guide/partials/con_controller-requirements.adoc
@@ -39,4 +39,4 @@ The Workspace Controller consists of a set of five services running in five dist
 |16 MiB
 |===
 
-These default values are sufficient when the {prod-short} Workspace Controller manages a small amount of {prod-short} workspaces. For larger deployments, increase the memory limit. See the xref:installation-guide:configuring-the-che-installation.adoc[Advanced configurations options] article for instructions on how to override the default requests and limits. For example, the hosted version of {prod-short} that runs on link:https://che.openshift.io[] uses 1 GB of memory.
+These default values are sufficient when the {prod-short} Workspace Controller manages a small amount of {prod-short} workspaces. For larger deployments, increase the memory limit. See the xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc[] article for instructions on how to override the default requests and limits. For example, the hosted version of {prod-short} that runs on link:https://che.openshift.io[] uses 1 GB of memory.

--- a/modules/administration-guide/partials/proc_enabling-metrics-collection.adoc
+++ b/modules/administration-guide/partials/proc_enabling-metrics-collection.adoc
@@ -62,5 +62,5 @@ The requested value is included in the service name that contains the `collector
 
 
 .Additional resources
-* For additional information about custom environment properties and how to define them in CheCluster Custom Resource, see xref:installation-guide:configuring-the-che-installation.adoc[].
+* For additional information about custom environment properties and how to define them in CheCluster Custom Resource, see xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc[].
 *  For custom configuration of Jaeger, see the list of link:https://github.com/jaegertracing/jaeger-client-go#user-content-environment-variables[Jaeger client environment variables].


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>



As the author of this Pull Request, I made sure that:

- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
