### PR TITLE
Fix wording/readability in adding plugins to workspace

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -39,7 +39,7 @@ asciidoc:
     link-cli-github: https://github.com/che-incubator/chectl
     link-identity-provider-documentation-openshift-3: https://www.keycloak.org/docs/latest/server_admin/#openshift-3
     link-identity-provider-documentation-openshift-4: https://www.keycloak.org/docs/latest/server_admin/#openshift-4
-    link-installing-an-instance: xref:overview:che-quick-starts.adoc[]
+    link-installing-an-instance: xref:installation-guide:installing-che.adoc[]
     
     link-postgres-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/postgres
     link-server-identity-provider-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/keycloak

--- a/modules/end-user-guide/partials/assembly_adding-tools-to-che-after-creating-a-workspace.adoc
+++ b/modules/end-user-guide/partials/assembly_adding-tools-to-che-after-creating-a-workspace.adoc
@@ -5,19 +5,21 @@
 
 :context: adding-tools-to-{prod-id-short}-after-creating-a-workspace
 
-When installed in the workspace, {prod-short} plug-ins bring new capabilities to the {prod-short}. Plug-ins consist of a Che-Theia plug-in, metadata, and a hosting container. These plug-ins may provide the following capabilities:
+When installed in a workspace, {prod-short} plug-ins bring new capabilities to {prod-short}. Plug-ins consist of a Che-Theia plug-in, metadata, and a hosting container. These plug-ins may provide the following capabilities:
 
-* Integrating with other systems, including OpenShift
+* Integrating with other systems, including 
 ifeval::["{project-context}" == "che"]
-and Kubernetes
+OpenShift and Kubernetes.
 endif::[]
-.
+ifeval::["{project-context}" != "che"]
+OpenShift.
+endif::[]
 
 * Automating some developer tasks, such as formatting, refactoring, and running automated tests.
 * Communicating with multiple databases directly from the IDE.
 * Enhanced code navigation, auto-completion and error highlighting.
 
-This chapter provides basic information about {prod-short} plug-ins installation, enabling, and use in {prod-short} workspaces.
+This chapter provides basic information about installing, enabling, and using {prod-short} plug-ins in workspaces.
 
 * xref:additional-tools-in-the-{prod-id-short}-workspace_{context}[]
 * xref:adding-language-support-plug-in-to-the-{prod-id-short}-workspace_{context}[]

--- a/modules/end-user-guide/partials/con_additional-tools-in-the-che-workspace.adoc
+++ b/modules/end-user-guide/partials/con_additional-tools-in-the-che-workspace.adoc
@@ -5,23 +5,14 @@
 [id="additional-tools-in-the-{prod-id-short}-workspace_{context}"]
 = Additional tools in the {prod-short} workspace
 
-{prod-short} plug-ins are extensions to the Che-Theia IDE that come bundled with a container image that contains their native prerequisites (for example, the OpenShift Connector plug-in needs the `oc` command installed). A {prod-short} plug-in is a list of Che-Theia plug-ins together with a Linux container that the plug-in requires to run in. It can also include metadata to define the description, categorization tags, and an icon.
+{prod-short} plug-ins are extensions to the Che-Theia IDE that come bundled with a container image that contains their native prerequisites (for example, the OpenShift Connector plug-in needs the `oc` command installed). Plug-ins can also include metadata to define a description, categorization tags, and an icon.
 {prod-short} provides a registry of plug-ins available for installation into the user's workspace.
 
-Because many VS Code extensions can run inside the Che-Theia IDE, they can be packaged as {prod-short} plug-ins by combining them with a runtime or a sidecar container. Users can choose from many more plug-ins that are provided out of the box.
+The Che-Theia IDE is generally compatible with the VS Code extensions API. This means that many VS Code extensions are automatically compatible with Che-Theia, and can be packaged as {prod-short} plug-ins by combining them container that contains their dependencies. By default, {prod-short} includes a plug-in registry containing common plug-ins.
 
-From the Dashboard, plug-ins in the registry can be added from the *Plugin* tab or by adding them into a devfile. The devfile can also be used for further configuration of the plug-in, such as to define memory or CPU usage.
-Alternatively, plug-ins can be installed from {prod-short} by pressing kbd:[Ctrl+Shift+J] or by navigating to *View -> Plugins*.
+From the Dashboard, plug-ins in the registry can be added from the *Plugin* tab in the *Workspace details* page, or by adding them directly into a devfile. The devfile can also be used for further configuration of the plug-in, such defining memory or CPU usage.
+Alternatively, plug-ins can also be installed from within the Che-Theia IDE by pressing kbd:[Ctrl+Shift+J] or by navigating to *View -> Plugins*.
 
 .Additional resources
 
 * xref:making-a-workspace-portable-using-a-devfile.adoc#adding-components-to-a-devfile_{context}[]
-
-////
-.Additional resources
-
-* A bulleted list of links to other material closely related to the contents of the concept module.
-* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
-* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-////

--- a/modules/end-user-guide/partials/proc_adding-language-support-plug-in-to-the-che-workspace.adoc
+++ b/modules/end-user-guide/partials/proc_adding-language-support-plug-in-to-the-che-workspace.adoc
@@ -3,9 +3,9 @@
 // adding-tools-to-{prod-id-short}-after-creating-a-workspace
 
 [id="adding-language-support-plug-in-to-the-{prod-id-short}-workspace_{context}"]
-= Adding language support plug-in to the {prod-short} workspace
+= Adding a language support plug-in to a {prod-short} workspace
 
-This procedure describes adding a tool to an already existing workspace, by enabling a dedicated plug-in from the Dashboard.
+This procedure describes adding a tool to an existing workspace by enabling a dedicated plug-in from the Dashboard.
 
 To add tools that are available as plug-ins into a {prod-short} workspace, use one of the following methods:
 
@@ -22,49 +22,44 @@ This procedure uses the *Java language support* plug-in as an example.
 ** xref:creating-and-configuring-a-new-workspace.adoc[]
 ** xref:creating-a-workspace-from-code-sample.adoc#creating-a-workspace-from-custom-workspace-view-of-user-dashboard_{context}[]
 
- * The workspace must be in a `stopped` state. To do so:
+ * The workspace must be in a **stopped** state. To stop a workspace,
 
 .. Navigate to the {prod-short} Dashboard. See xref:navigating-che-using-the-dashboard.adoc[].
 
 .. In the *Dashboard*, click the *Workspaces* menu to open the workspaces list and locate the workspace.
 
-.. On the same row with the displayed workspace, on the right side of the screen, click the btn:[Stop] button to stop the workspace.
+.. On the same row with the displayed workspace, on the right side of the screen, click the square btn:[Stop] button to stop the workspace.
 
-.. Wait a few seconds for the workspace to stop, then configure the workspace by clicking on it.
+.. Wait a few seconds for the workspace to stop (the workspace's icon on the list will turn grey), then configure the workspace by clicking on it.
 
 .Procedure
 
-To add the plug-in from the Plug-in registry to an already existing {prod-short} workspace, use one of the following methods:
+To add the plug-in from the Plug-in registry to an existing {prod-short} workspace, use one of the following methods:
 
 [id="installing-the-plug-in-from-the-plugin-tab_{context}"]
 
 //<<installing-the-plug-in-from-the-plugin-tab_{context}>>
 
 ** Installing the plug-in from the *Plugin* tab.
-. Navigate to the *Plugin* tab.
-+
-The list of plug-ins, installed or possible to install, is displayed.
-. Enable the desired plug-in, for example, the Language Support for Java 11, by using the *Enable* slide-toggle.
-+
-The plug-in source code is added to the workspace devfile, and the plug-in is now enabled.
-. On the bottom right side of the screen, save the changes by clicking the btn:[Save] button.
-+ Once the changes are saved, the workspace is restarted.
+. Navigate to the *Plugin* tab. The list of available plug-ins is displayed.
+. Enable the desired plug-in, for example, the Language Support for Java 11, by using the *Enable* slide-toggle. This will add the plug-in's ID to the workspace's devfile, enabling the plug-in.
+. On the bottom right side of the screen, save the changes by clicking the btn:[Save] button. After changes are saved, the workspace can be restarted and will include the new plug-in.
 
 [id="installing-the-plug-in-by-adding-content-to-the-devfile_{context}"]
 
 //<<installing-the-plug-in-by-adding-content-to-the-devfile_{context}>>
 
 ** Installing the plug-in by adding content to the devfile.
-. Navigate to the *Devfile* tab.
-+
-The devfile structure is displayed.
-. Locate the `component` section of the devfile and add the following lines to add the Java language v8 in to the workspace:
+. Navigate to the *Devfile* tab. The devfile YAML is displayed.
+. Locate the `components` section of the devfile and add the following lines to add the Java language plugin with Java 8 to the workspace:
 +
 include::example${project-context}-java-language-support.adoc[]
 +
-See the example of the final result:
+An example of the final result:
 +
 include::example${project-context}-workspace-from-the-php-stack-java-language-support.adoc[]
+. On the bottom right side of the screen, save the changes by clicking the btn:[Save] button. After changes are saved, the workspace can be restarted and will include the new plug-in.
+
 
 .Additional resources
 


### PR DESCRIPTION
### What does this PR do?
Fixes minor issues in the `Adding tools to Che after creating a workspace` section.

### What issues does this PR fix or reference?
[RHDEVDOCS-2166](https://issues.redhat.com/browse/RHDEVDOCS-2166)

### Specify the version of the product this PR applies to.
7.19.0

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successufully against the PR branch
  - No errors, `vale` warns that the grade level is too high.
- [x] Link checker has been run successfully against the PR branch
  - Link checker reports what I assume are spurious errors:
    ```
    URL        `../fonts/fontawesome-webfont.woff?v=4.7.0'
    Parent URL http://0.0.0.0:4000/_/font-awesome-4.7.0/css/font-awesome.min.css, line 1, col 246
    Real URL   http://0.0.0.0:4000/_/font-awesome-4.7.0/fonts/fontawesome-webfont.woff?v=4.7.0
    Result     Error: 404 Not Found

    URL        `_attachments/api-reference.html'
    Parent URL http://0.0.0.0:4000/devfile/assembly_making-a-workspace-portable-using-a-devfile/, line 55, col 5
    Real URL   http://0.0.0.0:4000/devfile/assembly_making-a-workspace-portable-using-a-devfile/_attachments/api-reference.html
    Result     Error: 404 Not Found

    URL        `_attachments/api-reference.html'
    Parent URL http://0.0.0.0:4000/devfile/migration_guide/, line 56, col 5
    Real URL   http://0.0.0.0:4000/devfile/migration_guide/_attachments/api-reference.html
    Result     Error: 404 Not Found

    URL        `https://devfile.github.io/website/'
    Parent URL http://0.0.0.0:4000/devfile/assembly_making-a-workspace-portable-using-a-devfile/, line 1897, col 4
    Real URL   https://devfile.github.io/website/
    Result     Error: 404 Not Found
    ```
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

