### PR TITLE
docs for single-host devfile endpoins exposure on subdomains

### DIFF
--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -50,7 +50,7 @@ Therefore, only applications that use relative URLs in their UI work with the si
 
 This single-host configuration exposes the endpoints on subdomains, for example: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints are exposed on an unsecured HTTP port. A dedicated Ingress or Route is used for such endpoints, even with `gateway` single-host setup.
 
-This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because `https` pages allow communication only with secured endpoints, users must open their application previews in another browser tab.
+This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Since `https` pages allow communication only with secured endpoints, users must open their application previews in another browser tab.
 
 ifeval::["{project-context}" == "che"]
 == Default-host strategy

--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -48,7 +48,7 @@ Therefore, only applications that use relative URLs in their UI work with the si
 === devfile endpoints: `multi-host`
 `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'multi-host'++`
 
-This single-host configuration exposes the endpoints on subdomains, e.g.: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints are exposed on an unsecured HTTP port. A dedicated Ingress or Route is used for such endpoints, even with `gateway` single-host setup.
+This single-host configuration exposes the endpoints on subdomains, for example: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints are exposed on an unsecured HTTP port. A dedicated Ingress or Route is used for such endpoints, even with `gateway` single-host setup.
 
 This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because `https` pages allows communication only with secured endpoints, users must open their application previews in another browser tab.
 

--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -35,7 +35,7 @@ This is convenient for TLS-secured {prod-short} servers because it is sufficient
 
 There are two types of endpoints, that are defined in the devfiles, exposures in single-host strategy. To configured it, use `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE++`. It is effective only in single-host server strategy..
 
-=== Devfile endpoints: `single-host`
+=== devfile endpoints: `single-host`
 
 `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'single-host'++`
 
@@ -45,7 +45,7 @@ For example, when the user accesses the hypothetical `[{prod-url}/component-pref
 
 Therefore, only applications that use relative URLs in their UI work with the single-host workspace exposure strategy.
 
-=== Devfile endpoints: `multi-host`
+=== devfile endpoints: `multi-host`
 `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'multi-host'++`
 
 This single-host configuration exposes the endpoints on subdomains, e.g.: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints will be exposed on unsecured HTTP port. We're using dedicated Ingress/Route for such endpoints, even with `gateway` single-host setup.

--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -24,7 +24,6 @@ This strategy is the easiest to understand from the perspective of component dep
 
 On a {prod-short} server secured using the Transport Layer Security (TLS) protocol, creating new subdomains for each component of each workspace requires a wildcard certificate to be available for all such subdomains for the {prod-short} deployment to be practical.
 
-ifeval::["{project-context}" == "che"]
 == Single-host strategy
 
 Single-host strategy have two subtypes with different implementation methods. First subtype is named `native`. This strategy is available and default on {kubernetes}, but not on OpenShift, since it uses ingresses for servers exposing. The second subtype named `gateway`, works both on
@@ -34,13 +33,26 @@ When any of those single-host types is used, all workspaces are deployed to sub-
 
 This is convenient for TLS-secured {prod-short} servers because it is sufficient to have a single certificate for the {prod-short} server, which will cover all the workspace component deployments as well.
 
-This strategy limits the exposed components and user applications. Any absolute URL generated on the server side that points back to the server does not work. This is because the server is hidden behind a path-rewriting Ingress that hides the workspace and the component-specific URL prefix from the server.
+There are two ways how endpoints defined in the devfiles can be exposed in single-host strategy. They can either follow the single-host strategy and be exposed on subpaths. Or they can be exposed on subdomains. Each of these have its pros and cons. It's configured with `CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE`, which is effective only if `CHE_INFRA_KUBERNETES_SERVER__STRATEGY: 'single-host'`.
+
+=== Devfile endpoints: `single-host`
+
+`CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'single-host'`
+
+This single-host configuration exposes the endpoints on subpaths, e.g.: `[https://<che-host>/serverihzmuqqc/go-cli-server-8080]`. This limits the exposed components and user applications. Any absolute URL generated on the server side that points back to the server does not work. This is because the server is hidden behind a path-rewriting Ingress that hides the workspace and the component-specific URL prefix from the server.
 
 For example, when the user accesses the hypothetical `[{prod-url}/component-prefix-djh3d/app/index.php]` URL, the application sees the request coming to `++https://internal-host/app/index.php++`. If the application used the host in the URL that it generates in its UI, it would not work because the internal host is different from the externally visible host. However, if the application used an absolute path as the URL (for the example above, this would be `/app/index.php`), such URL would still not work. This is because on the outside, such URL does not point to the application, because it is missing the component-specific prefix.
 
 Therefore, only applications that use relative URLs in their UI work with the single-host workspace exposure strategy.
 
+=== Devfile endpoints: `multi-host`
+`CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'multi-host'`
 
+This single-host configuration exposes the endpoints on subdomains, e.g.: `[http://serverihzmuqqc-go-cli-server-8080.<che-host>/serverihzmuqqc/go-cli-server-8080]`. These endpoints will be exposed on unsecured HTTP port. We're using dedicated Ingress/Route for such endpoints, even with `gateway` single-host setup.
+
+This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because unsecured pages can't be loaded from secured ones, users must open their applications on another tab of the browser.
+
+ifeval::["{project-context}" == "che"]
 == Default-host strategy
 
 This strategy exposes the components to the outside world on the sub-paths of the default host of the cluster. It is similar to the single-host strategy. All the limitations and advantages of the single-host strategy applying to this strategy as well.

--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -39,7 +39,7 @@ There are 2 ways of exposing the endpoints specified in the devfile. These can b
 
 `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'single-host'++`
 
-This single-host configuration exposes the endpoints on subpaths, e.g.: `++https://<che-host>/serverihzmuqqc/go-cli-server-8080++`. This limits the exposed components and user applications. Any absolute URL generated on the server side that points back to the server does not work. This is because the server is hidden behind a path-rewriting reverse proxy that hides the unique URL path prefix from the component or user application.
+This single-host configuration exposes the endpoints on subpaths, for example: `++https://<che-host>/serverihzmuqqc/go-cli-server-8080++`. This limits the exposed components and user applications. Any absolute URL generated on the server side that points back to the server does not work. This is because the server is hidden behind a path-rewriting reverse proxy that hides the unique URL path prefix from the component or user application.
 
 For example, when the user accesses the hypothetical `[{prod-url}/component-prefix-djh3d/app/index.php]` URL, the application sees the request coming to `++https://internal-host/app/index.php++`. If the application used the host in the URL that it generates in its UI, it would not work because the internal host is different from the externally visible host. However, if the application used an absolute path as the URL (for the example above, this would be `/app/index.php`), such URL would still not work. This is because on the outside, such URL does not point to the application, because it is missing the component-specific prefix.
 

--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -50,7 +50,7 @@ Therefore, only applications that use relative URLs in their UI work with the si
 
 This single-host configuration exposes the endpoints on subdomains, e.g.: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints will be exposed on unsecured HTTP port. We're using dedicated Ingress or Route for such endpoints, even with `gateway` single-host setup.
 
-This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because HTTPS pages allows communication only with secured endpoints, users must open their application previews on another tab of the browser.
+This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because `https` pages allows communication only with secured endpoints, users must open their application previews on another tab of the browser.
 
 ifeval::["{project-context}" == "che"]
 == Default-host strategy

--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -33,22 +33,22 @@ When any of those single-host types is used, all workspaces are deployed to sub-
 
 This is convenient for TLS-secured {prod-short} servers because it is sufficient to have a single certificate for the {prod-short} server, which will cover all the workspace component deployments as well.
 
-There are two ways how endpoints defined in the devfiles can be exposed in single-host strategy. They can either follow the single-host strategy and be exposed on subpaths. Or they can be exposed on subdomains. Each of these have its pros and cons. It's configured with `CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE`, which is effective only if `CHE_INFRA_KUBERNETES_SERVER__STRATEGY: 'single-host'`.
+There are two ways how endpoints defined in the devfiles can be exposed in single-host strategy. They can either follow the single-host strategy and be exposed on subpaths. Or they can be exposed on subdomains. Each of these have its pros and cons. It's configured with `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE++`, which is effective only if `CHE_INFRA_KUBERNETES_SERVER__STRATEGY: 'single-host'`.
 
 === Devfile endpoints: `single-host`
 
-`CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'single-host'`
+`++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'single-host'++`
 
-This single-host configuration exposes the endpoints on subpaths, e.g.: `[https://<che-host>/serverihzmuqqc/go-cli-server-8080]`. This limits the exposed components and user applications. Any absolute URL generated on the server side that points back to the server does not work. This is because the server is hidden behind a path-rewriting Ingress that hides the workspace and the component-specific URL prefix from the server.
+This single-host configuration exposes the endpoints on subpaths, e.g.: `++https://<che-host>/serverihzmuqqc/go-cli-server-8080++`. This limits the exposed components and user applications. Any absolute URL generated on the server side that points back to the server does not work. This is because the server is hidden behind a path-rewriting Ingress that hides the workspace and the component-specific URL prefix from the server.
 
 For example, when the user accesses the hypothetical `[{prod-url}/component-prefix-djh3d/app/index.php]` URL, the application sees the request coming to `++https://internal-host/app/index.php++`. If the application used the host in the URL that it generates in its UI, it would not work because the internal host is different from the externally visible host. However, if the application used an absolute path as the URL (for the example above, this would be `/app/index.php`), such URL would still not work. This is because on the outside, such URL does not point to the application, because it is missing the component-specific prefix.
 
 Therefore, only applications that use relative URLs in their UI work with the single-host workspace exposure strategy.
 
 === Devfile endpoints: `multi-host`
-`CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'multi-host'`
+`++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'multi-host'++`
 
-This single-host configuration exposes the endpoints on subdomains, e.g.: `[http://serverihzmuqqc-go-cli-server-8080.<che-host>/serverihzmuqqc/go-cli-server-8080]`. These endpoints will be exposed on unsecured HTTP port. We're using dedicated Ingress/Route for such endpoints, even with `gateway` single-host setup.
+This single-host configuration exposes the endpoints on subdomains, e.g.: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints will be exposed on unsecured HTTP port. We're using dedicated Ingress/Route for such endpoints, even with `gateway` single-host setup.
 
 This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because unsecured pages can't be loaded from secured ones, users must open their applications on another tab of the browser.
 

--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -33,7 +33,7 @@ When any of those single-host types is used, all workspaces are deployed to sub-
 
 This is convenient for TLS-secured {prod-short} servers because it is sufficient to have a single certificate for the {prod-short} server, which will cover all the workspace component deployments as well.
 
-There are two ways how endpoints defined in the devfiles can be exposed in single-host strategy. They can either follow the single-host strategy and be exposed on subpaths. Or they can be exposed on subdomains. Each of these have its pros and cons. It's configured with `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE++`, which is effective only if `CHE_INFRA_KUBERNETES_SERVER__STRATEGY: 'single-host'`.
+There are two types of endpoints, that are defined in the devfiles, exposures in single-host strategy. To configured it, use `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE++`. It is effective only in single-host server strategy..
 
 === Devfile endpoints: `single-host`
 

--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -48,9 +48,9 @@ Therefore, only applications that use relative URLs in their UI work with the si
 === devfile endpoints: `multi-host`
 `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'multi-host'++`
 
-This single-host configuration exposes the endpoints on subdomains, e.g.: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints will be exposed on unsecured HTTP port. We're using dedicated Ingress/Route for such endpoints, even with `gateway` single-host setup.
+This single-host configuration exposes the endpoints on subdomains, e.g.: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints will be exposed on unsecured HTTP port. We're using dedicated Ingress or Route for such endpoints, even with `gateway` single-host setup.
 
-This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because unsecured pages can't be loaded from secured ones, users must open their applications on another tab of the browser.
+This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because HTTPS pages allows communication only with secured endpoints, users must open their application previews on another tab of the browser.
 
 ifeval::["{project-context}" == "che"]
 == Default-host strategy

--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -50,7 +50,7 @@ Therefore, only applications that use relative URLs in their UI work with the si
 
 This single-host configuration exposes the endpoints on subdomains, for example: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints are exposed on an unsecured HTTP port. A dedicated Ingress or Route is used for such endpoints, even with `gateway` single-host setup.
 
-This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because `https` pages allows communication only with secured endpoints, users must open their application previews in another browser tab.
+This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because `https` pages allow communication only with secured endpoints, users must open their application previews in another browser tab.
 
 ifeval::["{project-context}" == "che"]
 == Default-host strategy

--- a/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
+++ b/modules/installation-guide/partials/con_workspace-exposure-strategies.adoc
@@ -33,13 +33,13 @@ When any of those single-host types is used, all workspaces are deployed to sub-
 
 This is convenient for TLS-secured {prod-short} servers because it is sufficient to have a single certificate for the {prod-short} server, which will cover all the workspace component deployments as well.
 
-There are two types of endpoints, that are defined in the devfiles, exposures in single-host strategy. To configured it, use `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE++`. It is effective only in single-host server strategy..
+There are 2 ways of exposing the endpoints specified in the devfile. These can be configured using the `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE++` environment variable of the {prod-short}. This environment variable is only effective with the single-host server strategy and is applicable to all workspaces of all users.
 
 === devfile endpoints: `single-host`
 
 `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'single-host'++`
 
-This single-host configuration exposes the endpoints on subpaths, e.g.: `++https://<che-host>/serverihzmuqqc/go-cli-server-8080++`. This limits the exposed components and user applications. Any absolute URL generated on the server side that points back to the server does not work. This is because the server is hidden behind a path-rewriting Ingress that hides the workspace and the component-specific URL prefix from the server.
+This single-host configuration exposes the endpoints on subpaths, e.g.: `++https://<che-host>/serverihzmuqqc/go-cli-server-8080++`. This limits the exposed components and user applications. Any absolute URL generated on the server side that points back to the server does not work. This is because the server is hidden behind a path-rewriting reverse proxy that hides the unique URL path prefix from the component or user application.
 
 For example, when the user accesses the hypothetical `[{prod-url}/component-prefix-djh3d/app/index.php]` URL, the application sees the request coming to `++https://internal-host/app/index.php++`. If the application used the host in the URL that it generates in its UI, it would not work because the internal host is different from the externally visible host. However, if the application used an absolute path as the URL (for the example above, this would be `/app/index.php`), such URL would still not work. This is because on the outside, such URL does not point to the application, because it is missing the component-specific prefix.
 
@@ -48,9 +48,9 @@ Therefore, only applications that use relative URLs in their UI work with the si
 === devfile endpoints: `multi-host`
 `++CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'multi-host'++`
 
-This single-host configuration exposes the endpoints on subdomains, e.g.: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints will be exposed on unsecured HTTP port. We're using dedicated Ingress or Route for such endpoints, even with `gateway` single-host setup.
+This single-host configuration exposes the endpoints on subdomains, e.g.: `++http://serverihzmuqqc-go-cli-server-8080.<che-host>++`. These endpoints are exposed on an unsecured HTTP port. A dedicated Ingress or Route is used for such endpoints, even with `gateway` single-host setup.
 
-This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because `https` pages allows communication only with secured endpoints, users must open their application previews on another tab of the browser.
+This configuration limits the usability of previews shown directly in the editor page when {prod-short} is configured with TLS. Because `https` pages allows communication only with secured endpoints, users must open their application previews in another browser tab.
 
 ifeval::["{project-context}" == "che"]
 == Default-host strategy


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Document new single-host configuration for exposing devfile endpoints on subdomains.
Che PR: https://github.com/eclipse/che/pull/17928

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17840

### Specify the version of the product this PR applies to.
7.20

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

