### PR TITLE
Update proc_preparing-the-aws-system-for-installing-che.adoc

### DIFF
--- a/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
+++ b/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
@@ -391,25 +391,28 @@ image::installation/create-policy-review.png[link="../_images/installation/creat
 +
 ----
 $ cat <<EOF | kubectl apply -f -
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: che-certificate-issuer
+  namespace: cert-manager
 spec:
   acme:
-    dns01:
-      providers:
-      - route53:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+    - selector:
+        dnsZones:
+          - "YOUR DOMAIN"
+      dns01:
+        route53:
           region: eu-west-1
           accessKeyID: <USE ACCESS_KEY_ID_CREATED_BEFORE>
           secretAccessKeySecretRef:
             name: aws-cert-manager-access-key
             key: CLIENT_SECRET
-        name: route53
-    email: florent@example.com
-    privateKeySecretRef:
-      name: letsencrypt
-    server: https://acme-v02.api.letsencrypt.org/directory
 EOF
 ----
 


### PR DESCRIPTION
Update instruction to create certificate issuer

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Update Instructions

### What issues does this PR fix or reference?
error: unable to recognize "STDIN": no matches for kind "ClusterIssuer" in version "certmanager.k8s.io/v1alpha1"

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

