### PR TITLE
Mount secrets into eclipse-che containers

### DIFF
--- a/modules/end-user-guide/examples/che-ref_a-kubernetes-secret-as-an-variable.adoc
+++ b/modules/end-user-guide/examples/che-ref_a-kubernetes-secret-as-an-variable.adoc
@@ -35,9 +35,9 @@ data:
   mykey: myvalue
 ----
 +
-This results in the environment variable named `FOO_ENV` and the value `myvalue` being provisioned into the container named `maven`.
+This results in the environment variable named `FOO_ENV` and the value `myvalue` being provisioned into the `maven` container.
 +
-*_Since the {prod-short} version 7.15_*, the `target-container` annotation is deprecated and `automount-workspace-secret` annotation with Boolean values is introduced. Its purpose is to define the default secret mounting behavior, with the ability to be overridden in a devfile. The `true` value enables the automatic mounting into all workspace containers. In contrast, the `false` value disables the mounting process until it is explicitly requested in a devfile component using the `automountWorkspaceSecrets:true` property.
+*_Since the {prod-short} version 7.15_*, the `target-container` annotation is deprecated and `automount-workspace-secret` annotation with Boolean values is introduced. Its purpose is to define the default secret mounting behavior, with the ability to be overridden in a devfile. The `true` value enables automatic mounting into all workspace containers. In contrast, the `false` value disables the mounting process until it is explicitly requested in a devfile component using the `automountWorkspaceSecrets:true` property.
 +
 [source,yaml]
 ----

--- a/modules/end-user-guide/examples/che-ref_a-kubernetes-secret-as-an-variable.adoc
+++ b/modules/end-user-guide/examples/che-ref_a-kubernetes-secret-as-an-variable.adoc
@@ -77,6 +77,6 @@ data:
   otherkey: othervalue
 ----
 +
-This results in two environment variables with names `FOO_ENV`, `OTHER_ENV`, and values `myvalue` and `othervalue`, being provisioned into all workpsace containers.
+This results in two environment variables with names `FOO_ENV`, `OTHER_ENV`, and values `myvalue` and `othervalue`, being provisioned into all workspace containers.
 +
 NOTE: The maximum length of annotation names in a {orch-name} secret is 63 characters, where 9 characters are reserved for a prefix that ends with `/`. This acts as a restriction for the maximum length of the key that can be used for the secret.

--- a/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-a-file.adoc
+++ b/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-a-file.adoc
@@ -1,0 +1,48 @@
+.Example:
+
+[source,yaml,subs="+attributes"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-certificate
+  labels:
+    app.kubernetes.io/part-of: che.eclipse.org
+    app.kubernetes.io/component: {prod-deployment}-secret
+...
+----
+
+Annotations must indicate the given secret is mounted as a file, provide the mount path.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-certificate
+  annotations:
+    che.eclipse.org/mount-path: /custom-certificates
+    che.eclipse.org/mount-as: file
+  labels:
+...
+----
+
+Data of the {orch-name} secret may contain several items, whose names must match the desired file name mounted into the container.
+
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-certificate
+  labels:
+    app.kubernetes.io/part-of: che.eclipse.org
+    app.kubernetes.io/component: {prod-deployment}-secret
+  annotations:
+    che.eclipse.org/mount-path: /custom-certificates
+    che.eclipse.org/mount-as: file
+data:
+  ca.crt: __<base64 encoded data content here>__
+----
+
+This results in a file named `ca.crt` being mounted at the `/custom-certificates` path of {prod-short} container.

--- a/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-a-file.adoc
+++ b/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-a-file.adoc
@@ -12,7 +12,7 @@ metadata:
 ...
 ----
 
-Annotations must indicate the given secret is mounted as a file, provide the mount path.
+Annotations must indicate that the given secret is mounted as a file. Set up annotation `che.eclipse.org/mount-path` values to provide a required mount path.
 
 [source,yaml]
 ----
@@ -27,7 +27,7 @@ metadata:
 ...
 ----
 
-Data of the {orch-name} secret may contain several items, whose names must match the desired file name mounted into the container.
+The {orch-name} secret may contain several items whose names must match the desired file name mounted into the container.
 
 [source,yaml,subs="+quotes,attributes"]
 ----

--- a/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-a-file.adoc
+++ b/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-a-file.adoc
@@ -12,7 +12,9 @@ metadata:
 ...
 ----
 
-Annotations must indicate that the given secret is mounted as a file. Set up annotation `che.eclipse.org/mount-path` values to provide a required mount path.
+Annotations must indicate that the given secret is mounted as a file. Set up the annotation values:
+* `che.eclipse.org/mount-as: file` - to indicate that a secret is mounted as a file
+* `che.eclipse.org/mount-path: _<FOO_ENV>_` - to provide a required mount path
 
 [source,yaml]
 ----

--- a/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-an-variable.adoc
+++ b/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-an-variable.adoc
@@ -1,0 +1,55 @@
+.Example:
+
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-settings
+  labels:
+    app.kubernetes.io/part-of: che.eclipse.org
+    app.kubernetes.io/component: {prod-deployment}-secret
+...
+----
+
+Annotations must indicate that the given secret is mounted as an environment variable, provides variable names.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-settings
+  annotations:
+    che.eclipse.org/env-name: FOO_ENV
+    che.eclipse.org/mount-as: env
+  labels:
+   ...
+data:
+  mykey: myvalue
+----
+
+This results in the environment variable named `FOO_ENV` and the value `myvalue` being provisioned into a {prod-short} container.
+
+If the secret provides more than one data item, the environment variable name must be provided for each of the data keys as follows:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-settings
+  annotations:
+    che.eclipse.org/mount-as: env
+    che.eclipse.org/mykey_env-name: FOO_ENV
+    che.eclipse.org/otherkey_env-name: OTHER_ENV
+  labels:
+   ...
+data:
+  mykey: myvalue
+  otherkey: othervalue
+----
+
+This results in two environment variables with names `FOO_ENV`, `OTHER_ENV`, and values `myvalue` and `othervalue`, being provisioned into a  {prod-short} container.
+
+NOTE: The maximum length of annotation names in a {orch-name} secret is 63 characters, where 9 characters are reserved for a prefix that ends with `/`. This acts as a restriction for the maximum length of the key that can be used for the secret.

--- a/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-an-variable.adoc
+++ b/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-an-variable.adoc
@@ -12,10 +12,10 @@ metadata:
 ...
 ----
 
-Annotations must indicate that the given secret is mounted as a file. Set up the annotation values:
+Annotations must indicate that the given secret is mounted as a environment variable. Set up the annotation values:
 
 * `che.eclipse.org/mount-as: env` - to indicate that a secret is mounted as an environment variable
-* `che.eclipse.org/env-name: _<FOO_ENV>_` - to provide an environment variable name, which is required to mount a secret
+* `che.eclipse.org/env-name: _<FOO_ENV>_` - to provide an environment variable name, which is required to mount a secret key value
 
 [source,yaml]
 ----

--- a/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-an-variable.adoc
+++ b/modules/installation-guide/examples/che-ref_a-kubernetes-secret-as-an-variable.adoc
@@ -12,7 +12,10 @@ metadata:
 ...
 ----
 
-Annotations must indicate that the given secret is mounted as an environment variable, provides variable names.
+Annotations must indicate that the given secret is mounted as a file. Set up the annotation values:
+
+* `che.eclipse.org/mount-as: env` - to indicate that a secret is mounted as an environment variable
+* `che.eclipse.org/env-name: _<FOO_ENV>_` - to provide an environment variable name, which is required to mount a secret
 
 [source,yaml]
 ----
@@ -21,7 +24,7 @@ kind: Secret
 metadata:
   name: custom-settings
   annotations:
-    che.eclipse.org/env-name: FOO_ENV
+    che.eclipse.org/env-name: FOO_ENV>
     che.eclipse.org/mount-as: env
   labels:
    ...

--- a/modules/installation-guide/nav.adoc
+++ b/modules/installation-guide/nav.adoc
@@ -45,6 +45,7 @@
 ** xref:importing-untrusted-tls-certificates.adoc[]
 ** xref:switching-between-external-and-internal-communication.adoc[]
 ** xref:setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc[]
+** xref:mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container.adoc[]
 
 * xref:upgrading-che.adoc[]
 

--- a/modules/installation-guide/pages/mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container.adoc
+++ b/modules/installation-guide/pages/mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container.adoc
@@ -1,0 +1,6 @@
+[id="mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container"]
+:navtitle: Mounting a secret as a file or an environment variable into a {prod} container
+:keywords: installation-guide, mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container
+:page-aliases: .:mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container
+
+include::partial$assembly_mounting-secrets-as-file-or-env-variable-in-container.adoc[]

--- a/modules/installation-guide/partials/assembly_advanced-configuration.adoc
+++ b/modules/installation-guide/partials/assembly_advanced-configuration.adoc
@@ -38,5 +38,6 @@ The next sections describe some specific user stories.
 
 * xref:setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc[]
 
+* xref:mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container.adoc[]
 
 :context: {parent-context-of-configuring-che}

--- a/modules/installation-guide/partials/assembly_mounting-secrets-as-file-or-env-variable-in-container.adoc
+++ b/modules/installation-guide/partials/assembly_mounting-secrets-as-file-or-env-variable-in-container.adoc
@@ -1,0 +1,19 @@
+:parent-context-of-mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container: {context}
+
+[id="mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container_{context}"]
+= Mounting a secret as a file or an environment variable into a {prod} container
+
+:context: mounting-a-secret-as-a-file-or-an-environment-variable-into-a-eclipse-che-container
+
+Secrets are {platforms-name} objects that store sensitive data such as user names, passwords, authentication tokens, and configurations in an encrypted form.
+
+Users can mount a secret that contains sensitive data in a {prod} container. A {platforms-name} secret can be mounted into a container as a file or an environment variable
+
+The mounting process uses the standard {platforms-name} mounting mechanism, but it requires additional annotations and labeling.
+
+include::partial$proc_mounting-a-secret-as-a-file-into-a-container.adoc[leveloffset=+1]
+
+include::partial$proc_mounting-a-secret-as-an-environment-variable-into-a-container.adoc[leveloffset=+1]
+
+:context: {parent-context-of-mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container}
+

--- a/modules/installation-guide/partials/assembly_mounting-secrets-as-file-or-env-variable-in-container.adoc
+++ b/modules/installation-guide/partials/assembly_mounting-secrets-as-file-or-env-variable-in-container.adoc
@@ -7,7 +7,10 @@
 
 Secrets are {platforms-name} objects that store sensitive data such as user names, passwords, authentication tokens, and configurations in an encrypted form.
 
-Users can mount a secret that contains sensitive data in a {prod} container. A {platforms-name} secret can be mounted into a container as a file or an environment variable
+Users can mount a {platforms-name} secret that contains sensitive data in a {prod} container as:
+
+* a file
+* an environment variable
 
 The mounting process uses the standard {platforms-name} mounting mechanism, but it requires additional annotations and labeling.
 

--- a/modules/installation-guide/partials/proc_mounting-a-secret-as-a-file-into-a-container.adoc
+++ b/modules/installation-guide/partials/proc_mounting-a-secret-as-a-file-into-a-container.adoc
@@ -7,7 +7,7 @@
 
 .Prerequisites
 
-* A running instance of {prod}. To install an instance of {prod}, see {link-installing-an-instance}.
+* A running instance of {prod-short}. To install an instance of {prod-short}, see {link-installing-an-instance}.
 
 .Procedure
 

--- a/modules/installation-guide/partials/proc_mounting-a-secret-as-a-file-into-a-container.adoc
+++ b/modules/installation-guide/partials/proc_mounting-a-secret-as-a-file-into-a-container.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container
+
+[id="mounting-a-secret-as-a-file-into-a-container_{context}"]
+= Mounting a secret as a file into a {prod} container
+
+.Prerequisites
+
+* A running instance of {prod}. To install an instance of {prod}, see {link-installing-an-instance}.
+
+.Procedure
+
+. Create a new {platforms-name} secret in the {platforms-name} {orch-namespace} where a {prod-short} is deployed. The labels of the secret that is about to be created must match the set of labels:
+
+* `app.kubernetes.io/part-of: che.eclipse.org`
+* `app.kubernetes.io/component: <DEPLOYMENT_NAME>-secret`
+
+Where `<DEPLOYMENT_NAME>` is one of the following deployments: `postgres`, `keycloak`, `devfile-registry`, `plugin-registry` or `{prod-deployment}`
+
+include::example${project-context}-ref_a-kubernetes-secret-as-a-file.adoc[levelofset=+1]

--- a/modules/installation-guide/partials/proc_mounting-a-secret-as-an-environment-variable-into-a-container.adoc
+++ b/modules/installation-guide/partials/proc_mounting-a-secret-as-an-environment-variable-into-a-container.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container
+
+[id="mounting-a-secret-as-an-environment-variable-into-a-container_{context}"]
+= Mounting a secret as an environment variable into a {prod} container
+
+.Prerequisites
+
+* A running instance of {prod}. To install an instance of {prod}, see {link-installing-an-instance}.
+
+.Procedure
+
+. Create a new {platforms-name} secret in the {platforms-name} {orch-namespace} where a {prod-short} is deployed. The labels of the secret that is about to be created must match the set of labels:
+
+* `app.kubernetes.io/part-of: che.eclipse.org`
+* `app.kubernetes.io/component: <DEPLOYMENT_NAME>-secret`
+
+Where `<DEPLOYMENT_NAME>` is one of the following deployments: `postgres`, `keycloak`, `devfile-registry`, `plugin-registry` or `{prod-deployment}`
+
+include::example${project-context}-ref_a-kubernetes-secret-as-an-variable.adoc[levelofset=+1]


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Describes how to mount secrets into eclipse-che containers

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18607

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

