### PR TITLE
chore(netlify): Allow to deploy each PR to netlify and add result in PR status

### DIFF
--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -1,0 +1,31 @@
+name: netlify-pr-preview
+on: pull_request
+jobs:
+  netlify:
+    name: publish to netlify
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: build
+        id: antora-build
+        run: |
+           yarn
+           ./node_modules/.bin/antora generate antora-playbook.yml
+      - name: Publish
+        uses: netlify/actions/cli@master
+        id: netlify-publish
+        with:
+          args: deploy --dir=build/site --functions=functions
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      - name: 'Comment PR'
+        uses: actions/github-script@v3.0.0
+        if: github.event_name == 'pull_request'
+        with:
+         script: |
+           const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+           const netlifyUrl = '${{ steps.netlify-publish.outputs.NETLIFY_URL }}';
+           const prSha = context.payload.pull_request.head.sha;
+           await github.repos.createCommitStatus({ owner, repo, sha: prSha, state: "success", target_url: netlifyUrl, description: "Browse PR documentation live", context: "netlify"})


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
build with github action and then deploy it remotely to netlify

### What issues does this PR fix or reference?
N/A

### Specify the version of the product this PR applies to.
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successufully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

Change-Id: I90f9770a50b53bcc01c1e8739324c88c3f6c356a
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
