### PR TITLE
Clarify devfile storage locations

### DIFF
--- a/modules/end-user-guide/partials/con_what-is-a-devfile.adoc
+++ b/modules/end-user-guide/partials/con_what-is-a-devfile.adoc
@@ -9,17 +9,17 @@
 
 A devfile is a file that describes and define a development environment:
 
-* the source code
-* the development components, such as browser IDE tools and application runtimes
-* a list of pre-defined commands
-* projects to clone
+* The source code.
+* The development components, such as browser IDE tools and application runtimes.
+* A list of pre-defined commands.
+* Projects to clone.
 
-Devfiles are YAML files that {prod-short} consumes and transforms into a cloud workspace composed of multiple containers. A devfile can be stored remotely or locally, in any number of ways, for example:
+A devfiles is a YAML file that {prod-short} consumes and transforms into a cloud workspace composed of multiple containers. It is possible to store a devfile remotely or locally, in any number of ways, such as:
 
-* In a git repository, in the root folder or on a feature branch
-* On a publicly accessible web server, fetchable via HTTP
-* Locally as a file, and deployed via `{prod-cli}`
-* In a collection of devfiles, known as a xref:administration-guide:customizing-the-registries.adoc#understanding-the-che-registries_{prod-short}[devfile registry]
+* In a git repository, in the root folder, or on a feature branch.
+* On a publicly accessible web server, accessible through HTTP.
+* Locally as a file, and deployed using `{prod-cli}`.
+* In a collection of devfiles, known as a xref:administration-guide:customizing-the-registries.adoc#understanding-the-che-registries_{prod-short}[devfile registry].
 
 When creating a workspace, {prod-short} uses that definition to initiate everything and run all the containers for the required tools and application runtimes. {prod-short} also mounts file-system volumes to make source code available to the workspace.
 
@@ -27,7 +27,7 @@ Devfiles can be versioned with the project source code. When there is a need for
 
 {prod-short} maintains the devfile up-to-date with the tools used in the workspace:
 
-* Projects of the workspace (path, Git location, branch)
-* Commands to perform daily tasks (build, run, test, debug)
-* Runtime environment (container images to run the application)
-* Che-Theia plug-ins with tools, IDE features, and helpers that a developer would use in the workspace (Git, Java support, SonarLint, Pull Request)
+* Elements of the project, such as the path, git location, or branch.
+* Commands to perform daily tasks such as build, run, test, and debug.
+* The runtime environment with its container images needed for the application to run.
+* Che-Theia plug-ins with tools, IDE features, and helpers that a developer would use in the workspace, for example, Git, Java support, SonarLint, and Pull Request.

--- a/modules/end-user-guide/partials/con_what-is-a-devfile.adoc
+++ b/modules/end-user-guide/partials/con_what-is-a-devfile.adoc
@@ -14,7 +14,12 @@ A devfile is a file that describes and define a development environment:
 * a list of pre-defined commands
 * projects to clone
 
-Devfiles are YAML files that {prod-short} consumes and transforms into a cloud workspace composed of multiple containers. The devfile can be saved in the root folder of a Git repository, a feature branch of a Git repository, a publicly accessible destination, or as a separate, locally stored artifact. Devfiles saved in Git repository can use multiple names, such as `devfile.yaml` or `.devfile.yaml`.
+Devfiles are YAML files that {prod-short} consumes and transforms into a cloud workspace composed of multiple containers. A devfile can be stored remotely or locally, in any number of ways, for example:
+
+* In a git repository, in the root folder or on a feature branch
+* On a publicly accessible web server, fetchable via HTTP
+* Locally as a file, and deployed via `{prod-cli}`
+* In a collection of devfiles, known as a xref:administration-guide:customizing-the-registries.adoc#understanding-the-che-registries_{prod-short}[devfile registry]
 
 When creating a workspace, {prod-short} uses that definition to initiate everything and run all the containers for the required tools and application runtimes. {prod-short} also mounts file-system volumes to make source code available to the workspace.
 

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
@@ -5,7 +5,7 @@
 [id="creating-a-workspace-from-the-default-branch-of-a-git-repository_{context}"]
 = Creating a workspace from the default branch of a Git repository
 
-A {prod-short} workspace can be created by pointing to a devfile that is stored in a Git source repository. The {prod-short} instance then uses the discovered link:https://github.com/eclipse/che/blob/master/devfile.yaml[devfile.yaml] file to build a workspace using the `/f?url=` API.
+A {prod-short} workspace can be created by pointing to a devfile that is stored in a Git source repository. The {prod-short} instance then uses the discovered link:https://github.com/eclipse/che/blob/master/devfile.yaml[devfile.yaml] file to build a workspace using the factory URL (`/f?url=`) API.
 
 .Prerequisites
 * A running instance of {prod}. To install an instance of {prod}, see xref:installation-guide:installing-che.adoc[].

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
@@ -5,13 +5,17 @@
 [id="creating-a-workspace-from-the-default-branch-of-a-git-repository_{context}"]
 = Creating a workspace from the default branch of a Git repository
 
-A {prod-short} workspace can be created by pointing to a devfile that is stored in a Git source repository. The {prod-short} instance then uses the discovered link:https://github.com/eclipse/che/blob/master/devfile.yaml[devfile.yaml] file to build a workspace using the factory URL (`/f?url=`) API.
+It is possible to create a {prod-short} workspace by pointing to a devfile that is stored in a Git source repository. The {prod-short} instance then uses the discovered link:https://github.com/eclipse/che/blob/master/devfile.yaml[devfile.yaml] file to build a workspace using the factory URL (`/f?url=`) API.
+
 
 .Prerequisites
+
 * A running instance of {prod}. To install an instance of {prod}, see xref:installation-guide:installing-che.adoc[].
 * The `devfile.yaml` or `.devfile.yaml` file is located in the root folder of a Git repository that is available over HTTPS. See xref:making-a-workspace-portable-using-a-devfile.adoc[] for detailed information about creating and using devfiles.
 
+
 .Procedure
+
 Run the workspace by opening the following URL: `pass:c,a,q[{prod-url}/f?url=https://__<GitRepository>__]`
 
 .Example


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

### What does this PR do?
Clarifies some sections of the `What is a devfile` documentation, to make it better understood where devfiles can be stored/deployed from.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-2300


### Specify the version of the product this PR applies to.
7.x

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

