### PR TITLE
update pre-creating namespaces for users documentation

### DIFF
--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -87,19 +87,24 @@ a random 6-symbol suffix is added and the result is stored in preferences for re
 
 == Pre-creating {orch-namespace}s for users
 
-To pre-create {orch-namespace}s for users, use {orch-namespace} labels and annotations.
+To pre-create {orch-namespace}s for users, use {orch-namespace} labels and annotations. Such namespace is used in preference to `CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT` variable.
 
 ----
 metadata:
   labels:
-    app.kubernetes.io/component: workspace
     app.kubernetes.io/part-of: che.eclipse.org
+    app.kubernetes.io/component: workspaces-namespace
   annotations:
     che.eclipse.org/username: <username>  <1>
 ----
 <1> target user's username
 
 To configure the labels, set the `CHE_INFRA_KUBERNETES_NAMESPACE_LABELS` to desired labels. To configure the annotations, set the `CHE_INFRA_KUBERNETES_NAMESPACE_ANNOTATIONS` to desired annotations. See the xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc#che-server-component-system-properties-reference_advanced-configuration-options-for-the-che-server-component[Che server component system properties reference] for more details.
+
+[WARNING]
+====
+We do not recommend to create multiple namespaces for single user. It may lead to undefined behavior.
+====
 
 [IMPORTANT]
 ====
@@ -122,5 +127,5 @@ subjects:
 <1> pre-created namespace
 <2> target user
 
-On {kubernetes}, `che` ServiceAccount must have a cluster-wide `list namespaces` privilege as well as an `admin` role in target namespace.
+On {kubernetes}, `che` ServiceAccount must have a cluster-wide `list` and `get` `namespaces` permissions as well as an `admin` role in target namespace.
 ====


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
updates documentation for pre-creating namespaces for users

### What issues does this PR fix or reference?
n/a

### Specify the version of the product this PR applies to.
7.21

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

