### PR TITLE
[GDPR] delete all the data related to user account from keycloak

### DIFF
--- a/modules/administration-guide/partials/assembly_removing-user-data.adoc
+++ b/modules/administration-guide/partials/assembly_removing-user-data.adoc
@@ -17,7 +17,9 @@ $ curl -X DELETE `http(s)://{prod-host}/api/user/\{id}`
 ----
 NOTE: For deletening all data releted to the user account from Keycloak need to set `che.keycloak.cascade_user_removal_enabled` to the `true`.
 For correct work need to set admin username `che.keycloak.admin_username` and password
-`che.keycloak.admin_password`. By default this feature is disabled. 
+`che.keycloak.admin_password`. 
+
+NOTE: By default this feature is disabled. 
 
 NOTE: All the user's workspaces should be stopped beforehand. Otherwise, the API request will fail with `500` Error.
 

--- a/modules/administration-guide/partials/assembly_removing-user-data.adoc
+++ b/modules/administration-guide/partials/assembly_removing-user-data.adoc
@@ -15,6 +15,9 @@ In case user data needs to be deleted, the following API should be used with the
 ----
 $ curl -X DELETE `http(s)://{prod-host}/api/user/\{id}`
 ----
+NOTE: For deletening all data releted to the user account from Keycloak need to set `che.keycloak.cascade_user_removal_enabled` to the `true`.
+For correct work need to set admin username `che.keycloak.admin_username` and password
+`che.keycloak.admin_password`. By default this feature is disabled. 
 
 NOTE: All the user's workspaces should be stopped beforehand. Otherwise, the API request will fail with `500` Error.
 

--- a/modules/administration-guide/partials/assembly_removing-user-data.adoc
+++ b/modules/administration-guide/partials/assembly_removing-user-data.adoc
@@ -7,22 +7,125 @@
 
 :context: removing-user-data
 
-== GDPR
+== Removing user data according to GDPR
 
-In case user data needs to be deleted, the following API should be used with the `user` or the `admin` authorization token:
+The General Data Protection Regulation (GDPR) law enforces the right for individuals to have personal data erased.
 
-[subs="+attributes"]
+The following procedure describes how to remove a user’s data from a cluster and the Keycloak database.
+
+.Prerequisites
+
+* A user or an administrator authorization token. If a user wants to delete any other data except the data bound to their user account, the `admin` privileges are required.
+The `admin` is a  special Che administrator account pre-created and enabled using the `CHE_SYSTEM_ADMIN__NAME / CHE_SYSTEM_SUPER__PRIVILEGED__MODE = true` Custom Resource definition .
++
 ----
-$ curl -X DELETE `http(s)://{prod-host}/api/user/\{id}`
+spec:
+ server:
+   customCheProperties:
+     CHE_SYSTEM_SUPER__PRIVILEGED__MODE: 'true'
+     CHE_SYSTEM_ADMIN__NAME: '<admin_name>'
 ----
-NOTE: For deletening all data releted to the user account from Keycloak need to set `che.keycloak.cascade_user_removal_enabled` to the `true`.
-For correct work need to set admin username `che.keycloak.admin_username` and password
-`che.keycloak.admin_password`. 
++
+If needed, use commands below for creating an `admin` user:
++
+[subs="+quotes,attributes"]
+----
+$ oc patch checluster eclipse-che --type merge  -p '{ "spec": { "server": {"customCheProperties": {"CHE_SYSTEM_SUPER__PRIVILEGED__MODE": "true"} } }}'  -n {prod-namespace}
+----
++
+[subs="+quotes,attributes"]
+----
+$ oc patch checluster eclipse-che --type merge  -p '{ "spec": { "server": {"customCheProperties": {"CHE_SYSTEM_ADMIN__NAME": "<admin_name>"} } }}'  -n {prod-namespace}
+----
++
+[NOTE]
+====
+All system permissions are granted to the administrative user who is configured in the `CHE_SYSTEM_ADMIN__NAME` property (the default is `admin`). The system permissions are granted when the {prod-short} server starts. If the user is not present in the {prod-short} user database, it happens after the first user’s login.
 
-NOTE: By default this feature is disabled. 
+.Authorization token privileges:
 
-NOTE: All the user's workspaces should be stopped beforehand. Otherwise, the API request will fail with `500` Error.
+* `admin` - Can delete all personal data of all users
+* `user` - Can delete only the data related to the user
+====
 
-To remove the data of all the users, follow instructions for xref:installation-guide:uninstalling-che.adoc[].
+* A user or an administrator is logged in the OpenSift cluster with deployed {prod-short}.
+
+* A user ID is obtained. Get the user ID using the commands below:
+
+** For the current user:
++
+[subs="+quotes,attributes"]
+----
+ $ curl -X GET 'http(s)://{prod-host}/api/user'
+----
+ 
+ 
+** To find a user by name: 
++
+[subs="+quotes,attributes"]
+----
+$ curl -X GET 'http(s)://{prod-host}/api/user/find?name=__<username>__'
+----
+ 
+** To find a user by email: 
++
+[subs="+quotes,attributes"]
+----
+$ curl -X GET 'http(s)://{prod-host}/api/user/find?email=__<email>__'
+----
+
+.Example of obtaining a user ID
+
+This example uses `vparfono` as a local user name.
+
+====
+[subs="+quotes,attributes"]
+----
+$ curl -X GET --header 'Accept: application/json' --header 'Authorization: token 'https://che-vp-che.apps.che-dev.x6e0.p1.openshiftapps.com/api/user/find?name=vparfono'
+----
+
+The user ID is at the bottom of the curl command output.
+
+----
+{
+ "name": "vparfono",
+ "links": [
+   {
+.
+.
+.
+   }
+ ],
+ "email": "vitaly.parfonov@gmail.com",
+ "id": "921b6f33-2657-407e-93a6-fb14cf2329ce"
+}
+----
+====
+
+.Procedure
+
+. Update the `customresourceCR` file to permit the removal of a user’s data from the Keycloak database:
++
+[subs="+quotes,attributes"]
+----
+$ oc patch checluster/{prod-checluster} --patch "{\"spec\":{\"server\":{\"customCheProperties\": {\"CHE_KEYCLOAK_CASCADE__USER__REMOVAL__ENABLED\": \"true\"}}}}" --type=merge -n {prod-namespace}
+----
+
+. Remove the data using the API:
++
+[subs="+quotes,attributes"]
+----
+$ curl -X DELETE `http(s)://{prod-host}/api/user/__<user-id>__`
+----
+
+
+.Verification
+
+The execution of the `curl -X DELETE `http(s)://{prod-host}/api/user/__<user-id>__` command, ` returns the code 204 as a API response.
+
+
+.Additional resources
+To remove the data of all the users, follow the instructions for xref:installation-guide:uninstalling-che.adoc[].
+
 
 :context: {parent-context-of-removing-user-data}

--- a/modules/administration-guide/partials/assembly_removing-user-data.adoc
+++ b/modules/administration-guide/partials/assembly_removing-user-data.adoc
@@ -16,7 +16,7 @@ The following procedure describes how to remove a user’s data from a cluster a
 .Prerequisites
 
 * A user or an administrator authorization token. If a user wants to delete any other data except the data bound to their user account, the `admin` privileges are required.
-The `admin` is a  special Che administrator account pre-created and enabled using the `CHE_SYSTEM_ADMIN__NAME / CHE_SYSTEM_SUPER__PRIVILEGED__MODE = true` Custom Resource definition .
+The `admin` is a  special {prod-short} administrator account pre-created and enabled using the `CHE_SYSTEM_ADMIN__NAME / CHE_SYSTEM_SUPER__PRIVILEGED__MODE = true` Custom Resource definition .
 +
 ----
 spec:


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Explaining how to turn on ability to remove data related to user account from keycloak on deleting user from Che.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17541

### Specify the version of the product this PR applies to.
7.20

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

