### PR TITLE
Adds docs about how to configure server logging levels.

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -17,6 +17,7 @@
 ** xref:removing-user-data.adoc[]
 
 * xref:retrieving-che-logs.adoc[]
+** xref:configuring-server-logging.adoc[]
 ** xref:viewing-kubernetes-events.adoc[]
 ** xref:viewing-operator-events.adoc[]
 ** xref:viewing-che-server-logs.adoc[]

--- a/modules/administration-guide/pages/configuring-server-logging.adoc
+++ b/modules/administration-guide/pages/configuring-server-logging.adoc
@@ -1,0 +1,7 @@
+[id=configuing-server-logging]
+// = Configuring Server Logging
+:navtitle: Configuring server logging
+:keywords: administration-guide, configuring-server-logging
+:page-aliases: .:configuring-server-logging
+
+include::partial$assembly_configuring-server-logging.adoc[]

--- a/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
@@ -5,11 +5,10 @@
 
 :context: configuring-server-logging
 
-It is possible to fine tune the log levels of individual loggers present in the {prod-short} server.
-The log level of the {prod-short} server is usually configured globally, using the xref:installation-guide:configuring-the-che-installation.adoc#checluster-custom-resources-fields-reference_configuring-the-che-installation[`cheLogLevel` configuration property] of the operator.
+It is possible to fine tune the log levels of individual loggers available in the {prod-short} server.
+The log level of the whole {prod-short} server is configured globally using the xref:installation-guide:configuring-the-che-installation.adoc#checluster-custom-resources-fields-reference_configuring-the-che-installation[`cheLogLevel` configuration property] of the Operator.
 
-However, if it is needed to change the log level selectively for some concrete logger, you can do that using the `CHE_LOGGER_CONFIG` 
-environment variable.
+It is possible to configure the log levels of the individual loggers using the `CHE_LOGGER_CONFIG` environment variable.
 
 include::partial$proc_configuring-server-logging.adoc[leveloffset=+1]
 

--- a/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
@@ -1,0 +1,18 @@
+:parent-context-of-configuring-server-logging: {context}
+
+[id="configuring-sever-logging_{context}"]
+= Configuring server logging
+
+:context: configuring-server-logging
+
+It is possible to fine tune the log levels of individual loggers present in the {prod-short} server.
+The log level of the {prod-short} server is usually configured globally, using the `cheLogLevel` configuration property of the operator.
+
+However, if it is needed to change the log level selectively for some concrete logger, you can do that using the `CHE_LOGGER_CONFIG` 
+environment variable.
+
+include::partial$proc_configuring-server-logging.adoc[leveloffset=+1]
+
+include::partial$con_logger-naming.adoc[leveloffset=+1]
+
+include::partial$con_logging-http-traffic.adoc[leveloffset=+1]

--- a/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
@@ -6,7 +6,7 @@
 :context: configuring-server-logging
 
 It is possible to fine tune the log levels of individual loggers present in the {prod-short} server.
-The log level of the {prod-short} server is usually configured globally, using the `cheLogLevel` configuration property of the operator.
+The log level of the {prod-short} server is usually configured globally, using the xref:installation-guide:configuring-the-che-installation.adoc#checluster-custom-resources-fields-reference_configuring-the-che-installation[`cheLogLevel` configuration property] of the operator.
 
 However, if it is needed to change the log level selectively for some concrete logger, you can do that using the `CHE_LOGGER_CONFIG` 
 environment variable.

--- a/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
@@ -8,8 +8,8 @@
 It is possible to fine-tune the log levels of individual loggers available in the {prod-short} server.
 
 The log level of the whole {prod-short} server is configured globally using the xref:installation-guide:configuring-the-che-installation.adoc#checluster-custom-resources-fields-reference_configuring-the-che-installation[`cheLogLevel` configuration property] of the Operator.
-To set the global log level in installations not managed by the Operator, the `CHE_LOG_LEVEL` environment variable specified in the `che`
-ConfigMap might be used for the same purpose.
+To set the global log level in installations not managed by the Operator, specify the `CHE_LOG_LEVEL` environment variable in the `che`
+ConfigMap.
 
 It is possible to configure the log levels of the individual loggers in the {prod-short} server using the `CHE_LOGGER_CONFIG` environment
 variable.

--- a/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
@@ -5,7 +5,7 @@
 
 :context: configuring-server-logging
 
-It is possible to fine tune the log levels of individual loggers available in the {prod-short} server.
+It is possible to fine-tune the log levels of individual loggers available in the {prod-short} server.
 
 The log level of the whole {prod-short} server is configured globally using the xref:installation-guide:configuring-the-che-installation.adoc#checluster-custom-resources-fields-reference_configuring-the-che-installation[`cheLogLevel` configuration property] of the Operator.
 To set the global log level in installations not managed by the Operator, the `CHE_LOG_LEVEL` environment variable specified in the `che`

--- a/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
@@ -6,9 +6,13 @@
 :context: configuring-server-logging
 
 It is possible to fine tune the log levels of individual loggers available in the {prod-short} server.
-The log level of the whole {prod-short} server is configured globally using the xref:installation-guide:configuring-the-che-installation.adoc#checluster-custom-resources-fields-reference_configuring-the-che-installation[`cheLogLevel` configuration property] of the Operator.
 
-It is possible to configure the log levels of the individual loggers using the `CHE_LOGGER_CONFIG` environment variable.
+The log level of the whole {prod-short} server is configured globally using the xref:installation-guide:configuring-the-che-installation.adoc#checluster-custom-resources-fields-reference_configuring-the-che-installation[`cheLogLevel` configuration property] of the Operator.
+To set the global log level in installations not managed by the Operator, the `CHE_LOG_LEVEL` environment variable specified in the `che`
+ConfigMap might be used for the same purpose.
+
+It is possible to configure the log levels of the individual loggers in the {prod-short} server using the `CHE_LOGGER_CONFIG` environment
+variable.
 
 include::partial$proc_configuring-server-logging.adoc[leveloffset=+1]
 

--- a/modules/administration-guide/partials/assembly_retrieving-che-logs.adoc
+++ b/modules/administration-guide/partials/assembly_retrieving-che-logs.adoc
@@ -9,6 +9,7 @@
 
 For information about obtaining various types of logs in {prod-short}, see the following sections:
 
+* xref:configuring-server-logging.adoc[]
 * xref:viewing-kubernetes-events.adoc[]
 * xref:viewing-che-server-logs.adoc[]
 * xref:viewing-external-service-logs.adoc[]

--- a/modules/administration-guide/partials/con_logger-naming.adoc
+++ b/modules/administration-guide/partials/con_logger-naming.adoc
@@ -1,0 +1,6 @@
+// configuring-server-logging
+
+[id="logger-naming_{context}"]
+= Logger naming
+
+The names of the loggers follow the class names of the internal server classes that use those loggers.

--- a/modules/administration-guide/partials/con_logging-http-traffic.adoc
+++ b/modules/administration-guide/partials/con_logging-http-traffic.adoc
@@ -3,7 +3,7 @@
 [id="logging-http-traffic_{context}"]
 = Logging HTTP traffic
 
-It is possible to log the HTTP traffic between the {prod-short} server and the API server of the Kubernetes/OpenShift cluster.
+It is possible to log the HTTP traffic between the {prod-short} server and the API server of the Kubernetes or OpenShift cluster.
 To do that, one has to set the `che.infra.request-logging` logger to the `TRACE` level.
 
 [source,yaml]

--- a/modules/administration-guide/partials/con_logging-http-traffic.adoc
+++ b/modules/administration-guide/partials/con_logging-http-traffic.adoc
@@ -3,7 +3,7 @@
 [id="logging-http-traffic_{context}"]
 = Logging HTTP traffic
 
-It is possible to log the HTTP traffic between the {prod-short} server and the API server of the Kubernetes or OpenShift cluster.
+It is possible to log the HTTP traffic between the {prod-short} server and the API server of the {kubernetes} or OpenShift cluster.
 To do that, one has to set the `che.infra.request-logging` logger to the `TRACE` level.
 
 [source,yaml]

--- a/modules/administration-guide/partials/con_logging-http-traffic.adoc
+++ b/modules/administration-guide/partials/con_logging-http-traffic.adoc
@@ -10,6 +10,6 @@ To do that, one has to set the `che.infra.request-logging` logger to the `TRACE`
 ----
 ...
 server:
-  cheCustomProperties:
+  customCheProperties:
     CHE_LOGGER_CONFIG: "che.infra.request-logging=TRACE"
 ----

--- a/modules/administration-guide/partials/con_logging-http-traffic.adoc
+++ b/modules/administration-guide/partials/con_logging-http-traffic.adoc
@@ -1,0 +1,15 @@
+// configuring-server-logging
+
+[id="logging-http-traffic_{context}"]
+= Logging HTTP traffic
+
+It is possible to log the HTTP traffic between the {prod-short} server and the API server of the Kubernetes/OpenShift cluster.
+To do that, one has to set the `che.infra.request-logging` logger to the `TRACE` level.
+
+[source,yaml]
+----
+...
+server:
+  cheCustomProperties:
+    CHE_LOGGER_CONFIG: "che.infra.request-logging=TRACE"
+----

--- a/modules/administration-guide/partials/proc_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/proc_configuring-server-logging.adoc
@@ -3,7 +3,7 @@
 [id="configuring-log-levels_{context}"]
 = Configuring log levels
 
-The format of the value of the `CHE_LOGGER_CONFIG` property is a list of comma separated key-value pairs, where keys are the names of the loggers as seen
+The format of the value of the `CHE_LOGGER_CONFIG` property is a list of comma-separated key-value pairs, where keys are the names of the loggers as seen
 in the {prod-short} server log output and values are the required log levels.
 
 In Operator-based deployments, the `CHE_LOGGER_CONFIG` variable is specified under the `customCheProperties` of the custom resource.

--- a/modules/administration-guide/partials/proc_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/proc_configuring-server-logging.adoc
@@ -6,7 +6,7 @@
 The format of the value of the `CHE_LOGGER_CONFIG` property is a list of comma separated key-value pairs, where keys are the names of the loggers as seen
 in the {prod-short} server log output and values are the required log levels.
 
-In Operator-based deployments, the `CHE_LOGGER_CONFIG` variable is specified under the `cheCustomProperties` of the custom resource.
+In Operator-based deployments, the `CHE_LOGGER_CONFIG` variable is specified under the `customCheProperties` of the custom resource.
 
 For example, the following snippet would make the `WorkspaceManager` produce the `DEBUG` log messages.
 
@@ -14,6 +14,6 @@ For example, the following snippet would make the `WorkspaceManager` produce the
 ----
 ...
 server:
-  cheCustomProperties:
+  customCheProperties:
     CHE_LOGGER_CONFIG: "org.eclipse.che.api.workspace.server.WorkspaceManager=DEBUG"
 ----

--- a/modules/administration-guide/partials/proc_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/proc_configuring-server-logging.adoc
@@ -3,10 +3,10 @@
 [id="configuring-log-levels_{context}"]
 = Configuring log levels
 
-The format of the value of the `CHE_LOGGING_CONFIG` property is a list of comma separated key-value pairs, where keys are the names of the loggers as seen
-in the che server log output and values are the required log levels.
+The format of the value of the `CHE_LOGGER_CONFIG` property is a list of comma separated key-value pairs, where keys are the names of the loggers as seen
+in the {prod-short} server log output and values are the required log levels.
 
-In operator-based deployments, you can change the log levels using the `cheCustomProperties`.
+In Operator-based deployments, the `CHE_LOGGER_CONFIG` variable is specified under the `cheCustomProperties` of the custom resource.
 
 For example, the following snippet would make the `WorkspaceManager` produce the `DEBUG` log messages.
 

--- a/modules/administration-guide/partials/proc_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/proc_configuring-server-logging.adoc
@@ -1,0 +1,19 @@
+// configuring-server-logging
+
+[id="configuring-log-levels_{context}"]
+= Configuring log levels
+
+The format of the value of the `CHE_LOGGING_CONFIG` property is a list of comma separated key-value pairs, where keys are the names of the loggers as seen
+in the che server log output and values are the required log levels.
+
+In operator-based deployments, you can change the log levels using the `cheCustomProperties`.
+
+For example, the following snippet would make the `WorkspaceManager` produce the `DEBUG` log messages.
+
+[source,yaml]
+----
+...
+server:
+  cheCustomProperties:
+    CHE_LOGGER_CONFIG: "org.eclipse.che.api.workspace.server.WorkspaceManager=DEBUG"
+----


### PR DESCRIPTION
### What does this PR do?
The administration guide was missing a section on how to configure the log levels of the Che server.

### What issues does this PR fix or reference?
eclipse/che#16616

### Specify the version of the product this PR applies to.
latest

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

