### PR TITLE
Fix hosted che factory link in contributing guide

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -34,7 +34,7 @@ https://www.eclipse.org/che/docs/che-7/hosted-che/[Hosted Che documentation].
 
 .Procedure
 
-. Open a che-docs workspace running on Hosted Che: `++https++://che.openshift.io/factory?url=https://github.com/__<github-handle>__/che-docs/__<branch-name>__/tree/`
+. Open a che-docs workspace running on Hosted Che: `++https++://che.openshift.io/factory?url=https://github.com/__<github-handle>__/che-docs/tree/__<branch-name>__/`
 
 . Create a branch `__<branch-name>__` for your work.
 


### PR DESCRIPTION
### What does this PR do?
Factory URL should be `.../tree/_branch_` instead of `.../_branch_/tree`
