### PR TITLE
Installing Che: link to Hosted Che, alias for quick-starts

### DIFF
--- a/modules/hosted-che/pages/hosted-che.adoc
+++ b/modules/hosted-che/pages/hosted-che.adoc
@@ -2,6 +2,6 @@
 // = Hosted Che
 :navtitle: Hosted Che
 :keywords: overview, hosted-che
-:page-aliases: .:hosted-che, overview:hosted-che.adoc, .:3-minutes-to-che, overview:3-minutes-to-che, .:che-quick-starts, .:quick-start.html, overview:che-quick-starts
+:page-aliases: .:hosted-che, overview:hosted-che.adoc 
 
 include::partial$assembly_hosted-che.adoc[]

--- a/modules/installation-guide/pages/installing-che.adoc
+++ b/modules/installation-guide/pages/installing-che.adoc
@@ -2,6 +2,6 @@
 // = Installing Che
 :navtitle: Installing Che
 :keywords: installation-guide, installing-che
-:page-aliases: .:installing-che
+:page-aliases: .:installing-che, .:3-minutes-to-che, overview:3-minutes-to-che, .:quick-starts, .:che-quick-starts, .:quick-start.html, overview:che-quick-start
 
 include::partial$assembly_installing-che.adoc[]

--- a/modules/installation-guide/partials/assembly_installing-che.adoc
+++ b/modules/installation-guide/partials/assembly_installing-che.adoc
@@ -22,7 +22,7 @@ ifeval::["{project-context}" == "che"]
 
 [TIP]
 ====
-* To use {prod-short} as a service, see: xref:hosted-che:hosted-che.adoc[]
+To use {prod-short} as a service, see: xref:hosted-che:hosted-che.adoc[].
 ====
 
 == Installing {prod-short} on a local single-node cluster

--- a/modules/installation-guide/partials/assembly_installing-che.adoc
+++ b/modules/installation-guide/partials/assembly_installing-che.adoc
@@ -20,6 +20,10 @@ ifeval::["{project-context}" == "che"]
 
 * A {platforms-name} cluster to deploy {prod-short} on.
 
+[TIP]
+====
+* To use {prod-short} as a service, see: xref:hosted-che:hosted-che.adoc[]
+====
 
 == Installing {prod-short} on a local single-node cluster
 


### PR DESCRIPTION
Installing Che should contain a link to Hosted Che and be the alias for quick-starts