### PR TITLE
Add command to upgrade helm charts to switch to internal cluster service hostnames

### DIFF
--- a/modules/installation-guide/partials/proc_switching-between-external-and-internal-communication.adoc
+++ b/modules/installation-guide/partials/proc_switching-between-external-and-internal-communication.adoc
@@ -30,6 +30,9 @@ The following section describes how to enable and disable the external inter-com
 
 Switching between external and internal inter-component communication method is reached through the update against Custom Resource (CR).
 
+ifeval::["{project-context}" == "che"]
+* For {prod-short} deployed using Operators
+endif::[]
 . To use external {platforms-ingress} in inter-component communication:
 +
 [subs="+quotes,+attributes"]
@@ -45,3 +48,26 @@ $ {orch-cli} patch checluster {prod-checluster} -n {prod-namespace} --type=json 
 $ {orch-cli} patch checluster {prod-checluster} -n {prod-namespace} --type=json -p \
 '[{"op": "replace", "path": "/spec/server/useInternalClusterSVCNames", "value": true}]'
 ----
+
+ifeval::["{project-context}" == "che"]
+* For {prod-short} deployed using a Helm Chart
+
+. Clone the https://github.com/eclipse/che[che] project
+. Go to `deploy/kubernetes/helm/che` directory
+. Update the `global.useInternalClusterSVCNames` property. To do that, add the following option to the `helm upgrade` command:
+- To use external {platforms-ingress} in inter-component communication:
++
+[subs="+quotes,+attributes"]
+----
+$ helm upgrade che -n {prod-namespace} --set global.useInternalClusterSVCNames=false \
+-f values/multi-user.yaml -f values/tls.yaml .
+----
+- To use internal {orch-name} DNS names in the inter-component communication:
++
+[subs="+quotes,+attributes"]
+----
+$ helm upgrade che -n {prod-namespace} --set global.useInternalClusterSVCNames=true  \
+-f values/multi-user.yaml -f values/tls.yaml .
+----
+NOTE: if {prod} has been deployed in single-host mode or without TLS then remove the corresponding flags from the `helm upgrade` command and add others if needed.
+endif::[]


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Add command to upgrade helm charts to switch to internal cluster service hostnames

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18579


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)


![screenshot-0 0 0 0_4000-2020 12 31-10_24_27](https://user-images.githubusercontent.com/1640675/103401724-bd48d300-4b52-11eb-90c9-0b781b7da45c.png)
