### PR TITLE
Update k8s.tlsSecretName property behaviour doc

### DIFF
--- a/modules/installation-guide/partials/ref_checluster-custom-resource-fields-reference.adoc
+++ b/modules/installation-guide/partials/ref_checluster-custom-resource-fields-reference.adoc
@@ -128,7 +128,7 @@ Property: Default value: Description
 `ingressStrategy`: `multi-host`: Strategy for ingress creation. This can be `multi-host` (host is explicitly provided in ingress), `single-host` (host is provided, path-based rules) and `default-host.*`(no host is provided, path-based rules).
 `securityContextFsGroup,omitempty`: `1724`: FSGroup the {prod-short} Pod and Workspace Pods containers run in.
 `securityContextRunAsUser`: `1724`: ID of the user the {prod-short} Pod and Workspace Pods containers run as.
-`tlsSecretName`: omit: Name of a secret that is used to set ingress TLS termination if TLS is enabled. See also the `tlsSupport` field.
+`tlsSecretName`: che-tls: Name of a secret that is used to set ingress TLS termination if TLS is enabled. If specified secret doesn't exist, self-signed certificate will be created. If the value empty or omitted, default ingress certificate will be used. See also the `tlsSupport` field. Note, if switch from user defined to cluster default ingress certificate, `self-signed-certificate` secret should be delete manually.
 :===
 
 [id="checluster-custom-resource-installation-settings_{context}"]

--- a/modules/installation-guide/partials/ref_checluster-custom-resource-fields-reference.adoc
+++ b/modules/installation-guide/partials/ref_checluster-custom-resource-fields-reference.adoc
@@ -128,7 +128,7 @@ Property: Default value: Description
 `ingressStrategy`: `multi-host`: Strategy for ingress creation. This can be `multi-host` (host is explicitly provided in ingress), `single-host` (host is provided, path-based rules) and `default-host.*`(no host is provided, path-based rules).
 `securityContextFsGroup,omitempty`: `1724`: FSGroup the {prod-short} Pod and Workspace Pods containers run in.
 `securityContextRunAsUser`: `1724`: ID of the user the {prod-short} Pod and Workspace Pods containers run as.
-`tlsSecretName`: che-tls: Name of a secret that is used to set ingress TLS termination if TLS is enabled. If specified secret doesn't exist, self-signed certificate will be created. If the value empty or omitted, default ingress certificate will be used. See also the `tlsSupport` field. Note, if switch from user defined to cluster default ingress certificate, `self-signed-certificate` secret should be delete manually.
+`tlsSecretName`: che-tls: Name of a secret that is used to set ingress TLS termination if TLS is enabled. If the specified secret does not exist, a self-signed certificate will be created. If the value empty or omitted, the default ingress certificate will be used. See also the `tlsSupport` field. Note, if switch from user-defined to cluster default ingress certificate, `self-signed-certificate` secret should be deleted manually.
 :===
 
 [id="checluster-custom-resource-installation-settings_{context}"]


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Updates docs regarding `k8s.tlsSecretName` CR field property.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18079

### Specify the version of the product this PR applies to.
Since merge of https://github.com/eclipse/che-operator/pull/508

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

