### PR TITLE
document subdomain plugin endpoint

### DIFF
--- a/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
+++ b/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
@@ -104,6 +104,7 @@ The link:https://github.com/eclipse/che-plugin-registry/tree/master/v3/plugins[c
 `discoverable`: `true`, `false`
 `secure`: `true`, `false`. If `true`, then the endpoint is assumed to listen solely on `127.0.0.1` and is exposed using a JWT proxy
 `cookiesAuthEnabled`: `true`, `false`
+`requireSubdomain`: `true`, `false`. If `true`, the endpoint is exposed on subdomain in single-host mode.
 :===
 
 .`spec.containers.lifecycle` and `spec.initContainers.lifecycle` attributes


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
document new plugin endpoint attribute `requireSubdomain`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18001

### Specify the version of the product this PR applies to.
7.20

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts) + [product.json](https://github.com/eclipse/che-dashboard/blob/master/src/assets/branding/product.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

