### PR TITLE
Add note about normalizing usernames if it did not match K8S naming format

### DIFF
--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -79,6 +79,12 @@ endif::[]
 allowUserDefinedWorkspaceNamespaces
 ----
 
+== Handling incompatible usernames or user ID-s
+
+{prod-short} server automatically checks usernames and\or ID-s for compatibility with Kubernetes objects naming convention before creating a {orch-namespace} from a template.
+In case of incompatible user name or ID, it will be reduced to nearest valid name by replacing groups of unsuitable symbols with an `-` symbol. To avoid collisions,
+some random 6 symbols suffix is added and result is stored into preferences for re-use.
+
 == Pre-creating {orch-namespace}s for users
 
 To pre-create {orch-namespace}s for users, use {orch-namespace} labels.

--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -79,7 +79,7 @@ endif::[]
 allowUserDefinedWorkspaceNamespaces
 ----
 
-== Handling incompatible usernames or user ID-s
+== Handling incompatible usernames or user IDs
 
 {prod-short} server automatically checks usernames and\or ID-s for compatibility with Kubernetes objects naming convention before creating a {orch-namespace} from a template.
 In case of incompatible user name or ID, it will be reduced to nearest valid name by replacing groups of unsuitable symbols with an `-` symbol. To avoid collisions,

--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -82,7 +82,7 @@ allowUserDefinedWorkspaceNamespaces
 == Handling incompatible usernames or user IDs
 
 {prod-short} server automatically checks usernames and IDs for compatibility with Kubernetes objects naming convention before creating a {orch-namespace} from a template.
-In case of incompatible user name or ID, it will be reduced to nearest valid name by replacing groups of unsuitable symbols with an `-` symbol. To avoid collisions,
+Incompatible username or IDs are reduced to the nearest valid name by replacing groups of unsuitable symbols with the `-` symbol. To avoid collisions,
 a random 6-symbol suffix is added and the result is stored in preferences for reuse.
 
 == Pre-creating {orch-namespace}s for users

--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -81,7 +81,7 @@ allowUserDefinedWorkspaceNamespaces
 
 == Handling incompatible usernames or user IDs
 
-{prod-short} server automatically checks usernames and\or ID-s for compatibility with Kubernetes objects naming convention before creating a {orch-namespace} from a template.
+{prod-short} server automatically checks usernames and IDs for compatibility with Kubernetes objects naming convention before creating a {orch-namespace} from a template.
 In case of incompatible user name or ID, it will be reduced to nearest valid name by replacing groups of unsuitable symbols with an `-` symbol. To avoid collisions,
 some random 6 symbols suffix is added and result is stored into preferences for re-use.
 

--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -83,7 +83,7 @@ allowUserDefinedWorkspaceNamespaces
 
 {prod-short} server automatically checks usernames and IDs for compatibility with Kubernetes objects naming convention before creating a {orch-namespace} from a template.
 In case of incompatible user name or ID, it will be reduced to nearest valid name by replacing groups of unsuitable symbols with an `-` symbol. To avoid collisions,
-some random 6 symbols suffix is added and result is stored into preferences for re-use.
+a random 6-symbol suffix is added and the result is stored in preferences for reuse.
 
 == Pre-creating {orch-namespace}s for users
 


### PR DESCRIPTION
### What does this PR do?
Add note about normalizing usernames/user ID-s when namespace naming strategy contains it and name did not match K8S naming format.

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

