### PR TITLE
Add a note about the limitation on paths with secure endpoints to the devfile reference

### DIFF
--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -634,6 +634,8 @@ Here, there are two Docker images, each defining a single endpoint. Endpoint is 
 WARNING: Listening on any other interface than the local loopback poses a security risk because such server is accessible without the JWT authentication within the cluster network on the corresponding IP addresses.
 
 * `path`: The URL of the endpoint.
++
+NOTE: Currently, it is not possible to specify a non-root path on secure endpoints. If you need your endpoint secured by {prod-short}, don't specify the path of the endpoint.
 
 * `unsecuredPaths`: A comma-separated list of endpoint paths that are to stay unsecured even if the `secure` attribute is set to `true`.
 

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -635,7 +635,7 @@ WARNING: Listening on any other interface than the local loopback poses a securi
 
 * `path`: The URL of the endpoint.
 +
-NOTE: Currently, it is not possible to specify a non-root path on secure endpoints. If you need your endpoint secured by {prod-short}, don't specify the path of the endpoint.
+IMPORTANT: Currently, it is not possible to specify a non-root path on secure endpoints. If you need your endpoint secured by {prod-short}, don't specify the path of the endpoint.
 
 * `unsecuredPaths`: A comma-separated list of endpoint paths that are to stay unsecured even if the `secure` attribute is set to `true`.
 

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -635,7 +635,7 @@ WARNING: Listening on any other interface than the local loopback poses a securi
 
 * `path`: The URL of the endpoint.
 +
-IMPORTANT: Currently, it is not possible to specify a non-root path on secure endpoints. If you need your endpoint secured by {prod-short}, don't specify the path of the endpoint.
+IMPORTANT: Currently, it is not possible to specify a non-root path on secure endpoints. If you need your endpoint secured by {prod-short}, do not specify the path of the endpoint.
 
 * `unsecuredPaths`: A comma-separated list of endpoint paths that are to stay unsecured even if the `secure` attribute is set to `true`.
 


### PR DESCRIPTION
### What does this PR do?
In eclipse/che#17852, we've discovered a limitation on the secure endpoints. As of now, they cannot specify a non-root path. This PR adds a note about this limitation to the devfile reference.

### What issues does this PR fix or reference?
eclipse/che#17852

### Specify the version of the product this PR applies to.
Eclipse Che 7.20

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

