### PR TITLE
chore(pr-check): validate links by linkchecker

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: linkchecker-pr-check
+on: [push, pull_request]
+jobs:
+  linkchecker:
+    name: link checker
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: build
+        id: antora-build
+        run: |
+           yarn
+           ./node_modules/.bin/antora generate antora-playbook.yml
+      - name: run linkchecker
+        run: |
+          ./node_modules/.bin/gulp &
+          sleep 10
+          # Run link checker
+          docker run --net=host --rm -v $(pwd):/doc linkchecker/linkchecker -f /doc/linkcheckerrc http://localhost:4000


### PR DESCRIPTION
### What does this PR do?
Run linkchecker on PR to validate that there is no broken link

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17909

### Specify the version of the product this PR applies to.
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

Change-Id: I211de9711e0681d9f0ae293099481c403d5d22e4
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
