### PR TITLE
Fix xref for defining entrypoints in devfile reference

### DIFF
--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -818,7 +818,7 @@ components:
       app: postgres
 ----
 
-Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers present in the resource list. For details of the advanced use case, see xref:end-user-guide:creating-and-configuring-a-new-workspace#defining specific-container-images[].
+Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers present in the resource list. For details of the advanced use case, see xref:creating-and-configuring-a-new-workspace.adoc#defining specific-container-images[Defining specifc container images].
 
 == Adding commands to a devfile
 

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -818,7 +818,7 @@ components:
       app: postgres
 ----
 
-Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers present in the resource list. For details of the advanced use case, see xref:end-user-guide:configuring-the-workspace-and-adding-tooling#defining specific-container-images[].
+Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers present in the resource list. For details of the advanced use case, see xref:end-user-guide:creating-and-configuring-a-new-workspace#defining specific-container-images[].
 
 == Adding commands to a devfile
 


### PR DESCRIPTION
### What does this PR do?
Fix `xref` introduced in https://github.com/eclipse/che-docs/pull/1576

### What issues does this PR fix or reference?
Broken cross reference in docs

### Specify the version of the product this PR applies to.
7.19

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
    - Vale lists 12 errors on the devfile reference, but they're all spurious (using "zip" in a code sample is an error, but it's the devfile spec not prose).
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
    - ???
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

