### PR TITLE
chore(netlify): use another kind of event to get secret from fork

### DIFF
--- a/.github/workflows/netlify.yaml
+++ b/.github/workflows/netlify.yaml
@@ -1,5 +1,5 @@
 name: netlify-pr-preview
-on: pull_request
+on: pull_request_target
 jobs:
   netlify:
     name: publish to netlify


### PR DESCRIPTION
### What does this PR do?
netlify is not working yet on forks repository.
Attempt to use another event

### What issues does this PR fix or reference?
https://github.com/eclipse/che-docs/pull/1583

### Specify the version of the product this PR applies to.
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

Change-Id: I103512f120d82cf9011b4888d6da7a6554e4f306
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
