### PR TITLE
Add `mergePlugins` to attributes in devfile reference and fix minor issues in doc

### DIFF
--- a/modules/end-user-guide/partials/proc_configuring-the-workspace-and-adding-tooling.adoc
+++ b/modules/end-user-guide/partials/proc_configuring-the-workspace-and-adding-tooling.adoc
@@ -55,20 +55,20 @@ To add a new container image:
 ----
 components:
   - mountSources: true
-     command:
-       - sleep
-     args:
-       - infinity
-     memoryLimit: 1Gi
-     alias: maven3-jdk11
-     type: dockerimage
-     endpoints:
-       - name: 8080/tcp
-         port: 8080
-     volumes:
-       - name: projects
-         containerPath: /projects
-     image: 'maven:3.6.0-jdk-11'
+    command:
+      - sleep
+    args:
+      - infinity
+    memoryLimit: 1Gi
+    alias: maven3-jdk11
+    type: dockerimage
+    endpoints:
+      - name: 8080/tcp
+        port: 8080
+    volumes:
+      - name: projects
+        containerPath: /projects
+    image: 'maven:3.6.0-jdk-11'
 ----
 ifeval::["{project-context}" == "che"]
 +

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -1006,3 +1006,23 @@ projects:
 attributes:
   persistVolumes: false
 ----
+
+=== Attribute: asyncPersist (asynchronous storage)
+
+When `persistVolumes` is set to `false` (see above), the additional attribute `asyncPersist` can be set to `true` to enable asynchronous storage. See xref:installation-guide:configuring-storage-types.adoc[] for more details.
+
+.Example of a devfile with asynchronous storage enabled
+[source,yaml]
+----
+apiVersion: 1.0.0
+metadata:
+  name: petclinic-dev-environment
+projects:
+  - name: petclinic
+    source:
+      type: git
+      location: 'https://github.com/che-samples/web-java-spring-petclinic.git'
+attributes:
+  persistVolumes: false
+  asyncPersist: true
+----

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -1026,3 +1026,22 @@ attributes:
   persistVolumes: false
   asyncPersist: true
 ----
+
+=== Attribute: mergePlugins
+
+This property can be set to manually control how plugins are included in the workspace. When the property `mergePlugins` is set to `true`, Che will attempt to avoid running multiple instances of the same container by combining plugins. The default value when this property is not included in a devfile is governed by the Che configuration property `che.workspace.plugin_broker.default_merge_plugins`; adding the `mergePlugins: false` attribute to a devfile will disable plugin merging for that workspace.
+
+.Example of a devfile with plugin merging disabled
+[source,yaml]
+----
+apiVersion: 1.0.0
+metadata:
+  name: petclinic-dev-environment
+projects:
+  - name: petclinic
+    source:
+      type: git
+      location: 'https://github.com/che-samples/web-java-spring-petclinic.git'
+attributes:
+  mergePlugins: false
+----

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -818,7 +818,7 @@ components:
       app: postgres
 ----
 
-Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers present in the resource list. For details of the advanced use case, see the reference (TODO: link).
+Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers present in the resource list. For details of the advanced use case, see xref:end-user-guide:configuring-the-workspace-and-adding-tooling#defining specific-container-images[].
 
 == Adding commands to a devfile
 


### PR DESCRIPTION
### What does this PR do?
Adds documentation for https://github.com/eclipse/che/pull/17785 to explain new devfile attribute. Also fixes minor issues in the doc:
- Add asyncPersist to devfile reference, as it was previously missing.
- Fix a vale error on `TODO` in the doc
- Fix indentation on a yaml code block.

### What issues does this PR fix or reference?
Required for eclipse/che#15373

### Specify the version of the product this PR applies to.
7.19.x

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successufully against the PR branch
  - Vale lists 12 errors on the devfile reference, but they're all spurious (using "zip" in a code sample is an error, but it's the devfile spec not prose).
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
  - ???
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

**Note:** I wasn't able to check `xref` links fully as I ran into issues starting a workspace from the devfile on Hosted Che.