### PR TITLE
Add link to getting workspaces logs to EUG

### DIFF
--- a/modules/end-user-guide/nav.adoc
+++ b/modules/end-user-guide/nav.adoc
@@ -33,6 +33,7 @@
 ** xref:using-nuget-artifact-repositories.adoc[]
 ** xref:using-npm-artifact-repositories.adoc[]
 * xref:troubleshooting-che.adoc[]
+** xref:administration-guide:viewing-che-workspaces-logs.adoc[]
 ** xref:troubleshooting-slow-workspaces.adoc[]
 ** xref:troubleshooting-network-problems.adoc[]
 ** xref:starting-a-che-workspace-in-debug-mode.adoc[]

--- a/modules/end-user-guide/partials/assembly_troubleshooting-che.adoc
+++ b/modules/end-user-guide/partials/assembly_troubleshooting-che.adoc
@@ -9,15 +9,10 @@
 
 This section provides troubleshooting procedures for most frequent issues an user can came in conflict with.
 
+* xref:administration-guide:viewing-che-workspaces-logs.adoc[]
 * xref:troubleshooting-slow-workspaces.adoc[]
 * xref:troubleshooting-network-problems.adoc[]
 * xref:starting-a-che-workspace-in-debug-mode.adoc[]
 * xref:restarting-a-che-workspace-in-debug-mode-after-start-failure.adoc[]
-
-
-[discrete]
-== Additional resources
-
-* xref:administration-guide:viewing-che-workspaces-logs.adoc[]
 
 :context: {parent-context-of-troubleshooting-che}


### PR DESCRIPTION
### What does this PR do?
Adds `Viewing Che workspaces logs` as a top-level item under EUG > Troubleshooting Che. Currently, this is linked separately as an additional info, but the user will only see it if they click specifically on the "Troubleshooting Che" topic.

The only thing I'm still not sure of from an Antora perspective is whether it's okay to have an `xref` to the Administration guide in and EUG article, but it looks fine and navigation isn't broken when running the preview server in a Che workspace.

### What issues does this PR fix or reference?
Resolves https://github.com/eclipse/che/issues/17459

### Specify the version of the product this PR applies to.
7.20

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [???] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

