### PR TITLE
Push to production on production branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,7 @@ spec:
                   export DOC_COMMIT_MSG=$(git log --oneline --format=%B -n 1 HEAD | tail -1)
                   git commit -s -m "[docs] ${DOC_COMMIT_MSG}"
                   git log --graph --abbrev-commit --date=relative -n 5
-                  git push origin HEAD:${BRANCH_NAME}
+                  git push origin HEAD:master
                 else
                   echo "No change have been detected since last build, nothing to publish"
                 fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ spec:
     
     stage('Checkout www repo (master)') {
       when {
-        branch 'master'
+        branch 'production'
         beforeAgent true
       }
       steps {
@@ -106,7 +106,7 @@ spec:
 
     stage('Push to www repo (master)') {
       when {
-        branch 'master'
+        branch 'production'
         beforeAgent true
       }
       steps {


### PR DESCRIPTION
Use the branch called `production` to publish the docs into the webservers.

First reason: quickfix because 'master' branch is not visible anymore in  https://ci.eclipse.org/che/job/che-docs-pipelinehttps://ci.eclipse.org/che/job/che-docs-pipeline. We raised an issue, but need to publish meanwhile: https://bugs.eclipse.org/bugs/show_bug.cgi?id=568254

Second reason: make it permanent in order to make clear the published version of the docs contain only documentation about released features.

