### PR TITLE
Add upstream IBM rules

### DIFF
--- a/.vale/styles/IBM/Abbreviations.yml
+++ b/.vale/styles/IBM/Abbreviations.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Do not use periods in all-uppercase abbreviations such as '%s'."
+link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#N100DC'
+level: error
+nonword: true
+tokens:
+  - '\b(?:[A-Z]\.){3,5}'

--- a/.vale/styles/IBM/DashSpacing.yml
+++ b/.vale/styles/IBM/DashSpacing.yml
@@ -1,0 +1,13 @@
+extends: existence
+message: "Add spaces around the dash in '%s'."
+link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#N106BF'
+ignorecase: true
+nonword: true
+level: error
+action:
+  name: edit
+  params:
+    - remove
+    - ' '
+tokens:
+  - '[^\s][—–][^\s]'

--- a/.vale/styles/IBM/Definitions.yml
+++ b/.vale/styles/IBM/Definitions.yml
@@ -1,0 +1,65 @@
+extends: conditional
+message: "Define acronyms and abbreviations (such as '%s') on first occurrence if they're likely to be unfamiliar."
+link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#N100DC'
+level: suggestion
+ignorecase: false
+# Ensures that the existence of 'first' implies the existence of 'second'.
+first: '\b([A-Z]{3,5}s?)\b'
+second: '\(([A-Z]{3,5}s?)\)'
+# ... with the exception of these:
+exceptions:
+  - API
+  - ASP
+  - CLI
+  - CPU
+  - CSS
+  - CSV
+  - DEBUG
+  - DOM
+  - DPI
+  - FAQ
+  - GCC
+  - GDB
+  - GET
+  - GPU
+  - GTK
+  - GUI
+  - HTML
+  - HTTP
+  - HTTPS
+  - IDE
+  - JAR
+  - JSON
+  - JSX
+  - LESS
+  - LLDB
+  - NET
+  - NOTE
+  - NVDA
+  - OSS
+  - PATH
+  - PDF
+  - PHP
+  - POST
+  - RAM
+  - REPL
+  - RSA
+  - SCM
+  - SCSS
+  - SDK
+  - SQL
+  - SSH
+  - SSL
+  - SVG
+  - SWAT
+  - TBD
+  - TCP
+  - TODO
+  - URI
+  - URL
+  - USB
+  - UTF
+  - XML
+  - XSS
+  - YAML
+  - ZIP

--- a/.vale/styles/IBM/Ellipses.yml
+++ b/.vale/styles/IBM/Ellipses.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: "Avoid the ellipsis (...) except to indicate omitted words."
+link: https://www.ibm.com/developerworks/library/styleguidelines/index.html
+nonword: true
+level: warning
+action:
+  name: remove
+tokens:
+  - '\.\.\.'
+  - '…'

--- a/.vale/styles/IBM/Headings.yml
+++ b/.vale/styles/IBM/Headings.yml
@@ -1,0 +1,10 @@
+extends: capitalization
+message: "'%s' should use sentence-style capitalization."
+link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#N1030C'
+level: suggestion
+scope: heading
+match: $sentence
+indicators:
+  - ':'
+exceptions:
+  - IBM

--- a/.vale/styles/IBM/Latin.yml
+++ b/.vale/styles/IBM/Latin.yml
@@ -1,0 +1,13 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#wordlist'
+ignorecase: true
+level: error
+nonword: true
+action:
+  name: replace
+swap:
+  '\b(?:eg|e\.g\.)[\s,]': for example
+  '\b(?:ie|i\.e\.)[\s,]': that is
+  '\betc\.': and so on
+  '\bvs\.': versus

--- a/.vale/styles/IBM/OxfordComma.yml
+++ b/.vale/styles/IBM/OxfordComma.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "Use the Oxford comma in '%s'."
+link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#N106BF'
+level: suggestion
+tokens:
+  - '(?:[^,]+,){1,}\s\w+\sand'

--- a/.vale/styles/IBM/SentenceLength.yml
+++ b/.vale/styles/IBM/SentenceLength.yml
@@ -1,0 +1,7 @@
+extends: occurrence
+message: "Try to keep sentences less than 25 words."
+link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#N106FB'
+scope: sentence
+level: suggestion
+max: 25
+token: \b(\w+)\b

--- a/.vale/styles/IBM/Terms.yml
+++ b/.vale/styles/IBM/Terms.yml
@@ -1,0 +1,197 @@
+extends: substitution
+message: Consider using '%s' instead of '%s'
+link: 'https://www.ibm.com/developerworks/library/styleguidelines/index.html#wordlist'
+level: error
+ignorecase: true
+action:
+  name: replace
+# swap maps tokens in form of bad: good
+swap:
+  '(?:Ctrl|control)-click': press Ctrl and click
+  'a lot(?: of)?': many|much
+  'backward(?:-)?compatible': compatible with earlier versions
+  'bottom(?:-)?left': lower left|lower-left
+  'bottom(?:-)?right': lower right|lower-right
+  'down(?:-)?level': earlier|previous|not at the latest level
+  'mash(?: )?up': create
+  'pop-up (?:blocker|killer)': software to block pop-up ad windows
+  're(?:-)?occur': recur
+  'sort(?:-|/)?merge': sort|merge
+  'top(?:-)?left': upper left|upper right|upper-left|upper-right
+  'top(?:-)?right': upper left|upper right|upper-left|upper-right
+
+  # These are currenly invalid patterns.
+  #
+  # dismiss (a window, a dialog box): close
+  # position (a cursor): move
+  # spawn (a process): create
+  # strike (a key): press|type
+  # touch (a key): press|type
+
+  a number of: several
+  abort: cancel|stop
+  administrate: administer
+  all caps: uppercase
+  and/or: a or b|a, b, or both
+  as long as: if|provided that
+  as per: according to|as|as in
+  back-level: earlier|previous|not at the latest level
+  Big Blue: IBM
+  blink: flash
+  blue screen of death: stop error
+  breadcrumbing: breadcrumb trail
+  canned: preplanned|preconfigured|predefined
+  case insensitive: not case-sensitive
+  catastrophic error: unrecoverable error
+  CBE: Common Base Event
+  CBTS: CICS BTS|BTS
+  cold boot: hardware restart
+  cold start: hardware restart
+  comes with: includes
+  componentization: component-based development|component model|component architecture|shared components
+  componentize: develop components
+  comprised of: consist of
+  connect with: connect to
+  context menu: menu|pop-up menu
+  contextual help: help|context-sensitive help
+  crash: fail|lock up|stop|stop responding
+  CRUD: create retrieve update and delete
+  customer: client
+  datum: data
+  debuggable: debug
+  deconfigure: unconfigure
+  deinstall: uninstall
+  deinstallation: uninstallation
+  demilitarized zone: DMZ
+  demo: demonstration
+  depress: press|type
+  deregister: unregister
+  desire: want|required
+  destroy: delete from the database
+  dismount: demount|unmount|remove
+  do: complete|perform
+  downgrade: upgrade|fallback|fall back|rollback|roll back
+  downward compatible: compatible with earlier versions
+  drag and drop: drag
+  drill up: navigate
+  e-fix: fix|interim fix
+  eFix: fix|interim fix
+  end user: user
+  end-user interface: graphical interface|interface
+  EUI: graphical user interface|interface
+  expose: display|show|make available
+  fill in: complete|enter|specify
+  fixed disk drive: hard disk drive
+  flavor: version|method
+  floppy disk: diskette|diskette drive
+  floppy drive: diskette|diskette drive
+  floppy: diskette|diskette drive
+  forward compatible: compatible with later versions
+  gzip: compress
+  gzipped: archive|compressed file
+  hard drive: hard disk|hard disk drive
+  hard file: hard disk|hard disk drive
+  hence: therefore
+  i-fix: interim fix
+  i-Fix: interim fix
+  IBM's: IBM's|IBM's AIX
+  ifix: interim fix
+  iFix: interim fix
+  in order to: to
+  in other words: for example|that is
+  in spite of: regardless of|despite
+  in the event: in case|if|when
+  inactivate: deactivate
+  information on: information about
+  information technology: IT
+  instead of: rather than
+  insure: ensure
+  Internet address: IP address|URL|Internet email address|web address
+  irrecoverable: unrecoverable
+  jar: compress|archive
+  keep in mind: remember
+  key: type|press
+  laptop: notebook
+  launch: start|open
+  left-hand: left
+  let's: let us
+  leverage: use
+  line cord: power cable|power cord
+  main directory: root directory
+  memory stick: USB flash drive
+  microcomputer: PC
+  motherboard: system board
+  mouse over: point to|move the mouse pointer over|Mouse|mouse over
+  network-centric computing: network computing
+  non-English: in languages other than English|non-English-language
+  nonrecoverable: unrecoverable
+  notion: concept
+  off-premise: on-premises|off-premises|onsite|offsite
+  offline storage: auxiliary storage
+  okay: OK
+  on ramp: access method
+  on the fly: dynamically|as needed|in real time|immediately
+  on the other hand: however|alternatively|conversely
+  on-premise: on-premises|off-premises|onsite|offsite
+  on-ramp: access method
+  pain point: challenge|concern|difficulty|issue
+  parent task: parent process
+  patch: fix|test fix|interim fix|fix pack|program temporary fix
+  perimeter network: DMZ
+  phone: telephone|cell phone|mobile phone
+  power down: turn on|turn off
+  power off: turn on|turn off
+  power on: turn on|turn off
+  preload: preinstall|preinstalled
+  preloaded: preinstall|preinstalled
+  prepend: add a prefix to
+  prior to: before
+  recommend: suggest
+  retry: retry|try again
+  right double-click: double right-click
+  right-hand: right
+  rule of thumb: rule
+  sanity check: test|evaluate
+  secondary storage: auxiliary storage
+  selection button: left mouse button
+  serial database: nonpartitioned database environment
+  shift-click: press Shift and click
+  ship: include|included
+  Simple Object Access Protocol: SOAP
+  single quote mark: single quotation mark
+  single quote: single quotation mark
+  SME routine: session management exit routine
+  start up: start
+  sunset: withdraw from service|withdraw from marketing|discontinue|no longer support
+  switch off: power on|turn on|power off|turn off
+  switch on: power on|turn on|power off|turn off
+  tar: compress|archive
+  tarball: tar file
+  terminate: end|stop
+  thru: through
+  thumbstick: USB flash drive
+  thus: therefore
+  toggle off: toggle
+  tooling: tools
+  touchscreen: touch-sensitive screen
+  transition: make the transition|move|migrate|change
+  transparent: indiscernible|not visible
+  typo: typing error|typographical error
+  uncheck: clear
+  uncompress: decompress
+  undeploy: remove|withdraw
+  unjar: extract
+  unselect: clear|deselect
+  untar: extract
+  unzip: unzip
+  upward compatible: compatible with later versions
+  utilize: use
+  version: create a version|assign a version number
+  versus: compared to
+  via: through
+  warning notice: attention notice
+  web-enable: enable for the web
+  webinar: webinar|webcast|web seminar|web-based event
+  wish: want
+  zero out: zero
+  zip: zip|compress


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Adds missing [upstream](https://github.com/errata-ai/IBM) rules for vale.

### Specify the version of the product this PR applies to.
Current

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

