### PR TITLE
Fixing GCP installation procedure

### DIFF
--- a/modules/installation-guide/partials/proc_installing-cert-manager-on-kubernetes.adoc
+++ b/modules/installation-guide/partials/proc_installing-cert-manager-on-kubernetes.adoc
@@ -11,9 +11,6 @@
 . To install cert-manager:
 +
 ----
-$ kubectl create namespace cert-manager
-namespace/cert-manager created
-
 $ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
 
 $ kubectl apply \
@@ -25,8 +22,8 @@ $ kubectl apply \
 +
 [subs="+quotes,+attributes"]
 ----
-$ kubectl create namespace __<{prod-namespace}>__
-namespace/__<{prod-namespace}>__ created
+$ kubectl create namespace __{prod-namespace}__
+namespace/__{prod-namespace}__ created
 ----
 
 . Create the certificate issuer. Replace your email address in the `email` field:


### PR DESCRIPTION
- Removing `cert-manager` namespace creation (already created few lines above)
- Fixing `che` namespace creation command.

Signed-off-by: sutan-1 <sutan@redhat.com>