### PR TITLE
Use the prod-id-short attribute for pages id

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -32,7 +32,7 @@ runtime:
 asciidoc:
   attributes:
     # for antora
-    context: che@
+    context: che
     experimental: ''
     favicon: favicon.png
     icons: font

--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -6,7 +6,8 @@ maxfilesizeparse=10000000
 maxnumurls=1000000
 maxrunseconds=60
 robotstxt=0
-threads=60
+# Disable threads to avoid false positives on anchors checks
+threads=-1
 timeout=60
 
 [filtering]

--- a/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
@@ -7,7 +7,7 @@
 
 It is possible to fine-tune the log levels of individual loggers available in the {prod-short} server.
 
-The log level of the whole {prod-short} server is configured globally using the xref:installation-guide:configuring-the-che-installation.adoc#checluster-custom-resources-fields-reference_configuring-the-che-installation[`cheLogLevel` configuration property] of the Operator.
+The log level of the whole {prod-short} server is configured globally using the xref:installation-guide:configuring-the-che-installation.adoc#checluster-custom-resources-fields-reference_{context}[`cheLogLevel` configuration property] of the Operator.
 To set the global log level in installations not managed by the Operator, specify the `CHE_LOG_LEVEL` environment variable in the `che`
 ConfigMap.
 

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-using-chectl-and-a-local-devfile.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-using-chectl-and-a-local-devfile.adoc
@@ -11,7 +11,7 @@ A {prod-short} workspace can be created by pointing the `{prod-cli}` tool to a l
 * A running instance of {prod}. To install an instance of {prod}, see xref:installation-guide:installing-che.adoc[].
 * The {prod-short} CLI management tool. See xref:overview:using-the-chectl-management-tool.adoc[].
 * The devfile is available on the local filesystem in the current working directory. See xref:making-a-workspace-portable-using-a-devfile.adoc[] for detailed information about creating and using devfiles.
-* You are logged in to {prod}. See xref:end-user-guide:navigating-che-using-the-dashboard.adoc#logging-in-to-{prod-id-short}-using-{prod-cli}_navigating-{prod-id-short}-using-the-dashboard[How to login into {prod-short} using {prod-cli}]
+* You are logged in to {prod}. See xref:end-user-guide:navigating-che-using-the-dashboard.adoc#logging-in-to-{prod-id-short}-using-{prod-cli}_{context}[Logging in to {prod-short} using {prod-cli}].
 
 +
 .Example

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-using-chectl-and-a-local-devfile.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-using-chectl-and-a-local-devfile.adoc
@@ -11,7 +11,7 @@ A {prod-short} workspace can be created by pointing the `{prod-cli}` tool to a l
 * A running instance of {prod}. To install an instance of {prod}, see xref:installation-guide:installing-che.adoc[].
 * The {prod-short} CLI management tool. See xref:overview:using-the-chectl-management-tool.adoc[].
 * The devfile is available on the local filesystem in the current working directory. See xref:making-a-workspace-portable-using-a-devfile.adoc[] for detailed information about creating and using devfiles.
-* You are logged in to {prod}. See xref:end-user-guide:navigating-{prod-id-short}-using-the-dashboard.adoc#logging-in-to-{prod-id}-using-{prod-cli}_navigating-{prod-id-short}-using-the-dashboard[How to login into {prod-short} using {prod-cli}]
+* You are logged in to {prod}. See xref:end-user-guide:navigating-che-using-the-dashboard.adoc#logging-in-to-{prod-id-short}-using-{prod-cli}_navigating-{prod-id-short}-using-the-dashboard[How to login into {prod-short} using {prod-cli}]
 
 +
 .Example

--- a/modules/end-user-guide/partials/proc_logging-in-to-che-server-using-cli.adoc
+++ b/modules/end-user-guide/partials/proc_logging-in-to-che-server-using-cli.adoc
@@ -1,4 +1,4 @@
-[id="logging-in-to-{prod-id}-using-{prod-cli}_{context}"]
+[id="logging-in-to-{prod-id-short}-using-{prod-cli}_{context}"]
 = Logging in to {prod-short} using {prod-cli}
 
 This section describes how to log in to {prod-short} using {prod-cli} tool by copying login command from {prod} Dashboard.

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -833,7 +833,7 @@ components:
       app: postgres
 ----
 
-Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers present in the resource list. For details of the advanced use case, see xref:creating-and-configuring-a-new-workspace.adoc#defining-specific-container-images_creating-and-configuring-a-new-workspace[Defining specific container images].
+Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers present in the resource list. For details of the advanced use case, see xref:creating-and-configuring-a-new-workspace.adoc#defining-specific-container-images_{context}[Defining specific container images].
 
 == Adding commands to a devfile
 

--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -111,7 +111,7 @@ metadata:
 ----
 <1> target user's username
 
-To configure the labels, set the `CHE_INFRA_KUBERNETES_NAMESPACE_LABELS` to desired labels. To configure the annotations, set the `CHE_INFRA_KUBERNETES_NAMESPACE_ANNOTATIONS` to desired annotations. See the xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc#{prod-id-short}-server-component-system-properties-reference_advanced-configuration-options-for-the-che-server-component[{prod-short} server component system properties reference] for more details.
+To configure the labels, set the `CHE_INFRA_KUBERNETES_NAMESPACE_LABELS` to desired labels. To configure the annotations, set the `CHE_INFRA_KUBERNETES_NAMESPACE_ANNOTATIONS` to desired annotations. See the xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc#{prod-id-short}-server-component-system-properties-reference_{context}[{prod-short} server component system properties reference] for more details.
 
 [WARNING]
 ====

--- a/modules/installation-guide/partials/proc_configuring-workspace-exposure-strategies-using-an-operator.adoc
+++ b/modules/installation-guide/partials/proc_configuring-workspace-exposure-strategies-using-an-operator.adoc
@@ -23,7 +23,7 @@ ifeval::["{project-context}" == "che"]
 * xref:default-host-workspace-exposure-strategy_{context}[`default-host`]
 endif::[]
 
-See xref:workspace-exposure-strategies_configuring-workspace-exposure-strategies[] for more detail about individual strategies.
+See xref:workspace-exposure-strategies_{context}[] for more detail about individual strategies.
 
 To activate changes done to CheCluster YAML file, do one of the following:
 


### PR DESCRIPTION
- Use the prod-id-short attribute for pages id
- Hard-setting the context attribute. See https://docs.antora.org/antora/2.3/playbook/asciidoc-attributes/#hard-set
- Disable threads for linkchecker runs to avoid false positives on anchors checks