### PR TITLE
Add the devfile documentation

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -12,6 +12,10 @@ content:
     - url: ./
       branches: HEAD
       edit_url: 'https://github.com/eclipse/che-docs/edit/master/{path}'
+    - url: https://github.com/devfile/docs.git
+      branches: master
+      start_path: docs
+      edit_url: 'https://github.com/devfile/docs/edit/master/{path}'
 output: 
   destinations:
     - provider: fs


### PR DESCRIPTION
This PR is a demonstration on how we could embed the devfile documentation into che-docs website.

How to  switch from one documentation to the other:

![Screenshot from 2020-09-03 13-53-18](https://user-images.githubusercontent.com/243761/92111666-eea3d300-edec-11ea-82fc-69ac1fb6e7fb.png)

The devfile docs inside the Antora generated docs website:

![Screenshot from 2020-09-03 13-53-34](https://user-images.githubusercontent.com/243761/92111673-f1062d00-edec-11ea-8b19-284735e995a1.png)

I am not sure at all this is something we want. What do you think of it @sunix @l0rd @rkratky?