### PR TITLE
che #18463 Adding clarification that Hosted Che is Eclipse Che hosted by Red Hat

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -25,7 +25,7 @@ templates, see https://github.com/mrksu/newdoc[`+newdoc+` documentation].
 
 * To learn more about the `+test-adoc+` tool validating the topic files, see the https://github.com/jhradilek/check-links[`+test-adoc+`documentation].
 
-* To learn more about Hosted Che, see the
+* To learn more about Eclipse Che hosted by Red Hat, see the
 https://www.eclipse.org/che/docs/che-7/hosted-che/[Hosted Che documentation].
 
 

--- a/modules/hosted-che/pages/hosted-che.adoc
+++ b/modules/hosted-che/pages/hosted-che.adoc
@@ -1,6 +1,6 @@
 [id="hosted-che"]
 // = Hosted Che
-:navtitle: Hosted Che
+:navtitle: Eclipse Che hosted by Red Hat
 :keywords: overview, hosted-che
 :page-aliases: .:hosted-che, overview:hosted-che.adoc 
 

--- a/modules/hosted-che/partials/assembly_hosted-che.adoc
+++ b/modules/hosted-che/partials/assembly_hosted-che.adoc
@@ -3,11 +3,11 @@
 :parent-context-of-hosted-che: {context}
 
 [id="hosted-che_{context}"]
-= Hosted Che
+= Eclipse Che hosted by Red Hat
 
 :context: hosted-che
 
-This section describes procedures to get started with Hosted Che that are not covered by xref:end-user-guide:workspaces-overview.adoc[].
+This section describes procedures to get started with Eclipse Che hosted by Red Hat that are not covered by xref:end-user-guide:workspaces-overview.adoc[].
 
 include::partial$ref_about-hosted-che.adoc[leveloffset=+1]
 

--- a/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
+++ b/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
@@ -25,7 +25,7 @@ Authorization token is missing
 Click here to reload page.
 ----
 
-Also, note that telemetry is enabled in Hosted Che so Woopra / Segment tracking scripts must be explicitly allowed in case being blocked by a browser extension:
+Also, note that telemetry is enabled in Eclipse Che hosted by Red Hat, so Woopra / Segment tracking scripts must be explicitly allowed in case being blocked by a browser extension:
 
 - https://api.segment.io/v1/t 
 - https://static.woopra.com/js/w.js


### PR DESCRIPTION
### What does this PR do?

Adding clarification that Hosted Che is Eclipse Che hosted by Red Hat

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/18463

![image](https://user-images.githubusercontent.com/1461122/101807889-ed81f080-3b15-11eb-9233-cf3c54f101bf.png)


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

