### PR TITLE
Small fixes to vale style specifications

### DIFF
--- a/.vale/styles/CheDocs/Attributes.yml
+++ b/.vale/styles/CheDocs/Attributes.yml
@@ -3,7 +3,7 @@ extends: substitution
 message: Use the attribute '%s' instead of '%s'.
 level: warning
 ignorecase: true
-code: true
+scope: raw
 # swap maps tokens in form of bad: good
 swap:
   Image Puller: image-puller-name-short

--- a/.vale/styles/IBM/Usage.yml
+++ b/.vale/styles/IBM/Usage.yml
@@ -1,4 +1,4 @@
-----
+---
 extends: existence
 message: "Verify your use of '%s' with the word usage guidelines."
 link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#wordlist'

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -58,7 +58,7 @@ components:
     type: chePlugin
   - id: ms-vscode/vscode-github-pullrequest/latest
     type: chePlugin
-  - id: joaompinto/vscode-asciidoctor/latest
+  - id: joaompinto/asciidoctor-vscode/latest
     type: chePlugin
 
 commands:

--- a/tools/test-adoc.sh
+++ b/tools/test-adoc.sh
@@ -15,6 +15,10 @@
 # You should have received a copy of the  GNU General Public License  along
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 # -------------------------------------------------------------------------
 #                            GLOBAL VARIABLES
 # -------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

Fixes some problems I had running `vale` and `test-adoc.sh` locally. And another problem using che-docs `devfile` on https://che.openshift.io.

[🚀 Factory link](https://che.openshift.io/f?url=https://github.com/l0rd/che-docs/tree/small-fixes) to test the PR.

### What issues does this PR fix or reference?

```bash
$ vale --version
vale version 2.6.8
```

1st problem (`.vale/styles/CheDocs/Attributes.yml:6:1`):

```bash
$ vale ./modules/installation-guide/partials/ref_checluster-custom-resource-fields-reference.adoc
E201 Invalid value provided [/Users/mloriedo/GitHub/che-docs/.vale/styles/CheDocs/Attributes.yml:6:1]:

   5  ignorecase: true
   6* code: true
   7  # swap maps tokens in form of bad: good
   8  swap:

`code` is deprecated; please use `scope: raw` instead.

Execution stopped with code 1.
```

2nd problem (`.vale/styles/IBM/Usage.yml:2:1`):

```bash
vale ./modules/installation-guide/partials/ref_checluster-custom-resource-fields-reference.adoc
E201 Invalid value provided [/Users/mloriedo/GitHub/che-docs/.vale/styles/IBM/Usage.yml:2:1]:

   1  ----
   2* extends: existence
   3  message: "Verify your use of '%s' with the word usage guidelines."
   4  link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#wordlist'

mapping values are not allowed in this context

Execution stopped with code 1.
```

3rd problem (`tools/test-adoc.sh `): execution of the script continues even if an error happens

4th problme (`devfile.yaml`):

<img width="460" alt="image" src="https://user-images.githubusercontent.com/606959/103385907-b7280780-4afc-11eb-9720-ae5c0c6114ca.png">

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

