### PR TITLE
fixup! making wording in Hosted Che docs vale compatible

### DIFF
--- a/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
+++ b/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
@@ -30,7 +30,7 @@ Also, note that telemetry is enabled in Hosted Che so Woopra / Segment tracking 
 - https://api.segment.io/v1/t 
 - https://static.woopra.com/js/w.js
 
-In case, the browser is running in the incognito mode the third-party cookies should be also explicitly unblocked:
+In case, the browser is running in the incognito mode the third-party cookies must be explicitly unblocked:
 
 image::hosted-che/unblock_third_party_cookies.png[]
 


### PR DESCRIPTION
fixup! making wording in Hosted Che docs vale compatible

### What does this PR do?
fixing wording from https://github.com/eclipse/che-docs/pull/1641 to make it vale compatible

### What issues does this PR fix or reference?
N/A

### Specify the version of the product this PR applies to.
4.20

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

