### PR TITLE
Add the DEPLOYMENT_NAME parameter to the image puller parameters

### DIFF
--- a/modules/administration-guide/examples/che-proc_deploying-image-puller-using-openshift-templates_parameters.adoc
+++ b/modules/administration-guide/examples/che-proc_deploying-image-puller-using-openshift-templates_parameters.adoc
@@ -3,6 +3,7 @@
 |===
 |Value |Usage |Default
 |`DAEMONSET_NAME` |The value of `DAEMONSET_NAME` to set in the ConfigMap |`{image-puller-deployment-name}`
+|`DEPLOYMENT_NAME` |The value of `DEPLOYMENT_NAME` to set in the ConfigMap |`{image-puller-deployment-name}`
 |`IMAGE` |Image used for the `{image-puller-deployment-name}` deployment |`{image-puller-image-name}`
 |`IMAGE_TAG` |The image tag to pull |`latest`
 |`SERVICEACCOUNT_NAME` |The name of the ServiceAccount used by the deployment (created as part of installation) |`k8s-image-puller`

--- a/modules/administration-guide/partials/con_image-puller-overview.adoc
+++ b/modules/administration-guide/partials/con_image-puller-overview.adoc
@@ -30,7 +30,7 @@ The {image-puller-name-short} loads its configuration from a `ConfigMap` with th
 |`CACHING_CPU_REQUEST` |The CPU request for each cached image when the puller is running |`.05`
 |`CACHING_CPU_LIMIT` |The CPU limit for each cached image when the puller is running |`.2`
 |`DAEMONSET_NAME` |Name of DaemonSet to be created |`{image-puller-deployment-name}`
-|`DEPLOYMENT_NAME` |Name of the Deployment to be created |`kubernetes-image-puller`
+|`DEPLOYMENT_NAME` |Name of the Deployment to be created |`{image-puller-deployment-name}`
 |`NAMESPACE` |Namespace where DaemonSet is to be created |`k8s-image-puller`
 |`IMAGES` |List of images to be cached, in the format `<name>=<image>;...` |Contains a default list of images. Before deploying, fill this with the images that fit the current requirements
 |`NODE_SELECTOR` |Node selector applied to the Pods created by the DaemonSet |`'{}'`

--- a/modules/administration-guide/partials/con_image-puller-overview.adoc
+++ b/modules/administration-guide/partials/con_image-puller-overview.adoc
@@ -7,7 +7,7 @@ Slow starts of {prod} workspaces may be caused by waiting for the underlying clu
 
 The {image-puller-name-short} is an additional deployment that runs alongside {prod}. Given a list of images to pre-pull, the application runs inside a cluster and creates a _DaemonSet_ that pulls the images on each node.
 
-NOTE: The minimal requirement for an image to be pre-pulled is the availability of the `sleep` command, which means that `FROM scratch` images (for example, 'che-machine-exec') are currently not supported. Also, images that mount volumes in the dockerfile are not supported for pre-pulling on OpenShift.
+NOTE: The minimal requirement for an image to be pre-pulled is the availability of the `sleep` command, which means that `FROM scratch` images (for example, 'che-machine-exec') are currently not supported. Also, images that mount volumes in the `Dockerfile` are not supported for pre-pulling on OpenShift.
 
 The application can be deployed:
 
@@ -30,6 +30,7 @@ The {image-puller-name-short} loads its configuration from a `ConfigMap` with th
 |`CACHING_CPU_REQUEST` |The CPU request for each cached image when the puller is running |`.05`
 |`CACHING_CPU_LIMIT` |The CPU limit for each cached image when the puller is running |`.2`
 |`DAEMONSET_NAME` |Name of DaemonSet to be created |`{image-puller-deployment-name}`
+|`DEPLOYMENT_NAME` |Name of the Deployment to be created |`kubernetes-image-puller`
 |`NAMESPACE` |Namespace where DaemonSet is to be created |`k8s-image-puller`
 |`IMAGES` |List of images to be cached, in the format `<name>=<image>;...` |Contains a default list of images. Before deploying, fill this with the images that fit the current requirements
 |`NODE_SELECTOR` |Node selector applied to the Pods created by the DaemonSet |`'{}'`

--- a/modules/administration-guide/partials/proc_deploying-image-puller-using-helm.adoc
+++ b/modules/administration-guide/partials/proc_deploying-image-puller-using-helm.adoc
@@ -21,9 +21,9 @@ The following parameters are available for configuring the installation with Hel
 [options="header",subs="+attributes"]
 |===
 |Value |Usage |Default
-|`appName` |The value of `DAEMONSET_NAME` to be set in the ConfigMap | `{image-puller-image-name}`
-|`image.repository` |The repository to pull the image from | `{image-puller-image-tag}`
-|`image.tag` |The image tag to pull |`latest`
+|`deploymentName` |The value of `DAEMONSET_NAME` and `DEPLOYMENT_NAME` to be set in the ConfigMap | `{image-puller-deployment-name}`
+|`image.repository` |The repository to pull the image from | `{image-puller-image-name}`
+|`image.tag` |The image tag to pull |`{image-puller-image-tag}`
 |`serviceAccount.name` |The name of the ServiceAccount to create |`k8s-image-puller`
 |`configMap.name` |The name of the ConfigMap to create |`k8s-image-puller`
 |`configMap.cachingIntervalHours` |The value of `CACHING_INTERVAL_HOURS` to be set in the ConfigMap |``"1"``


### PR DESCRIPTION
Signed-off-by: Tom George <tgeorge@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?

Add the DEPLOYMENT_NAME parameter to the image puller parameters to allow for setting owner references

### What issues does this PR fix or reference?

part of https://github.com/eclipse/che/issues/16796

### Specify the version of the product this PR applies to.

The soon to be released version of kubernetes-image-puller
### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

