### PR TITLE
fix(doc) replace wsmaster by {prod-short} server

### DIFF
--- a/modules/administration-guide/partials/con_che-plug-in-registry.adoc
+++ b/modules/administration-guide/partials/con_che-plug-in-registry.adoc
@@ -5,7 +5,7 @@
 [id="{prod-id-short}-plug-in-registry_{context}"]
 = {prod-short} plug-in registry
 
-The {prod-short} plug-in registry is a service that provides the list of plug-ins and editors for the {prod-short} workspaces. A devfile only references a plug-in that is published in a {prod-short} plug-in registry. It runs in a container and can be deployed wherever wsmaster connects.
+The {prod-short} plug-in registry is a service that provides the list of plug-ins and editors for the {prod-short} workspaces. A devfile only references a plug-in that is published in a {prod-short} plug-in registry. It runs in a container and can be deployed wherever {prod-short} server connects.
 
 For more information about plug-in registry customization, see xref:building-and-running-a-custom-registry-image.adoc[].
 

--- a/modules/administration-guide/partials/con_che-server.adoc
+++ b/modules/administration-guide/partials/con_che-server.adoc
@@ -6,7 +6,7 @@
 [id="{prod-id-short}-server_{context}"]
 = {prod-short} server
 
-The {prod-short} server, also known as *wsmaster*, is the central service of the workspaces controller. It is a Java web service that exposes an HTTP REST API to manage {prod-short} workspaces and, in multi-user mode, {prod-short} users.
+The {prod-short} server is the central service of the workspaces controller. It is a Java web service that exposes an HTTP REST API to manage {prod-short} workspaces and, in multi-user mode, {prod-short} users.
 
 [cols=2*]
 |===

--- a/modules/administration-guide/partials/con_che-workspace-creation-flow.adoc
+++ b/modules/administration-guide/partials/con_che-workspace-creation-flow.adoc
@@ -15,12 +15,12 @@ The following is a {prod-short} workspace creation flow:
 * A list of plug-ins (for example, Java and Kubernetes tools)
 * A list of runtime applications
 
-. *wsmaster* retrieves the editor and plug-in metadata from the plug-in registry.
-. For every plug-in type, *wsmaster* starts a specific plug-in broker.
+. {prod-short} server retrieves the editor and plug-in metadata from the plug-in registry.
+. For every plug-in type, {prod-short} server starts a specific plug-in broker.
 . The {prod-short} plug-ins broker transforms the plug-in metadata into a Che Plugin definition. It executes the following steps:
 +
 .. Downloads a plug-in and extracts its content.
-.. Processes the plug-in `meta.yaml` file and sends it back to *wsmaster* in the format of a Che Plugin.
+.. Processes the plug-in `meta.yaml` file and sends it back to {prod-short} server in the format of a Che Plugin.
 
-. *wsmaster* starts the editor and the plug-in sidecars.
+. {prod-short} server starts the editor and the plug-in sidecars.
 . The editor loads the plug-ins from the plug-in persistent volume.

--- a/modules/end-user-guide/partials/con_che-theia-plug-in-lifecycle.adoc
+++ b/modules/end-user-guide/partials/con_che-theia-plug-in-lifecycle.adoc
@@ -7,7 +7,7 @@
 
 When a user is starting a workspace, the following procedure is followed:
 
-. {prod-short} master checks for plug-ins to start from the workspace definition.
+. {prod-short} server checks for plug-ins to start from the workspace definition.
 . Plug-in metadata is retrieved, and the type of each plug-in is recognized.
 . A broker is selected according to the plug-in type.
 . The broker processes the installation and deployment of the plug-in (the installation process is different for each broker).
@@ -20,12 +20,12 @@ NOTE: Different types of plug-ins exist. A broker ensures all installation requi
 .Che-Theia plug-in lifecycle
 image::extensibility/che-theia-plug-in-lifecycle.png[link="../_images/extensibility/che-theia-plug-in-lifecycle.png"]
 
-Before a {prod-short} workspace is launched, {prod-short} master starts containers for the workspace:
+Before a {prod-short} workspace is launched, {prod-short} server starts containers for the workspace:
 
 . The Che-Theia plug-in broker extracts the plug-in (from the `.theia` file) to get the sidecar containers that the plug-in needs.
-. The broker sends the appropriate container information to {prod-short} master.
+. The broker sends the appropriate container information to {prod-short} server.
 . The broker copies the Che-Theia plug-in to a volume to have it available for the Che-Theia editor container.
-. {prod-short} workspace master then starts all the containers of the workspace.
+. {prod-short} server then starts all the containers of the workspace.
 . Che-Theia is started in its own container and checks the correct folder to load the plug-ins.
 
 Che-Theia plug-in lifecycle:

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -40,8 +40,8 @@ source:
     startPoint: master           <1>
     tag: 7.2.0
     commitId: 36fe587
-    branch: master
-    sparseCheckoutDir: wsmaster  <2>
+    branch: 7.20.x
+    sparseCheckoutDir: core  <2>
 ----
 <1> `startPoint` is the general value for `tag`, `commitId`, and `branch`. The `startPoint`, `tag`, `commitId`, and `branch` parameters are mutually exclusive. When more than one is supplied, the following order is used: `startPoint`, `tag`, `commitId`, `branch`.
 <2> `sparseCheckoutDir` the template for the sparse checkout Git feature. This is useful when only a part of a project (typically only a single directory) is needed.

--- a/modules/installation-guide/examples/system-variables.adoc
+++ b/modules/installation-guide/examples/system-variables.adoc
@@ -37,7 +37,7 @@
  `+CHE_WORKSPACE_ACTIVITY__CHECK__SCHEDULER__PERIOD__S+`,"`+60+`","Period of inactive workspaces suspend job execution." 
  `+CHE_WORKSPACE_ACTIVITY__CLEANUP__SCHEDULER__PERIOD__S+`,"`+3600+`","The period of the cleanup of the activity table. The activity table can contain invalid or stale data if some unforeseen errors happen, like a server crash at a peculiar point in time. The default is to run the cleanup job every hour." 
  `+CHE_WORKSPACE_ACTIVITY__CLEANUP__SCHEDULER__INITIAL__DELAY__S+`,"`+60+`","The delay after server startup to start the first activity clean up job." 
- `+CHE_WORKSPACE_ACTIVITY__CHECK__SCHEDULER__DELAY__S+`,"`+180+`","Delay before first workspace idleness check job started to avoid mass suspend if ws master was unavailable for period close to inactivity timeout." 
+ `+CHE_WORKSPACE_ACTIVITY__CHECK__SCHEDULER__DELAY__S+`,"`+180+`","Delay before first workspace idleness check job started to avoid mass suspend if {prod-short} server was unavailable for period close to inactivity timeout." 
  `+CHE_WORKSPACE_CLEANUP__TEMPORARY__INITIAL__DELAY__MIN+`,"`+5+`","Period of stopped temporary workspaces cleanup job execution." 
  `+CHE_WORKSPACE_CLEANUP__TEMPORARY__PERIOD__MIN+`,"`+180+`","Periodof stopped temporary workspaces cleanup job execution." 
  `+CHE_WORKSPACE_SERVER_PING__SUCCESS__THRESHOLD+`,"`+1+`","Number of sequential successful pings to server after which it is treated as available. Note: the property is common for all servers e.g. workspace agent, terminal, exec etc." 
@@ -215,7 +215,7 @@
 ,=== 
  Environment Variable Name,Default value, Description 
  
- `+CHE_CORS_ALLOWED__ORIGINS+`,"`+*+`","CORS filter on WS Master is turned off by default. Use environment variable 'CHE_CORS_ENABLED=true' to turn it on 'cors.allowed.origins' indicates which request origins are allowed" 
+ `+CHE_CORS_ALLOWED__ORIGINS+`,"`+*+`","CORS filter on {prod-short} server is turned off by default. Use environment variable 'CHE_CORS_ENABLED=true' to turn it on 'cors.allowed.origins' indicates which request origins are allowed" 
  `+CHE_CORS_ALLOW__CREDENTIALS+`,"`+false+`","'cors.support.credentials' indicates if it allows processing of requests with credentials (in cookies, headers, TLS client certificates)" 
 ,=== 
 

--- a/modules/installation-guide/partials/system-variables.adoc
+++ b/modules/installation-guide/partials/system-variables.adoc
@@ -36,7 +36,7 @@
  `+CHE_WORKSPACE_ACTIVITY__CHECK__SCHEDULER__PERIOD__S+`,"`+60+`","Period of inactive workspaces suspend job execution." 
  `+CHE_WORKSPACE_ACTIVITY__CLEANUP__SCHEDULER__PERIOD__S+`,"`+3600+`","The period of the cleanup of the activity table. The activity table can contain invalid or stale data if some unforeseen errors happen, like a server crash at a peculiar point in time. The default is to run the cleanup job every hour." 
  `+CHE_WORKSPACE_ACTIVITY__CLEANUP__SCHEDULER__INITIAL__DELAY__S+`,"`+60+`","The delay after server startup to start the first activity clean up job." 
- `+CHE_WORKSPACE_ACTIVITY__CHECK__SCHEDULER__DELAY__S+`,"`+180+`","Delay before first workspace idleness check job started to avoid mass suspend if ws master was unavailable for period close to inactivity timeout." 
+ `+CHE_WORKSPACE_ACTIVITY__CHECK__SCHEDULER__DELAY__S+`,"`+180+`","Delay before first workspace idleness check job started to avoid mass suspend if {prod-short} server was unavailable for period close to inactivity timeout." 
  `+CHE_WORKSPACE_CLEANUP__TEMPORARY__INITIAL__DELAY__MIN+`,"`+5+`","Period of stopped temporary workspaces cleanup job execution." 
  `+CHE_WORKSPACE_CLEANUP__TEMPORARY__PERIOD__MIN+`,"`+180+`","Periodof stopped temporary workspaces cleanup job execution." 
  `+CHE_WORKSPACE_SERVER_PING__SUCCESS__THRESHOLD+`,"`+1+`","Number of sequential successful pings to server after which it is treated as available. Note: the property is common for all servers e.g. workspace agent, terminal, exec etc." 
@@ -206,7 +206,7 @@
 ,=== 
  Environment Variable Name,Default value, Description 
  
- `+CHE_CORS_ALLOWED__ORIGINS+`,"`+*+`","CORS filter on WS Master is turned off by default. Use environment variable 'CHE_CORS_ENABLED=true' to turn it on 'cors.allowed.origins' indicates which request origins are allowed" 
+ `+CHE_CORS_ALLOWED__ORIGINS+`,"`+*+`","CORS filter on {prod-short} server is turned off by default. Use environment variable 'CHE_CORS_ENABLED=true' to turn it on 'cors.allowed.origins' indicates which request origins are allowed" 
  `+CHE_CORS_ALLOW__CREDENTIALS+`,"`+false+`","'cors.support.credentials' indicates if it allows processing of requests with credentials (in cookies, headers, TLS client certificates)" 
 ,=== 
 


### PR DESCRIPTION
### What does this PR do?
Replace problematic language wsmaster by Che server

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17602

### Specify the version of the product this PR applies to.
all

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)


Change-Id: I0250a5b6404e1fd15154374fccb658c8d612b9cf
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
