### PR TITLE
Fix linkchecker errors

### DIFF
--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -29,7 +29,7 @@ ignore=
   https://domain.net
   https://codeready.*
   # false positives:
-  https://che.eclipse.org/
+  https://che.eclipse.org*
   https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpsslCAInfo
   https://github.com/eclipse/che-devfile-registry/blob/master/devfiles/quarkus-command-mode/devfile.yaml#L63-L71
   https://github.com/eclipse/che-docs
@@ -42,6 +42,7 @@ ignore=
   https://www.youtube.com/embed/VooNzKxRFgw?rel=0
   https://www.youtube.com/embed/B6aCqywKpyY?rel=0
   https://www.youtube.com/embed/HbTKDlOL1eo?rel=0
+  https://console.aws.amazon.com/*
 
 
 # Checks validity of HTML anchors.

--- a/modules/overview/partials/assembly_introduction-to-eclipse-che.adoc
+++ b/modules/overview/partials/assembly_introduction-to-eclipse-che.adoc
@@ -48,7 +48,7 @@ Visit StackOverflow to help other users of {prod}: link:https://stackoverflow.co
 
 Community blog::
 
-Learn about the latest of {prod} and submit your blog posts to the link:https://medium.com/eclipse-che-blog[{prod} blog].
+Learn about the latest of {prod} and submit your blog posts to the link:https://che.eclipse.org[{prod} blog].
 
 Weekly meetings::
 


### PR DESCRIPTION
* Add https://console.aws.amazon.com/* in the list of websites ignored by linkchecker (need authentication).

* Use https://che.eclipse.org as URL for the blog, for consistency with the link in the headers.

- [x] Link checker has been run successfully against the PR branch
