### PR TITLE
Update vale documentation URL

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -11,7 +11,7 @@
 * Eclipse Che documentation follows the _IBM Style Guide_. If you do not have a paper copy of the style guide, see the
 https://www.ibm.com/developerworks/library/styleguidelines/index.html[developerWorks editorial style guide] on the IBM website. While developerWorks is no longer maintained, it still provides useful reference information.
 
-* To learn more about the tool validating the style, see the https://errata-ai.gitbook.io/vale/[`+vale+` documentation].
+* To learn more about the tool validating the style, see the https://docs.errata.ai/vale/about/[`+vale+` documentation].
 
 * Eclipse Che documentation uses AsciiDoc for markup. To learn more about AsciiDoc syntax, see the https://asciidoctor.org/docs/asciidoc-writers-guide/[AsciiDoc Writer’s Guide].
 
@@ -209,7 +209,7 @@ WARNING: This is not the preferred method. For the supported method, see: xref:b
 * An installation of link:https://github.com/mrksu/newdoc[newdoc].
 
 * An installation of 
-https://errata-ai.gitbook.io/vale/getting-started/installation[vale].
+https://docs.errata.ai/vale/install[vale].
 
 * An installation of https://github.com/linkchecker/linkchecker[linkchecker].
 


### PR DESCRIPTION
### What does this PR do?

Update `CONTRIBUTING.md` with the updated reference to `vale` documentation.

### What issues does this PR fix or reference?

<img width="772" alt="image" src="https://user-images.githubusercontent.com/606959/103228834-feae6800-4931-11eb-8c1e-2637aaf9aaed.png">

### Specify the version of the product this PR applies to.

All

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

