### PR TITLE
Fix xref in Installation Guide

### DIFF
--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -99,7 +99,7 @@ metadata:
 ----
 <1> target user's username
 
-To configure the labels, set the `CHE_INFRA_KUBERNETES_NAMESPACE_LABELS` to desired labels. To configure the annotations, set the `CHE_INFRA_KUBERNETES_NAMESPACE_ANNOTATIONS` to desired annotations. See the xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc#che-server-component-system-properties-reference_advanced-configuration-options-for-the-che-server-component[Che server component system properties reference] for more details.
+To configure the labels, set the `CHE_INFRA_KUBERNETES_NAMESPACE_LABELS` to desired labels. To configure the annotations, set the `CHE_INFRA_KUBERNETES_NAMESPACE_ANNOTATIONS` to desired annotations. See the xref:advanced-configuration-options-for-the-che-server-component.adoc#che-server-component-system-properties-reference_advanced-configuration-options-for-the-che-server-component[Che server component system properties reference] for more details.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
In a same-guide xref statement, we don't need to state the guide.