### PR TITLE
The paths are now allowed on secure endpoints.

### DIFF
--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -633,9 +633,7 @@ Here, there are two Docker images, each defining a single endpoint. Endpoint is 
 +
 WARNING: Listening on any other interface than the local loopback poses a security risk because such server is accessible without the JWT authentication within the cluster network on the corresponding IP addresses.
 
-* `path`: The URL of the endpoint.
-+
-IMPORTANT: Currently, it is not possible to specify a non-root path on secure endpoints. If you need your endpoint secured by {prod-short}, do not specify the path of the endpoint.
+* `path`: The path portion of the URL to the endpoint. This defaults to `/`, meaning that the endpoint is assumed to be accessible at the web root of the server defined by the component.
 
 * `unsecuredPaths`: A comma-separated list of endpoint paths that are to stay unsecured even if the `secure` attribute is set to `true`.
 


### PR DESCRIPTION
### What does this PR do?
This updates the dev file reference to be up-to-date with the latest impl that now correctly supports paths on secure endpoints.

### What issues does this PR fix or reference?
eclipse/che#15867 eclipse/che#18155

### Specify the version of the product this PR applies to.
Che 7.21

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

