### PR TITLE
Add @eclipse/ecd-che-docs-reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @rkratky @themr0c @boczkowska @MichalMaler
+* @rkratky @themr0c @boczkowska @MichalMaler @eclipse/ecd-che-docs-reviewers


### PR DESCRIPTION
### What does this PR do?

Add the team @eclipse/ecd-che-docs-reviewers (cf #1711)

### What issues does this PR fix or reference?

Apparently setting up [GitHub automatic code review assignement](https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-organizations-and-teams/managing-code-review-assignment-for-your-team) was not enough. We have to add the team in CODEOWNERS.

