### PR TITLE
chore(pr-check): Add vale PR check

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: vale-pr-check
+on: [push, pull_request]
+jobs:
+  vale:
+    name: check vale
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: build
+        id: antora-build
+        run: |
+           yarn
+           ./node_modules/.bin/antora generate antora-playbook.yml
+      - name: run vale
+        run: |
+          git fetch
+          git diff --name-only origin/master > changed-files.txt
+          for f in `cat changed-files.txt` ; do
+            mkdir -p /tmp/vale/$(dirname $f)
+            echo "-- extracting git changes from $f --"
+            git diff --unified=0 origin/master -- $f | tail -n +6 | sed '/^-/d' | sed 's/^+\(.*\)/\1/' > /tmp/vale/$f
+          done
+          # Run vale on the delta changes
+          docker run --rm -v $(pwd):/docs -v /tmp/vale:/che-docs --entrypoint=sh jdkato/vale -c 'cd /docs && vale --sort /che-docs'


### PR DESCRIPTION
### What does this PR do?
Fail build by vale check in case of errors on the delta lines added by a PR
It's running the vale on added/changed lines, not on files modified as reported by @themr0c 
so I don't know if it can produce false/invalid result on a partial content.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/17908

### Specify the version of the product this PR applies to.
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

Change-Id: I1015567d0dc2002c8f2775a8f314ae973288df43
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
