### PR TITLE
che #17404 Updating Hosted Che terms of service. Adding info about maximum time for a running workspace

### DIFF
--- a/modules/hosted-che/partials/ref_about-hosted-che.adoc
+++ b/modules/hosted-che/partials/ref_about-hosted-che.adoc
@@ -20,6 +20,10 @@ Hosted Che has the following usage limits and terms of service:
 * Number of workspaces: Unlimited
 * Number of projects per workspace: Unlimited
 * Usage time limit: None
+* Maximum time for a running workspace: 8 hours
++
+NOTE: Hosted Che automatically stops workspaces that run more than 8 hours regardless of activity.
+
 * Maximum account inactivity period: 30 days
 +
 NOTE: Hosted Che automatically deactivates accounts that have been inactive for more than 30 days. All existing workspaces in a deactivated account are lost. To start using Hosted Che again, a user must re-register.


### PR DESCRIPTION
### What does this PR do?
Updating Hosted Che terms of service. Adding info about the maximum time for a running workspace

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17404

### Specify the version of the product this PR applies to.
latest

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
