### PR TITLE
Adding Vale vocabulary. Need vale 2.3

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -3,6 +3,8 @@
 # The relative path to the folder containing linting rules (styles)
 # -----------------------------------------------------------------
 StylesPath = .vale/styles
+ 
+Vocab = Che
 
 # Minimum alert level
 # -------------------

--- a/.vale/styles/Vocab/Che/accept.txt
+++ b/.vale/styles/Vocab/Che/accept.txt
@@ -18,6 +18,12 @@ DNS
 Dockerfile
 Dotnet
 Endevor
+factory
+factories
+Git
+git
+GitHub
+GitLab
 Gluster
 Gradle
 Grafana
@@ -30,6 +36,7 @@ Mattermost
 millicores
 Minikube
 Minishift
+minishift
 mixin
 Mixin
 mixins
@@ -45,14 +52,18 @@ OAuth
 ocp
 OpenShift
 OpenTracing
+Operator
 osd
 PHP
+Pod
 Podman
 podman
 PostgreSQL
 preconfigured
 runtime
 runtimes
+stack
+stacks
 subnetwork
 subpath
 subpaths
@@ -66,6 +77,9 @@ URIs
 URL
 URLs
 Velero
+Visual Studio Code
+workspace
+workspaces
 YAML
 Yeoman
 Zowe

--- a/.vale/styles/Vocab/Che/reject.txt
+++ b/.vale/styles/Vocab/Che/reject.txt
@@ -1,0 +1,59 @@
+admin
+almost
+can
+clicking
+config
+DevFile
+Devfile
+DevFiles
+Devfiles
+e.g.
+etc.
+Factory
+Github
+github
+Gitlab
+gitlab
+grab
+I
+i.e.
+if
+info
+K8S
+K8S
+k8s
+Kube
+kubernetes
+let's
+like
+look up
+may
+maybe
+might
+mostly
+next
+node.js
+Nodejs
+nodejs
+now
+Oauth
+oauth
+operator
+our
+out of the box
+please
+pod
+previous
+probably
+refer
+repo
+set up
+should
+Stack
+start up
+take care of
+usage
+usually
+want
+we
+Workspace


### PR DESCRIPTION
Vocabularies (available since v2.3) allow you to maintain custom lists of terminology independent of your styles.
See: https://docs.errata.ai/vale/vocab

This is an incomplete implementation of these guidelines:

![Screenshot from 2020-09-18 09-52-50](https://user-images.githubusercontent.com/243761/93571720-24bc8780-f995-11ea-9229-e6d2cdf07df5.png)
