### PR TITLE
Fixing typo in env variable CHE_LIMITS_USER_WORKSPACES_RUN_COUNT and improving docs for PVC Strategy.

### DIFF
--- a/modules/administration-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
+++ b/modules/administration-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
@@ -119,7 +119,7 @@ $ {orch-cli} patch checluster {prod-checluster} --type=json \
   -p '[{"op": "replace", "path": "/spec/storage/pvcStrategy", "value": "per-workspace"}]'
 ----
 
-Depending on the strategy used, replace the `_per-workspace_` option in the above example with `unique` or `common`.
+Depending on the strategy used, replace the `per-workspace` option in the above example with `unique` or `common`.
 
 ////
 .Additional resources

--- a/modules/administration-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
+++ b/modules/administration-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
@@ -116,10 +116,10 @@ $ {orch-cli} apply -f _<my-cluster.yaml>_
 [subs="+quotes,+attributes"]
 ----
 $ {orch-cli} patch checluster {prod-checluster} --type=json \
-  -p '[{"op": "replace", "path": "/spec/storage/pvcStrategy", "value": "__<per-workspace>__"}]'
+  -p '[{"op": "replace", "path": "/spec/storage/pvcStrategy", "value": "__per-workspace__"}]'
 ----
 
-Depending on the strategy used, replace the `_<per-workspace>_` option in the above example with `unique` or `common`.
+Depending on the strategy used, replace the `_per-workspace_` option in the above example with `unique` or `common`.
 
 ////
 .Additional resources

--- a/modules/administration-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
+++ b/modules/administration-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
@@ -30,23 +30,23 @@ WARNING: It is not recommended to reconfigure PVC strategies on an existing {pro
 
 .Procedure
 
-When deploying {prod-short} using Helm Chart, configure the workspace PVC strategy by setting values for the `global.pvcStrategy` option. 
+When deploying {prod-short} using Helm Chart, configure the workspace PVC strategy by setting values for the `global.cheWorkspacesPVCStrategy` option. 
 
-* For a new installation, use the `helm install` command with the `global.pvcStrategy` option:
+* For a new installation, use the `helm install` command with the `global.cheWorkspacesPVCStrategy` option:
 +
 [subs="+quotes"]
 ----
-$ helm install --set global.pvcStrategy=__<per-workspace>__
+$ helm install --set global.cheWorkspacesPVCStrategy=__per-workspace__
 ----
 
-* For an already installed instance, use the `helm upgrade` command with the `global.pvcStrategy` option:
+* For an already installed instance, use the `helm upgrade` command with the `global.cheWorkspacesPVCStrategy` option:
 +
 [subs="+quotes"]
 ----
-$ helm upgrade --set global.pvcStrategy=__<per-workspace>__
+$ helm upgrade --set global.cheWorkspacesPVCStrategy=__per-workspace__
 ----
 
-Depending on the strategy used, replace the `_<per-workspace>_` option in the above examples with `unique` or `common`.
+Depending on the strategy used, replace the `_per-workspace_` option in the above examples with `unique` or `common`.
 
 [id="configuring-a-pvc-strategy-by-editing-a-configmap_{context}"]
 == Configuring a PVC strategy strategy by editing a configMap
@@ -66,10 +66,10 @@ Changes to a configMap created during Operator installation are not permanent be
 +
 [subs="+quotes"]
 ----
-CHE_INFRA_KUBERNETES_PVC_STRATEGY=__<per-workspace>__
+CHE_INFRA_KUBERNETES_PVC_STRATEGY=__per-workspace__
 ----
 +
-Depending on the strategy used, replace the `_<per-workspace>_` option in the above example with `unique` or `common`.
+Depending on the strategy used, replace the `_per-workspace_` option in the above example with `unique` or `common`.
 
 . Restart {prod-short} by scaling the deployment to zero and then back to one again:
 +

--- a/modules/administration-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
+++ b/modules/administration-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
@@ -36,17 +36,17 @@ When deploying {prod-short} using Helm Chart, configure the workspace PVC strate
 +
 [subs="+quotes"]
 ----
-$ helm install --set global.cheWorkspacesPVCStrategy=__per-workspace__
+$ helm install --set global.cheWorkspacesPVCStrategy=per-workspace
 ----
 
 * For an already installed instance, use the `helm upgrade` command with the `global.cheWorkspacesPVCStrategy` option:
 +
 [subs="+quotes"]
 ----
-$ helm upgrade --set global.cheWorkspacesPVCStrategy=__per-workspace__
+$ helm upgrade --set global.cheWorkspacesPVCStrategy=per-workspace
 ----
 
-Depending on the strategy used, replace the `_per-workspace_` option in the above examples with `unique` or `common`.
+Depending on the strategy used, replace the `per-workspace` value in the above examples with `unique` or `common`.
 
 [id="configuring-a-pvc-strategy-by-editing-a-configmap_{context}"]
 == Configuring a PVC strategy strategy by editing a configMap
@@ -66,7 +66,7 @@ Changes to a configMap created during Operator installation are not permanent be
 +
 [subs="+quotes"]
 ----
-CHE_INFRA_KUBERNETES_PVC_STRATEGY=__per-workspace__
+CHE_INFRA_KUBERNETES_PVC_STRATEGY=per-workspace
 ----
 +
 Depending on the strategy used, replace the `_per-workspace_` option in the above example with `unique` or `common`.
@@ -116,7 +116,7 @@ $ {orch-cli} apply -f _<my-cluster.yaml>_
 [subs="+quotes,+attributes"]
 ----
 $ {orch-cli} patch checluster {prod-checluster} --type=json \
-  -p '[{"op": "replace", "path": "/spec/storage/pvcStrategy", "value": "__per-workspace__"}]'
+  -p '[{"op": "replace", "path": "/spec/storage/pvcStrategy", "value": "per-workspace"}]'
 ----
 
 Depending on the strategy used, replace the `_per-workspace_` option in the above example with `unique` or `common`.

--- a/modules/installation-guide/partials/proc_running-more-than-one-workspace-at-a-time.adoc
+++ b/modules/installation-guide/partials/proc_running-more-than-one-workspace-at-a-time.adoc
@@ -34,7 +34,7 @@ endif::[]
 [subs="+quotes,+attributes"]
 ----
 $ {orch-cli} patch checluster {prod-checluster} -n {prod-namespace} --type merge \
-  -p '{ "spec": { "server": {"customCheProperties": {"CHE_LIMITS_USER_WORKSPACE_RUN_COUNT": "-1"} } }}'
+  -p '{ "spec": { "server": {"customCheProperties": {"CHE_LIMITS_USER_WORKSPACES_RUN_COUNT": "-1"} } }}'
 ----
 
 . Set the `per-workspace` or `unique` PVC strategy. See xref:administration-guide:che-workspaces-architecture.adoc#configuring-a-{prod-id-short}-workspace-with-a-persistent-volume-strategy_{prod-id-short}-workspace-configuration[Configuring a {prod-short} workspace with a persistent volume strategy].

--- a/modules/installation-guide/partials/proc_running-more-than-one-workspace-at-a-time.adoc
+++ b/modules/installation-guide/partials/proc_running-more-than-one-workspace-at-a-time.adoc
@@ -26,7 +26,7 @@ ifeval::["{project-context}" == "che"]
 +
 [subs="+quotes,+attributes"]
 ----
-$ helm upgrade che -n {prod-namespace} --set global.workspace.number=-1
+$ helm upgrade che -n {prod-namespace} --set che.limits.userWorkspacesRunCount=-1
 ----
 * For Operator deployments:
 +


### PR DESCRIPTION
### What does this PR do?

1. It fixes a typo in the documentation about CHE_LIMITS_USER_WORKSPACES_RUN_COUNT (made me go in the code to figure out what was wrong)
2. The documentation is wrong when it comes to configuring the workspace PVC strategy using Helm charts (`global.cheWorkspacesPVCStrategy` vs `global.pvcStrategy`).  I preferred how it was done in the documentation, but the helm chart was done differently.  For backward compatibility reason, it is probably easier to change the documentation.
3. The documentation always use `<per-workspace>` when in fact it should be `per-workspace` (which is in line with `common` and `unique`).  

### What issues does this PR fix or reference?
This PR is linked with changes done by https://github.com/eclipse/che/pull/18528

### Specify the version of the product this PR applies to.
7.22.1

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

