### PR TITLE
Use eclipse-che as default namespace

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -96,7 +96,7 @@ asciidoc:
     prod-host: che-host
     prod-id-short: che
     prod-id: eclipse-che
-    prod-namespace: che
+    prod-namespace: eclipse-che
     prod-operator: che-operator
     prod-operator-image-name: che-operator
     prod-prev-ver-major: 6

--- a/modules/administration-guide/partials/con_authentication-modes.adoc
+++ b/modules/administration-guide/partials/con_authentication-modes.adoc
@@ -48,7 +48,7 @@ spec:
 +
 [subs="+quotes,+attributes"]
 ----
-$ helm upgrade --install che --force --namespace che --set global.cheDomain=__<{prod-host}>__  -f multi-user.yaml
+$ helm upgrade --install che --force --namespace {prod-namespace} --set global.cheDomain=__<{prod-host}>__  -f multi-user.yaml
 ----
 
 {prod-short} deployed using the `{prod-cli}` command-line tool defaults to single-user mode. To change to multiuser mode:

--- a/modules/administration-guide/partials/proc_verification-custom-registries.adoc
+++ b/modules/administration-guide/partials/proc_verification-custom-registries.adoc
@@ -36,7 +36,7 @@ $ echo $\{INDEX_JSON} | jq '.[] | select(.name == "my-plug-in")'
 }
 ----
 
-. Verify that the {prod-short} server points to the URL of the registry. To do this, compare the value of the `pass:[CHE_WORKSPACE_PLUGIN__REGISTRY__URL]` parameter in the `che` ConfigMap (or `pass:[CHE_WORKSPACE_DEVFILE__REGISTRY__URL]` for the devfile registry):
+. Verify that the {prod-short} server points to the URL of the registry. To do so, compare the value of the `pass:[CHE_WORKSPACE_PLUGIN__REGISTRY__URL]` parameter in the `che` ConfigMap (or `pass:[CHE_WORKSPACE_DEVFILE__REGISTRY__URL]` for the devfile registry):
 +
 [subs="+attributes"]
 ----

--- a/modules/end-user-guide/partials/assembly_workspaces-overview.adoc
+++ b/modules/end-user-guide/partials/assembly_workspaces-overview.adoc
@@ -11,12 +11,12 @@
 
 . The source code of a project.
 . A web-based integrated development environment (IDE).
-. Tool dependencies, needed by developers to work on a project
-. Application runtime: a replica of the environment where the application runs in production
+. Tool dependencies, needed by developers to work on a project.
+. Application runtime: a replica of the environment where the application runs in production.
 
 Pods manage each component of a {prod-short} workspace. Therefore, everything running in a {prod-short} workspace is running inside containers. This makes a {prod-short} workspace highly portable.
 
-The embedded browser-based IDE is the point of access for everything running in a {prod-short} workspace. This makes a {prod-short} workspace easily shareable.
+The embedded browser-based IDE is the point of access for everything running in a {prod-short} workspace. This makes a {prod-short} workspace easy to share.
 
 [IMPORTANT]
 ====

--- a/modules/end-user-guide/partials/assembly_workspaces-overview.adoc
+++ b/modules/end-user-guide/partials/assembly_workspaces-overview.adoc
@@ -24,7 +24,7 @@ By default, it is possible to run only one workspace at a time. To increase the 
 
 [subs="+quotes,+attributes"]
 ----
-$ oc patch checluster {prod-checluster} -n __<user-project-namespace>__ --type=merge \ 
+$ oc patch checluster {prod-checluster} -n {prod-namespace} --type=merge \
 -p '{ "spec": { "server": { "customCheProperties": { "CHE_LIMITS_USER_WORKSPACES_RUN_COUNT": "-1" } } } }'
 ----
 

--- a/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
+++ b/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
@@ -1,5 +1,5 @@
 [id="creating-a-telemetry-plugin_{context}"]
-= Creating A Telemetry Plugin
+= Creating A Telemetry Plug-in
 
 This section shows how to create an `AnalyticsManager` class that extends link:https://github.com/che-incubator/che-workspace-telemetry-client/blob/master/backend-base/src/main/java/org/eclipse/che/incubator/workspace/telemetry/base/AbstractAnalyticsManager.java[`AbstractAnalyticsManager`] and implements the following methods:
 
@@ -8,6 +8,13 @@ This section shows how to create an `AnalyticsManager` class that extends link:h
 * `onActivity()` - notifies that some activity is still happening for a given user. This is mainly used to send `WORKSPACE_INACTIVE` events.
 * `onEvent()` - submits telemetry events to the telemetry server, such as `WORKSPACE_USED` or `WORKSPACE_STARTED`.
 * `increaseDuration()` - increases the duration of a current event rather than sending multiple events in a small frame of time.
+
+The following section covers:
+
+* Creation of a telemetry server to echo events to standard output.
+* Extending the {prod-short} telemetry client and implementing a user's custom back-end.
+* Creating a `meta.yaml` file representing a {prod-short} workspace plug-in for a user's custom back-end.
+* Specifying of a location of a custom plug-in to {prod-short} by setting the `CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR_PLUGINS` environment variable.
 
 == Getting Started
 
@@ -111,8 +118,8 @@ $ mvn quarkus:dev -Dquarkus.http.port=${CHE_WORKSPACE_TELEMETRY_BACKEND_PORT} \
 
 Create two new files in your project:
 
-* `AnalyticsManager.java` contains the logic specific to our telemetry system.
-* `MainConfiguration.java` is the main entrypoint that creates an instance of `AnalyticsManager` and starts listening for events.
+* `AnalyticsManager.java` - contains the logic specific to our telemetry system.
+* `MainConfiguration.java` - is the main entrypoint that creates an instance of `AnalyticsManager` and starts listening for events.
 
 .AnalyticsManager.java
 [source,java]
@@ -148,11 +155,11 @@ It is possible to put more a complex login in `isEnabled()`. For example, the se
 include::example$telemetry/onEvent.java[]
 ----
 
-This sends an HTTP request to the telemetry server and automatically debounces identical events in a small time period (the default is 1500 milliseconds, and it can be changed by subclasses.
+This sends an HTTP request to the telemetry server and automatically debounces identical events in a small time period, where the default value is 1500 milliseconds. It is possible to modify this period by setting subclasses.
 
 == Implementing `increaseDuration()`
 
-Many telemetry systems recognize event duration. The `AbstractAnalyticsManager` merges similar events that happen in the same frame of time into one event, so that you do not get several identical events sent to the server in a small frame of time. This implementation of `increaseDuration()` is a no-op. This method uses the APIs of your telemetry provider to alter the event or event properties to reflect an increased duration of the event.
+Many telemetry systems recognize event duration. The `AbstractAnalyticsManager` merges similar events that happen in the same frame of time into one event, so that a user does not get several identical events sent to the server in a small time frame. This implementation of `increaseDuration()` is a no-op. This method uses the APIs of a user's telemetry provider to alter the event or event properties to reflect an event's increased duration.
 
 .AnalyticsManager.java
 [source,java]
@@ -196,14 +203,16 @@ Create a `meta.yaml` definition representing a {prod-short} plug-in that runs yo
 include::example$telemetry/sample_meta.yaml[]
 ----
 
-Ordinarily, you would deploy this file to a corporate web server. For this guide, we create an Apache web server on OpenShift and host the plug-in there. Create a configMap referencing your new `meta.yaml` file.
+Usually, a user would deploy this file to a corporate web server. For this guide, we create an Apache web server on OpenShift and host the plug-in there.
+
+Create a configMap referencing the new `meta.yaml` file.
 
 [subs="+attributes"]
 ----
 $ oc create configmap --from-file=meta.yaml -n {prod-namespace} telemetry-plugin-meta
 ----
 
-Then create a deployment, a service, and a route to expose the web server. The deployment references this configMap and places it in the `/var/www/html` directory.
+Create a deployment, a service, and a route to expose the web server. The deployment references this configMap and places it in the `/var/www/html` directory.
 
 .manifests.yaml
 [source,yaml,subs="+quotes,+attributes"]
@@ -232,17 +241,9 @@ Update the `CheCluster` Custom Resource, and add the `CHE_WORKSPACE_DEVFILE_DEFA
 include::example$telemetry/che_cluster_with_custom_plugin.yaml[]
 ----
 
-Wait for the {prod-short} server to restart, and create a new workspace. You should see a new message saying that your plug-in is being installed into the workspace.
+Wait for the {prod-short} server to restart, and create a new workspace. See a new message stating that the plug-in is being installed into the workspace.
 
 image::telemetry/custom_telemetry_plugin.png[]
 
-Perform a some operations in the workspace you started. You should see those events in the logs of the example telemetry server.
+Perform any operations in the started workspace and observe their events in the example telemetry server logs.
 
-== Summary
-
-In this guide, you:
-
-* Created a telemetry server to echo events to standard out.
-* Extended the {prod-short} telemetry client and implemented your own custom back-end.
-* Created a `meta.yaml` file to represent a {prod-short} workspace plug-in for your custom back-end.
-* Told {prod-short} where to find your custom plug-in by changing the `CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR_PLUGINS` environment variable.

--- a/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
+++ b/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
@@ -40,7 +40,7 @@ The following Go code starts a server on port 8080 and writes events to standard
 include::example$telemetry/main.go[]
 ----
 
-Create a container image based on this code and expose it as a deployment in OpenShift in the `che` {orch-namespace}. The code for the example telemetry server is available at link:https://github.com/che-incubator/che-workspace-telemetry-example[che-workspace-telemetry-example]. To deploy the telemetry server, clone the repository and build the container:
+Create a container image based on this code and expose it as a deployment in OpenShift in the {prod-namespace} {orch-namespace}. The code for the example telemetry server is available at link:https://github.com/che-incubator/che-workspace-telemetry-example[che-workspace-telemetry-example]. To deploy the telemetry server, clone the repository and build the container:
 
 ----
 $ git clone https://github.com/che-incubator/che-workspace-telemetry-example
@@ -53,7 +53,7 @@ In `manifest.yaml`, replace the `image` and `host` fields to match the image you
 
 [subs="+quotes"]
 ----
-$ kubectl apply -f manifest.yaml -n _<namespace to deploy>_
+$ kubectl apply -f manifest.yaml -n {prod-namespace}
 ----
 
 == Creating a new Maven project

--- a/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
+++ b/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
@@ -9,7 +9,7 @@ This section shows how to create an `AnalyticsManager` class that extends link:h
 * `onEvent()` - submits telemetry events to the telemetry server, such as `WORKSPACE_USED` or `WORKSPACE_STARTED`.
 * `increaseDuration()` - increases the duration of a current event rather than sending multiple events in a small frame of time.
 
-The following section covers:
+The following sections cover:
 
 * Creation of a telemetry server to echo events to standard output.
 * Extending the {prod-short} telemetry client and implementing a user's custom back-end.

--- a/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
+++ b/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
@@ -198,8 +198,9 @@ include::example$telemetry/sample_meta.yaml[]
 
 Ordinarily, you would deploy this file to a corporate web server. For this guide, we create an Apache web server on OpenShift and host the plug-in there. Create a configMap referencing your new `meta.yaml` file.
 
+[subs="+attributes"]
 ----
-$ oc create configmap --from-file=meta.yaml -n che telemetry-plugin-meta
+$ oc create configmap --from-file=meta.yaml -n {prod-namespace} telemetry-plugin-meta
 ----
 
 Then create a deployment, a service, and a route to expose the web server. The deployment references this configMap and places it in the `/var/www/html` directory.
@@ -224,7 +225,7 @@ This command should return the `meta.yaml` file.
 
 == Updating {prod-short} to reference your telemetry plug-in
 
-Update the `CheCluster` Custom Resource, and add the `CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR_PLUGINS` environment variable to `spec.server.customCheProperties`. The value of the environment variable should be the URL of the location of the `meta.yaml` file on your web server.  This can be accomplished by running `oc edit checluster -n che` and typing in the change at the terminal, or by editing the CR in the OpenShift console (*Installed Operators -> {prod} -> {prod} Cluster -> {prod-checluster} -> YAML*).
+Update the `CheCluster` Custom Resource, and add the `CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR_PLUGINS` environment variable to `spec.server.customCheProperties`. The value of the environment variable should be the URL of the location of the `meta.yaml` file on your web server.  This can be accomplished by running `oc edit checluster -n {prod-namespace}` and typing in the change at the terminal, or by editing the CR in the OpenShift console (*Installed Operators -> {prod} -> {prod} Cluster -> {prod-checluster} -> YAML*).
 
 [source,yaml,subs="+quotes,+attributes"]
 ----

--- a/modules/installation-guide/examples/proc_che-uninstalling-che-after-chectl-installation.adoc
+++ b/modules/installation-guide/examples/proc_che-uninstalling-che-after-chectl-installation.adoc
@@ -29,11 +29,11 @@ $ {orch-cli} login -u _<username>_ -p _<password>_ _<cluster_URL>_
 $ {orch-cli} get checluster --all-namespaces -o=jsonpath="{.items[*].metadata.namespace}"
 ----
 
-. Remove the {prod-short} instance from the _<namespace>_ {orch-namespace}:
+. Remove the {prod-short} instance from the {prod-namespace} {orch-namespace}:
 +
 [subs="+quotes,attributes"]
 ----
-$ {prod-cli} server:delete -n _<namespace>_
+$ {prod-cli} server:delete -n {prod-namespace}
 ----
 +
 [NOTE]
@@ -41,9 +41,9 @@ $ {prod-cli} server:delete -n _<namespace>_
 When the name of the {orch-namespace} containing the {prod-short} instance is `{prod-namespace}`, the `-n` argument is not necessary.
 ====
 
-. Remove the  _<namespace>_ {orch-namespace}:
+. Remove the {prod-namespace} {orch-namespace}:
 +
 [subs="+quotes,attributes"]
 ----
-$ {orch-cli} delete namespaces __<namespace>__
+$ {orch-cli} delete namespaces {prod-namespace}
 ----

--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -42,7 +42,7 @@ $ helm upgrade --namespace <namespace>
 <1> - {prod-short} workspace namespace configuration
 endif::[]
 
-NOTE: The underlying environmant variable that {prod-short} server uses is `CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT`.
+NOTE: The underlying environment variable that {prod-short} server uses is `CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT`.
 
 WARNING: `CHE_INFRA_KUBERNETES_NAMESPACE` and `CHE_INFRA_OPENSHIFT_PROJECT` are legacy variables. Keep these variables unset for a new installations. Changing these variables during an update can lead to data loss.
 

--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -84,6 +84,7 @@ ifeval::["{project-context}" == "che"]
 [subs="+quotes,+attributes"]
 ----
 $ helm ... --set global.cheWorkspacesNamespace=__{prod-workspace}__-__<username>__
+----
 endif::[]
 ====
 
@@ -112,6 +113,7 @@ ifeval::["{project-context}" == "che"]
 [subs="+quotes,+attributes"]
 ----
 $ helm ... --set global.cheWorkspacesNamespace=__{prod-workspace}__-__<workspaceID>__
+----
 endif::[]
 ====
 
@@ -140,6 +142,7 @@ ifeval::["{project-context}" == "che"]
 [subs="+quotes,+attributes"]
 ----
 $ helm ... --set global.cheWorkspacesNamespace=__{prod-workspace}__
+----
 endif::[]
 ====
 

--- a/modules/installation-guide/partials/proc_configuring-the-che-operator-checluster-resource-with-kubectl.adoc
+++ b/modules/installation-guide/partials/proc_configuring-the-che-operator-checluster-resource-with-kubectl.adoc
@@ -7,7 +7,7 @@ Edit the CheCluster custom resource configuration with kubectl:
 
 [subs="+attributes"]
 ----
-kubectl edit CheCluster/eclipse-che -n che
+kubectl edit CheCluster/eclipse-che -n {prod-namespace}
 ----
 
 For more details on configuring CheCluster custom resource, see xref:installation-guide:configuring-the-che-installation.adoc[]

--- a/modules/installation-guide/partials/proc_configuring-workspace-exposure-strategies-using-a-helm-chart.adoc
+++ b/modules/installation-guide/partials/proc_configuring-workspace-exposure-strategies-using-a-helm-chart.adoc
@@ -8,7 +8,7 @@
 
 A link:https://helm.sh/[Helm Chart] is a {kubernetes} extension for defining, installing, and upgrading {kubernetes} applications.
 
-.Procedure 
+.Procedure
 
 When deploying {prod-short} using the Helm chart, configure the workspace exposure strategy using the `global.serverStrategy`.  For single-host, optional `global.singleHostExposure` and `cheSinglehostGateway.deploy` properties may be configured as well. To do so, add the following option to the `helm install` or `helm upgrade` command:
 
@@ -38,9 +38,9 @@ The supported values for `global.serverStrategy` are:
 
 Single-host on Kubernetes has 2 implementations, `native`(default) and `gateway`. To deploy with `gateway` use:
 
-[subs="+quotes"]
+[subs="+quotes,+attributes"]
 ----
-$ helm install --namespace __<namespace>__ \
+$ helm install --namespace {prod-namespace} \
 --set global.serverStrategy=single-host \
 --set global.singleHostExposure=gateway \
 --set cheSinglehostGateway.deploy=true
@@ -48,9 +48,9 @@ $ helm install --namespace __<namespace>__ \
 
 or:
 
-[subs="+quotes"]
+[subs="+quotes,+attributes"]
 ----
-$ helm upgrade --install che --namespace __<namespace>__ \
+$ helm upgrade --install che --namespace {prod-namespace} \
 --set global.serverStrategy=single-host \
 --set global.singleHostExposure=gateway \
 --set cheSinglehostGateway.deploy=true
@@ -58,8 +58,8 @@ $ helm upgrade --install che --namespace __<namespace>__ \
 
 Alternatively, predefined values file can be used as follows:
 
-[subs="+quotes"]
+[subs="+quotes,+attributes"]
 ----
-$ helm upgrade --install che --namespace __<namespace>__ \
+$ helm upgrade --install che --namespace {prod-namespace} \
 -f "${SOURCE_HOME_DIR}"/deploy/kubernetes/helm/che/values/single-host-gateway.yaml
 ----

--- a/modules/installation-guide/partials/proc_configuring-workspace-exposure-strategies-using-an-operator.adoc
+++ b/modules/installation-guide/partials/proc_configuring-workspace-exposure-strategies-using-an-operator.adoc
@@ -64,7 +64,7 @@ $ {orch-cli} patch checluster {prod-checluster} --type=json \
   -p '[{"op": "replace",
   "path": "/spec/server/serverExposureStrategy",
   "value": "__<exposure-strategy>__"}]' \ <1>
-  -n __<namespace-name>__
+  -n {prod-namespace}
 ----
 <1> - used workspace exposure strategy
 

--- a/modules/installation-guide/partials/proc_deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc
+++ b/modules/installation-guide/partials/proc_deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc
@@ -34,7 +34,7 @@ In the command, substitute `_<host:port>_` for the host and port of the HTTPS co
 ====
 * When `githost` is not specified, the given certificate is used for all HTTPS repositories.
 * The certificate file must be named `ca.crt`.
-* Certificate files are typically stored as Base64 ASCII files, such as. `.pem`, `.crt`, `.ca-bundle`. Also, they can be encoded as binary data, for example, `.cer`.  All `Secrets` that hold certificate files should use the Base64 ASCII certificate rather than the binary data certificate. 
+* Certificate files are typically stored as Base64 ASCII files, such as. `.pem`, `.crt`, `.ca-bundle`. Also, they can be encoded as binary data, for example, `.cer`.  All `Secrets` that hold certificate files should use the Base64 ASCII certificate rather than the binary data certificate.
 ====
 
 . Configure the workspace exposure strategy:
@@ -47,9 +47,9 @@ ifeval::["{project-context}" == "che"]
 . Go to `deploy/kubernetes/helm/che` directory
 . Update the `global.useGitSelfSignedCerts` property. To do that, add the following option to the `helm upgrade` command:
 +
-[subs="+quotes"]
+[subs="+quotes,+attributes"]
 ----
-$ helm upgrade che -n che --set global.useGitSelfSignedCerts=true \
+$ helm upgrade che -n {prod-namespace} --set global.useGitSelfSignedCerts=true \
   --set global.ingressDomain=__<kubernetes-cluster-domain>__ .
 ----
 

--- a/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates-old.adoc
+++ b/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates-old.adoc
@@ -153,9 +153,9 @@ For a {prod-short} link:https://helm.sh/[Helm Chart] deployment:
 . Go to the `deploy/kubernetes/helm/che` directory.
 . Update the name of the configMap {prod-short} will use, by editing the `global.tls.serverTrustStoreConfigMapName` Helm Chart property to match the created or updated ConfigMap:
 +
-[subs="+quotes",options="nowrap",role=white-space-pre]
+[subs="+quotes,+attributes",options="nowrap",role=white-space-pre]
 ----
-$ helm upgrade che -n che --set global.tls.serverTrustStoreConfigMapName=<config-map-name> \
+$ helm upgrade che -n {prod-namespace} --set global.tls.serverTrustStoreConfigMapName=<config-map-name> \
    --set global.ingressDomain=__<kubernetes-cluster-domain>__ .
 ----
 +

--- a/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates-old.adoc
+++ b/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates-old.adoc
@@ -54,7 +54,7 @@ include::example$snip_importing-untrusted-tls-certificates_1.adoc[]
 +
 [subs="+attributes,+quotes"]
 ----
-$ {orch-cli} create configmap ca-certs --from-file=__<certificate-file-path>__ -n=__<{project-context}-namespace-name>__
+$ {orch-cli} create configmap ca-certs --from-file=__<certificate-file-path>__ -n={prod-namespace}
 ----
 +
 To apply more than one certificate, add another `--from-file=_<certificate-file-path>_` option to the above command.
@@ -98,7 +98,7 @@ retrieve the name of the ConfigMap by reading the `spec.server.ServerTrustStoreC
 
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} get checluster {prod-checluster} -n __<{project-context}-namespace-name>__ -o jsonpath={.spec.server.serverTrustStoreConfigMapName}
+$ {orch-cli} get checluster {prod-checluster} -n {prod-namespace} -o jsonpath={.spec.server.serverTrustStoreConfigMapName}
 ----
 ====
 ifeval::["{project-context}" == "che"]
@@ -126,7 +126,7 @@ include::example$snip_importing-untrusted-tls-certificates_1.adoc[]
 +
 [subs="+attributes,+quotes"]
 ----
-$ {orch-cli} create configmap __<config-map-name>__ --from-file=__<certificate-file-path>__ -n=__<{project-context}-namespace-name>__ -o yaml --dry-run | {orch-cli} apply -f -
+$ {orch-cli} create configmap __<config-map-name>__ --from-file=__<certificate-file-path>__ -n={prod-namespace} -o yaml --dry-run | {orch-cli} apply -f -
 ----
 +
 To apply more than one certificate, add another `--from-file=_<certificate-file-path>_` option to the above command.
@@ -140,7 +140,7 @@ For a {prod-short} link:https://docs.openshift.com/container-platform/latest/ope
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} patch checluster {prod-checluster} -n __<{project-context}-namespace-name>__ --type=json -p '[{"op": "replace", "path": "/spec/server/serverTrustStoreConfigMapName", "value": "<config-map-name>"}]'
+$ {orch-cli} patch checluster {prod-checluster} -n {prod-namespace} --type=json -p '[{"op": "replace", "path": "/spec/server/serverTrustStoreConfigMapName", "value": "<config-map-name>"}]'
 ----
 +
 ====
@@ -167,9 +167,9 @@ endif::[]
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ kubectl rollout restart -n __<{project-context}-namespace-name>__ deployment/{prod-id-short}-operator
-$ kubectl rollout restart -n __<{project-context}-namespace-name>__ deployment/keycloak
-$ kubectl rollout restart -n __<{project-context}-namespace-name>__ deployment/{prod-id-short}
+$ kubectl rollout restart -n {prod-namespace} deployment/{prod-id-short}-operator
+$ kubectl rollout restart -n {prod-namespace} deployment/keycloak
+$ kubectl rollout restart -n {prod-namespace} deployment/{prod-id-short}
 ----
 +
 [NOTE]
@@ -192,28 +192,28 @@ If you added the certificates without error, the {prod-short} server starts and 
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} get -o json checluster/{prod-checluster} -n __<{project-context}-namespace-name>__ | jq .spec.server.serverTrustStoreConfigMapName
+$ {orch-cli} get -o json checluster/{prod-checluster} -n {prod-namespace} | jq .spec.server.serverTrustStoreConfigMapName
 ----
 +
 . {prod-short} Pod Volumes list contains one Volume that uses the ConfigMap as data-source. To get the list of Volumes of the {prod-short} Pod:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} get pod -o json __<{prod-id-short}-pod-name>__ -n __<{project-context}-namespace-name>__ | jq .spec.volumes
+$ {orch-cli} get pod -o json __<{prod-id-short}-pod-name>__ -n {prod-namespace} | jq .spec.volumes
 ----
 +
 . {prod-short} mounts certificates in folder `/public-certs/` of the {prod-short} server container. This command returns the list of files in that folder:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} exec -t __<{prod-id-short}-pod-name>__ -n __<{project-context}-namespace-name>__ -- ls /public-certs/
+$ {orch-cli} exec -t __<{prod-id-short}-pod-name>__ -n {prod-namespace} -- ls /public-certs/
 ----
 +
 . In the {prod-short} server logs there is a line for every certificate added to the Java truststore, including configured {prod-short} certificates.
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} logs __<{prod-id-short}-pod-name>__ -n __<{project-context}-namespace-name>__
+$ {orch-cli} logs __<{prod-id-short}-pod-name>__ -n {prod-namespace}
 (...)
 Found a custom cert. Adding it to java trust store based on /usr/lib/jvm/java-1.8.0/jre/lib/security/cacerts
 (...)
@@ -276,7 +276,7 @@ manually-added-certificate.crt
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} get -o json pod __<workspace pod name>__ -n __<workspace namespace>__ | \
+$ {orch-cli} get -o json pod __<workspace pod name>__ -n {prod-namespace} | \
     jq '.spec.volumes[] | select(.configMap.name == "ca-certs")'
 {
   "configMap": {

--- a/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates.adoc
+++ b/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates.adoc
@@ -107,9 +107,9 @@ Upgrade {prod-short} Helm Chart:
 . Go to the `deploy/kubernetes/helm/che` directory.
 . Update the name of the configMap {prod-short} will use, by editing the `global.tls.serverTrustStoreConfigMapName` Helm Chart property to match the created or updated ConfigMap:
 +
-[subs="+quotes",options="nowrap",role=white-space-pre]
+[subs="+quotes,+attributes",options="nowrap",role=white-space-pre]
 ----
-$ helm upgrade che -n che --set global.tls.serverTrustStoreConfigMapName=<config-map-name> .
+$ helm upgrade che -n {prod-namespace} --set global.tls.serverTrustStoreConfigMapName=<config-map-name> .
 ----
 +
 When using Minikube to run {prod-short}, substitute _<kubernetes-cluster-domain>_ with `$(minikube ip).nip.io`.

--- a/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates.adoc
+++ b/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates.adoc
@@ -58,7 +58,7 @@ include::example$snip_importing-untrusted-tls-certificates_1.adoc[]
 +
 [subs="+attributes,+quotes"]
 ----
-$ {orch-cli} create configmap custom-certs --from-file=__<bundle-file-path>__ -n=__<{project-context}-namespace-name>__
+$ {orch-cli} create configmap custom-certs --from-file=__<bundle-file-path>__ -n={prod-namespace}
 ----
 +
 To apply more than one bundle, add another `--from-file=_<bundle-file-path>_` flag to the above command.
@@ -124,12 +124,13 @@ If after adding the certificates something does not work as expected, here is a 
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} get cm --selector=app.kubernetes.io/component=ca-bundle,app.kubernetes.io/part-of=che.eclipse.org -n __<{project-context}-namespace-name>__
+$ {orch-cli} get cm --selector=app.kubernetes.io/component=ca-bundle,app.kubernetes.io/part-of=che.eclipse.org -n {prod-namespace}
 ----
 +
 And to check content of ConfigMap:
+[subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} get cm __<name>__ -n __<{project-context}-namespace-name>__ -o yaml
+$ {orch-cli} get cm __<name>__ -n {prod-namespace} -o yaml
 ----
 
 - {prod-short} Pod Volumes list contains a volume that uses `ca-certs-merged` ConfigMap as data-source.
@@ -137,21 +138,21 @@ To get the list of Volumes of the {prod-short} Pod:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} get pod -o json __<{prod-id-short}-pod-name>__ -n __<{project-context}-namespace-name>__ | jq .spec.volumes
+$ {orch-cli} get pod -o json __<{prod-id-short}-pod-name>__ -n {prod-namespace} | jq .spec.volumes
 ----
 +
 - {prod-short} mounts certificates in folder `/public-certs/` of the {prod-short} server container. This command returns the list of files in that folder:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} exec -t __<{prod-id-short}-pod-name>__ -n __<{project-context}-namespace-name>__ -- ls /public-certs/
+$ {orch-cli} exec -t __<{prod-id-short}-pod-name>__ -n {prod-namespace} -- ls /public-certs/
 ----
 +
 - In the {prod-short} server logs there is a line for every certificate added to the Java truststore, including configured {prod-short} certificates.
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ {orch-cli} logs __<{prod-id-short}-pod-name>__ -n __<{project-context}-namespace-name>__
+$ {orch-cli} logs __<{prod-id-short}-pod-name>__ -n {prod-namespace}
 ----
 +
 - {prod-short} server Java truststore contains the certificates. The certificates SHA1 fingerprints are among the list of the SHA1 of the certificates included in the truststore returned by the following command:

--- a/modules/installation-guide/partials/proc_installing-cert-manager.adoc
+++ b/modules/installation-guide/partials/proc_installing-cert-manager.adoc
@@ -31,9 +31,10 @@ $ kubectl apply \
 
 . Create the *che* {orch-namespace} if it does not already exist:
 +
+[subs="+attributes"]
 ----
-$ kubectl create namespace che
-namespace/che created
+$ kubectl create namespace {prod-namespace}
+namespace/{prod-namespace} created
 ----
 
 . Create the certificate issuer. Enter your email address in the *email* field and set *clientID*, *CLIENT_SECRET* *subscriptionID*, *tenantID*, *hostedZoneName*  fields:

--- a/modules/installation-guide/partials/proc_installing-cert-manager.adoc
+++ b/modules/installation-guide/partials/proc_installing-cert-manager.adoc
@@ -106,8 +106,9 @@ $  kubectl logs -f -n cert-manager cert-manager-8d478bb45-2924h
 
 . Ensure that the certificate is ready:
 +
+[subs="+attributes"]
 ----
-$ kubectl describe certificate/che-tls -n che
+$ kubectl describe certificate/che-tls -n {prod-namespace}
 
 Status:
   Conditions:

--- a/modules/installation-guide/partials/proc_installing-cert-manager.adoc
+++ b/modules/installation-guide/partials/proc_installing-cert-manager.adoc
@@ -6,25 +6,29 @@
 = Installing cert-manager on Azure
 
 
+.Prerequisites
+
+* The `{orch-cli}` tool is available.
+
 .Procedure
 
 . To install the cert-manager on Azure, create the *cert-manager* namespace:
 +
 ----
-$ kubectl create namespace cert-manager
+$ {orch-cli} create namespace cert-manager
 namespace/cert-manager created
 
-$ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+$ {orch-cli} label namespace cert-manager certmanager.k8s.io/disable-validation=true
 ----
 
 +
 ----
-$ kubectl apply \
+$ {orch-cli} apply \
   -f https://github.com/jetstack/cert-manager/releases/download/v0.15.0/cert-manager.yaml
 ----
 
 ----
-$ kubectl apply \
+$ {orch-cli} apply \
  --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.0/cert-manager.crds.yaml
 ----
 
@@ -33,14 +37,14 @@ $ kubectl apply \
 +
 [subs="+attributes"]
 ----
-$ kubectl create namespace {prod-namespace}
+$ {orch-cli} create namespace {prod-namespace}
 namespace/{prod-namespace} created
 ----
 
 . Create the certificate issuer. Enter your email address in the *email* field and set *clientID*, *CLIENT_SECRET* *subscriptionID*, *tenantID*, *hostedZoneName*  fields:
 +
 ----
-cat <<EOF | kubectl apply -f -
+cat <<EOF | {orch-cli} apply -f -
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
@@ -77,7 +81,7 @@ EOF
 . Create the certificate. Edit the domain name:
 +
 ----
-cat <<EOF | kubectl apply -f -
+cat <<EOF | {orch-cli} apply -f -
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
@@ -102,14 +106,14 @@ The cert-manager logs contain information about the DNS challenge.
 . Obtain the logs using the following command (here, `cert-manager-8d478bb45-2924h` is the name of the cert-manager Pod):
 +
 ----
-$  kubectl logs -f -n cert-manager cert-manager-8d478bb45-2924h
+$  {orch-cli} logs -f -n cert-manager cert-manager-8d478bb45-2924h
 ----
 
 . Ensure that the certificate is ready:
 +
 [subs="+attributes"]
 ----
-$ kubectl describe certificate/che-tls -n {prod-namespace}
+$ {orch-cli} describe certificate/che-tls -n {prod-namespace}
 
 Status:
   Conditions:
@@ -130,7 +134,7 @@ Events:
 . Wait for the status to show *OK* and ensure that the log contains the following:
 +
 ----
-$ kubectl describe certificate/che-tls -n {prod-namespace}
+$ {orch-cli} describe certificate/che-tls -n {prod-namespace}
 Name:         che-tls
 Namespace:    che
 Labels:       <none>

--- a/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
@@ -55,11 +55,11 @@ oc v3.11.0+0cbc58b
 
 . Run the following command to create the {prod-short} instance
 +
-** In the user-defined _<namespace>_:
+** In the {prod-namespace} {orch-namespace}:
 +
 [subs="+quotes,+attributes",options="nowrap"]
 ----
-$ {prod-cli} server:deploy -n _<namespace>_ -p openshift
+$ {prod-cli} server:deploy -n {prod-namespace} -p openshift
 ----
 
 ** In the default {orch-namespace} called {prod-namespace}:

--- a/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
+++ b/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
@@ -301,10 +301,10 @@ $ kubectl apply \
 
 . Create the {prod-short} {orch-namespace} if it does not already exist:
 +
-[subs="+quotes",options="nowrap"]
+[subs="+quotes,+attributes",options="nowrap"]
 ----
-$ kubectl create namespace che
-namespace/che created
+$ kubectl create namespace {prod-namespace}
+namespace/{prod-namespace} created
 ----
 
 . Create the *cert-manager* user:

--- a/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
+++ b/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
@@ -476,9 +476,9 @@ I0730 14:47:03.220952       1 dns.go:124] Waiting DNS record TTL (60s) to allow 
 
 . Ensure that the certificate is ready:
 +
-[subs="+quotes",options="nowrap"]
+[subs="+quotes,+attributes",options="nowrap"]
 ----
-$ kubectl describe certificate/che-tls -n che
+$ kubectl describe certificate/che-tls -n {prod-namespace}
 Status:
   Conditions:
     Last Transition Time:  2019-07-30T14:46:23Z
@@ -501,9 +501,9 @@ I0729 13:56:26.140886       1 conditions.go:143] Found status change for Certifi
 
 . Ensure that the status is up-to-date using the following command:
 +
-[subs="+quotes",options="nowrap"]
+[subs="+quotes,+attributes",options="nowrap"]
 ----
-$ kubectl describe certificate/che-tls -n che
+$ kubectl describe certificate/che-tls -n {prod-namespace}
 
 Status:
   Conditions:

--- a/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
+++ b/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
@@ -11,7 +11,7 @@ on Amazon Elastic Compute Cloud (Amazon EC2).
 .Prerequisites
 
 * A running instance of {kubernetes}, version 1.9 or higher, and Ingress.
-* The `{orch-cli} ` tool installed.
+* The `{orch-cli}` tool installed.
 * The `{prod-cli}` tool installed.
 
 
@@ -122,10 +122,10 @@ Your cluster eu.aws.my-ide.cloud is ready
 +
 [subs="+quotes",options="nowrap"]
 ----
-$ kubectl config current-context
+$ {orch-cli} config current-context
 eu.aws.my-ide.cloud
 
-$ kubectl get pods --all-namespaces
+$ {orch-cli} get pods --all-namespaces
 
 All the pods in the running state are displayed.
 ----
@@ -139,7 +139,7 @@ To install Ingress-nginx:
 +
 [subs="+quotes",options="nowrap"]
 ----
-$ kubectl apply \
+$ {orch-cli} apply \
   -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.41.0/deploy/static/provider/aws/deploy.yaml
 ----
 +
@@ -147,7 +147,7 @@ The following output confirms that the Ingress controller is running.
 +
 [subs="+quotes",options="nowrap"]
 ----
-$ kubectl get pods --namespace ingress-nginx
+$ {orch-cli} get pods --namespace ingress-nginx
 NAME                                        READY   STATUS    RESTARTS   AGE
 nginx-ingress-controller-76c86d76c4-gswmg   1/1     Running   0          9m3s
 ----
@@ -156,14 +156,14 @@ nginx-ingress-controller-76c86d76c4-gswmg   1/1     Running   0          9m3s
 +
 [subs="+quotes",options="nowrap"]
 ----
-$ kubectl get services --namespace ingress-nginx -o jsonpath='{.items[].status.loadBalancer.ingress[0].hostname}'
+$ {orch-cli} get services --namespace ingress-nginx -o jsonpath='{.items[].status.loadBalancer.ingress[0].hostname}'
 Ade9c9f48b2cd11e9a28c0611bc28f24-1591254057.eu-west-1.elb.amazonaws.com
 ----
 +
 *Troubleshooting*: If the output is empty, it implies that the cluster has configuration issues. Use the following command to find the cause of the issue:
 +
 ----
-$ kubectl describe service -n ingress-nginx ingress-nginx
+$ {orch-cli} describe service -n ingress-nginx ingress-nginx
 ----
 +
 Output similar to the following means a needed role must be created manually:
@@ -284,9 +284,9 @@ image::installation/create-policy-review-policy.png[link="../_images/installatio
 +
 [subs="+quotes",options="nowrap"]
 ----
-$ kubectl create namespace cert-manager
+$ {orch-cli} create namespace cert-manager
 namespace/cert-manager created
-$ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+$ {orch-cli} label namespace cert-manager certmanager.k8s.io/disable-validation=true
 namespace/cert-manager labeled
 ----
 
@@ -294,7 +294,7 @@ namespace/cert-manager labeled
 +
 [subs="+quotes",options="nowrap"]
 ----
-$ kubectl apply \
+$ {orch-cli} apply \
   -f https://github.com/jetstack/cert-manager/releases/download/v0.15.0/cert-manager.yaml \
   --validate=false
 ----
@@ -303,7 +303,7 @@ $ kubectl apply \
 +
 [subs="+quotes,+attributes",options="nowrap"]
 ----
-$ kubectl create namespace {prod-namespace}
+$ {orch-cli} create namespace {prod-namespace}
 namespace/{prod-namespace} created
 ----
 
@@ -345,7 +345,7 @@ IMPORTANT: Remember the access key for later use.
 +
 [subs="+quotes",options="nowrap"]
 ----
-$ kubectl create secret generic aws-cert-manager-access-key \
+$ {orch-cli} create secret generic aws-cert-manager-access-key \
   --from-literal=CLIENT_SECRET=<REPLACE WITH SecretAccessKey content> -n cert-manager
 ----
 
@@ -390,7 +390,7 @@ image::installation/create-policy-review.png[link="../_images/installation/creat
 . To create the certificate issuer, change the email address and specify the `accessKeyID`:
 +
 ----
-$ cat <<EOF | kubectl apply -f -
+$ cat <<EOF | {orch-cli} apply -f -
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
@@ -419,7 +419,7 @@ EOF
 . Add the certificate by editing the domain name value (`aws.my-ide.cloud`, in this case) and the `dnsName` value:
 +
 ----
-$ cat <<EOF | kubectl apply -f -
+$ cat <<EOF | {orch-cli} apply -f -
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
@@ -451,7 +451,7 @@ The cert-manager logs contain information about the DNS challenge.
 +
 [subs="+quotes",options="nowrap"]
 ----
-$ kubectl get pods --namespace cert-manager
+$ {orch-cli} get pods --namespace cert-manager
 NAME                                       READY   STATUS    RESTARTS   AGE
 cert-manager-6587688cb8-wj68p              1/1     Running   0          6h
 cert-manager-cainjector-76d56f7f55-zsqjp   1/1     Running   0          6h
@@ -463,7 +463,7 @@ cert-manager-webhook-7485dd47b6-88m6l      1/1     Running   0          6h
 +
 [subs="+quotes",options="nowrap"]
 ----
-$ kubectl logs -f cert-manager-8d478bb45-sdfmz -n cert-manager
+$ {orch-cli} logs -f cert-manager-8d478bb45-sdfmz -n cert-manager
 I0730 14:46:25.382385       1 sync.go:274] Need to create 0 challenges
 I0730 14:46:25.382401       1 sync.go:319] Waiting for all challenges for order "che-tls-3365293372" to enter 'valid' state
 I0730 14:46:25.382431       1 controller.go:204] cert-manager/controller/orders "level"=0 "msg"="finished processing work item" "key"="che/che-tls-3365293372"
@@ -478,7 +478,7 @@ I0730 14:47:03.220952       1 dns.go:124] Waiting DNS record TTL (60s) to allow 
 +
 [subs="+quotes,+attributes",options="nowrap"]
 ----
-$ kubectl describe certificate/che-tls -n {prod-namespace}
+$ {orch-cli} describe certificate/che-tls -n {prod-namespace}
 Status:
   Conditions:
     Last Transition Time:  2019-07-30T14:46:23Z
@@ -503,7 +503,7 @@ I0729 13:56:26.140886       1 conditions.go:143] Found status change for Certifi
 +
 [subs="+quotes,+attributes",options="nowrap"]
 ----
-$ kubectl describe certificate/che-tls -n {prod-namespace}
+$ {orch-cli} describe certificate/che-tls -n {prod-namespace}
 
 Status:
   Conditions:


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Use `eclipse-che` as a default namespace instead of `che`


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

