### PR TITLE
Removing l0rd from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @rkratky @themr0c @boczkowska @MichalMaler @l0rd
+* @rkratky @themr0c @boczkowska @MichalMaler


### PR DESCRIPTION
### What does this PR do?

Removing myself from codeowners

### What issues does this PR fix or reference?

Starting from yesterday, one engineer amongst eclipse-che-docs-reviewer should be assigned to review a PR in a round robin way (using [GitHub automatic code review assignement](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-organizations-and-teams/managing-code-review-assignment-for-your-team)).

There is no need to have engineer in CODEOWNERS anymore. 

### PR Checklist

As the author of this Pull Request I made sure that:

- [N/A] `vale` has been run successfully against the PR branch
- [N/A] Link checker has been run successfully against the PR branch
- [N/A] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [N/A] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [N/A] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [N/A] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

