### PR TITLE
Provide more specific information for certificate handling

### DIFF
--- a/modules/end-user-guide/partials/proc_importing-certificates-to-browsers.adoc
+++ b/modules/end-user-guide/partials/proc_importing-certificates-to-browsers.adoc
@@ -21,7 +21,7 @@ When a TLS certificate is not trusted, the error message *Authorization token is
 . Save the certificate:
 .. Click the warning or open lock icon on the left of the address bar.
 .. Click *Certificates* and navigate to the *Details* tab.
-.. Select the top-level certificate which is the Root certificate authority and export it :
+.. Select the top-level certificate which is the Root certificate authority and export it:
 +
 * On Linux, click the btn:[Export] button.
 * On Windows, click the btn:[Save to file] button.

--- a/modules/end-user-guide/partials/proc_importing-certificates-to-browsers.adoc
+++ b/modules/end-user-guide/partials/proc_importing-certificates-to-browsers.adoc
@@ -19,9 +19,9 @@ When a TLS certificate is not trusted, the error message *Authorization token is
 
 . Navigate to URL where {prod-short} is deployed.
 . Save the certificate:
-.. Click the lock icon on the left of the address bar.
+.. Click the warning or open lock icon on the left of the address bar.
 .. Click *Certificates* and navigate to the *Details* tab.
-.. Select the certificate to use and export it:
+.. Select the top-level certificate which is the Root certificate authority and export it :
 +
 * On Linux, click the btn:[Export] button.
 * On Windows, click the btn:[Save to file] button.


### PR DESCRIPTION
- depending on Chrome version/OS (and if the certificate has been
already provided), it can be an open lock icon or a warning icon
- there are 2 certificates available. it is the root one that needs to
be exported, then imported

### What does this PR do?

it provides more specific information to add a ceertificate

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.

master and also 7.18 ans surely some previous one too

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
