### PR TITLE
Use certificates from /public-certs

### DIFF
--- a/modules/end-user-guide/examples/che-go-use-self-signed-cert.adoc
+++ b/modules/end-user-guide/examples/che-go-use-self-signed-cert.adoc
@@ -12,6 +12,6 @@ components:
     name: GOPROXY
   - value: 'on'
     name: GO111MODULE
-  - value: '/projects/tls/rootCA.crt'
+  - value: '/public-certs/athens-server.cer'
     name: SSL_CERT_FILE
 ----

--- a/modules/end-user-guide/examples/che-python-use-self-signed-cert.adoc
+++ b/modules/end-user-guide/examples/che-python-use-self-signed-cert.adoc
@@ -6,7 +6,7 @@
     env:
       - name: 'PIP_INDEX_URL'
         value: 'https://<username>:<password>@pypi.company.com/simple'
-      - value: '/public-certs/pi'
+      - value: '/public-certs/pip.cer'
         name: 'PIP_CERT'
   - mountSources: true
     memoryLimit: 512Mi

--- a/modules/end-user-guide/examples/che-python-use-self-signed-cert.adoc
+++ b/modules/end-user-guide/examples/che-python-use-self-signed-cert.adoc
@@ -6,7 +6,7 @@
     env:
       - name: 'PIP_INDEX_URL'
         value: 'https://<username>:<password>@pypi.company.com/simple'
-      - value: '/projects/tls/rootCA.pem'
+      - value: '/public-certs/pi'
         name: 'PIP_CERT'
   - mountSources: true
     memoryLimit: 512Mi
@@ -16,6 +16,6 @@
     env:
       - name: 'PIP_INDEX_URL'
         value: 'https://<username>:<password>@pypi.company.com/simple'
-      - value: '/projects/tls/rootCA.pem'
+      - value: '/public-certs/pip.cer'
         name: 'PIP_CERT'
 ----

--- a/modules/end-user-guide/partials/proc_using-npm-artifact-repositories.adoc
+++ b/modules/end-user-guide/partials/proc_using-npm-artifact-repositories.adoc
@@ -32,7 +32,7 @@ Obtain a server certificate file from the repository server. It is customary for
     image: 'quay.io/eclipse/che-nodejs10-ubi:nightly'
     env:
       -name: NODE_EXTRA_CA_CERTS  
-       value: '/projects/nexus.cer
+       value: '/public-certs/nexus.cer
      - name: NPM_CONFIG_REGISTRY 
        value: 'https://snexus-airgap.apps.acme.com/repository/npm-proxy/'
 ----

--- a/modules/end-user-guide/partials/proc_using-npm-artifact-repositories.adoc
+++ b/modules/end-user-guide/partials/proc_using-npm-artifact-repositories.adoc
@@ -16,7 +16,7 @@ Use the following environment variables for configuration:
 * The URL for the artifact repository: `NPM_CONFIG_REGISTRY`
 * For using a certificate from a file: `NODE_EXTRA_CA_CERTS`
 
-To be able to reference the certificate in a devfile, get a copy of the certificate of the npm repository server and put it inside the `/project` folder. 
+Obtain a server certificate file from the repository server. It is customary for administrators to provide certificates of internal artifact servers as Kubernetes secrets (see xref:installation-guide:importing-untrusted-tls-certificates.adoc[]). The relevant server certificates will be mounted in `/public-certs` in every container in the workspace.
 
 . An example configuration for the use of an internal repository with a self-signed certificate:
 +
@@ -32,7 +32,7 @@ To be able to reference the certificate in a devfile, get a copy of the certific
     image: 'quay.io/eclipse/che-nodejs10-ubi:nightly'
     env:
       -name: NODE_EXTRA_CA_CERTS  
-       value: '/projects/config/tls.crt'
+       value: '/projects/nexus.cer
      - name: NPM_CONFIG_REGISTRY 
        value: 'https://snexus-airgap.apps.acme.com/repository/npm-proxy/'
 ----

--- a/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-go-projects.adoc
+++ b/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-go-projects.adoc
@@ -11,9 +11,7 @@ Go uses certificates from a file defined in the `SSL_CERT_FILE` environment vari
 
 .Procedure
 
-. Obtain the certificate used by the Athens server in the Privacy-Enhanced Mail (PEM) format and place it in the `/projects/tls/rootCA.crt` file to make it accessible from all your containers.
-
-. Right-click the project explorer and select *Upload files* to upload the `rootCA.crt` certificate file to your {prod} workspace.
+. Obtain the certificate used by the Athens server in the Privacy-Enhanced Mail (PEM) format. It is customary for administrators to provide certificates of internal artifact servers as Kubernetes secrets (see xref:installation-guide:importing-untrusted-tls-certificates.adoc[]). The relevant server certificates will be mounted in `/public-certs` in every container in the workspace.
 
 . Add the appropriate environment variables to your devfile:
 +

--- a/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-gradle-projects.adoc
+++ b/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-gradle-projects.adoc
@@ -42,5 +42,7 @@ Certificate was added to keystore
     env:
        -name: JAVA_OPTS
         value: >-
-          -Duser.home=/projects/gradle -Djavax.net.ssl.trustStore=/projects/maven/truststore.jks
+          -Duser.home=/projects/gradle 
+          -Djavax.net.ssl.trustStore=/projects/maven/truststore.jks
+          -Djavax.net.ssl.trustStorePassword=changeit
 ----

--- a/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-gradle-projects.adoc
+++ b/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-gradle-projects.adoc
@@ -9,36 +9,22 @@ Internal artifact repositories often do not have a certificate signed by an auth
 
 .Procedure
 
-. Obtain a server certificate file from the repository server. It is often a file named `tls.crt`.
+. Obtain a server certificate file from the repository server. It is customary for administrators to provide certificates of internal artifact servers as Kubernetes secrets (see xref:installation-guide:importing-untrusted-tls-certificates.adoc[]). The relevant server certificates will be mounted in `/public-certs` in every container in the workspace.
 
-.. Create a Java truststore file:
+.. Copy the original Java truststore file:
 +
 ----
-$ keytool -import -file tls.crt -alias nexus -keystore truststore.jks -storepass changeit
-
-Trust this certificate? [no]:  yes
+$ mkdir /projects/maven
+$ cp $JAVA_HOME/lib/security/cacerts /projects/maven/truststore.jks
+$ chmod +w /projects/maven/truststore.jks
+----
++
+.. Import the certificate into the Java truststore file
++
+----
+$ keytool -import -noprompt -file /public-certs/nexus.cer -alias nexus -keystore /projects/maven/truststore.jks -storepass changeit
 Certificate was added to keystore
-Owner: CN=example.com
-Issuer: CN=example.com
-Serial number: 80ca0f6980c6019a
-Valid from: Thu Feb 06 11:00:29 CET 2020 until: Fri Feb 05 11:00:29 CET 2021
-Certificate fingerprints:
-     MD5:  88:3C:EC:E1:BE:57:DD:9D:46:36:8E:DD:BF:14:04:22
-     SHA1: 08:D8:79:D3:F8:6B:5C:3D:71:AA:23:CA:72:01:47:BD:9D:91:0A:AD
-     SHA256: 5C:BB:66:81:44:D2:50:EE:EB:CE:D6:15:7E:63:E1:9A:71:EA:58:3F:14:01:15:4E:68:5D:71:0A:A0:31:33:29
-Signature algorithm name: SHA256withRSA
-Subject Public Key Algorithm: 4096-bit RSA key
-Version: 3
 
-Extensions:
-
-#1: ObjectId: 2.5.29.17 Criticality=false
-SubjectAlternativeName [
-  DNSName: *.apps.example.com
-]
-
-Trust this certificate? [no]:  yes
-Certificate was added to keystore
 ----
 
 .. Upload the truststore file to `/projects/gradle/truststore.jks` to make it available for all containers.

--- a/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-maven-projects.adoc
+++ b/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-maven-projects.adoc
@@ -9,40 +9,24 @@ Internal artifact repositories often do not have a certificate signed by an auth
 
 .Procedure
 
-. Obtain a server certificate file from the repository server. It is often a file named `tls.crt`.
+. Obtain a server certificate file from the repository server. It is customary for administrators to provide certificates of internal artifact servers as Kubernetes secrets (see xref:installation-guide:importing-untrusted-tls-certificates.adoc[]). The relevant server certificates will be mounted in `/public-certs` in every container in the workspace.
 
-.. Create a Java truststore file:
+.. Copy the original Java truststore file:
 +
 ----
-$ keytool -import -file tls.crt -alias nexus -keystore truststore.jks -storepass changeit
-
-Trust this certificate? [no]:  yes
-Certificate was added to keystore
-Owner: CN=example.com
-Issuer: CN=example.com
-Serial number: 80ca0f6980c6019a
-Valid from: Thu Feb 06 11:00:29 CET 2020 until: Fri Feb 05 11:00:29 CET 2021
-Certificate fingerprints:
-     MD5:  88:3C:EC:E1:BE:57:DD:9D:46:36:8E:DD:BF:14:04:22
-     SHA1: 08:D8:79:D3:F8:6B:5C:3D:71:AA:23:CA:72:01:47:BD:9D:91:0A:AD
-     SHA256: 5C:BB:66:81:44:D2:50:EE:EB:CE:D6:15:7E:63:E1:9A:71:EA:58:3F:14:01:15:4E:68:5D:71:0A:A0:31:33:29
-Signature algorithm name: SHA256withRSA
-Subject Public Key Algorithm: 4096-bit RSA key
-Version: 3
-
-Extensions:
-
-#1: ObjectId: 2.5.29.17 Criticality=false
-SubjectAlternativeName [
-  DNSName: *.apps.example.com
-]
-
-Trust this certificate? [no]:  yes
-Certificate was added to keystore
+$ mkdir /projects/maven
+$ cp $JAVA_HOME/lib/security/cacerts /projects/maven/truststore.jks
+$ chmod +w /projects/maven/truststore.jks
 ----
 +
-.. Upload the truststore file to `/projects/maven/truststore.jks` to make it available for all containers.
+.. Import the certificate into the Java truststore file
++
+----
+$ keytool -import -noprompt -file /public-certs/nexus.cer -alias nexus -keystore /projects/maven/truststore.jks -storepass changeit
+Certificate was added to keystore
 
+----
++
 . Add the truststore file.
 +
 * In the Maven container:

--- a/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-maven-projects.adoc
+++ b/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-maven-projects.adoc
@@ -61,5 +61,6 @@ components:
         -noverify -Xmx1G -XX:+UseG1GC -XX:+UseStringDeduplication
         -Duser.home=/projects/maven
         -Djavax.net.ssl.trustStore=/projects/maven/truststore.jks
+        -Djavax.net.ssl.trustStorePassword=changeit
 [...]
 ----

--- a/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-nuget-projects.adoc
+++ b/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-nuget-projects.adoc
@@ -9,7 +9,7 @@ Internal artifact repositories often do not have a self-signed TLS certificate s
 
 .Procedure
 
-. Obtain the certificate file of a non-standard repository and place it in the `/projects/tls/rootCA.crt` file to make it accessible from all your containers.
+. Obtain the certificate used by the Athens server in the Privacy-Enhanced Mail (PEM) format. It is customary for administrators to provide certificates of internal artifact servers as Kubernetes secrets (see xref:installation-guide:importing-untrusted-tls-certificates.adoc[]). The relevant server certificates will be mounted in `/public-certs` in every container in the workspace.
 
 . Specify the location of the certificate file in the `SSL_CERT_FILE` environment variable in your devfile for the OmniSharp plug-in and for the .NET container.
 +
@@ -22,7 +22,7 @@ components:
     type: chePlugin
     alias: omnisharp
     env:
-     - value: /projects/tls/rootCA.crt
+     - value: /public-certs/nuget.cer
        name: SSL_CERT_FILE
  - mountSources: true
    endpoints:

--- a/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-python-projects.adoc
+++ b/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-python-projects.adoc
@@ -11,7 +11,7 @@ Python uses certificates from a file defined in the `PIP_CERT` environment varia
 
 .Procedure
 
-. Obtain the certificate from the non-standard repository and place the certificate file in the `/projects/tls/rootCA.pem` file to make it accessible from all your containers.
+. Obtain the certificate used by the Athens server in the Privacy-Enhanced Mail (PEM) format. It is customary for administrators to provide certificates of internal artifact servers as Kubernetes secrets (see xref:installation-guide:importing-untrusted-tls-certificates.adoc[]). The relevant server certificates will be mounted in `/public-certs` in every container in the workspace.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Update docs to make use of certificates in `/public-certs`


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18131

### Specify the version of the product this PR applies to.
> 7.24

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

