### PR TITLE
Remove Let's Encrypt reference.

### DIFF
--- a/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
@@ -78,7 +78,7 @@ $ {prod-cli} server:start -p openshift
 Command server:start has completed successfully.
 ----
 
-. Navigate to the {prod-short} cluster instance: `pass:c,a,q[{prod-url}]`. The domain uses _Let’s Encrypt_ ACME certificates.
+. Navigate to the {prod-short} cluster instance: `pass:c,a,q[{prod-url}]`.
 
 .Having multiple {prod-short} deployments
 


### PR DESCRIPTION
### What does this PR do?

Removes out-of-date reference to Let’s Encrypt.

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/RHDEVDOCS-1888

### Specify the version of the product this PR applies to.

7.x

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

