### PR TITLE
[backport] Add Bitbucket authentication topic

### DIFF
--- a/modules/administration-guide/examples/snip_bitbucket-personal-access-token-secret.adoc
+++ b/modules/administration-guide/examples/snip_bitbucket-personal-access-token-secret.adoc
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bitbucket-personal-access-token-secret
+  labels:
+    app.kubernetes.io/part-of: che.eclipse.org
+    app.kubernetes.io/component: scm-personal-access-token
+  annotations:
+    che.eclipse.org/expired-after: '-1'
+    che.eclipse.org/che-userid: '355d1ce5-990e-401e-9a8c-094bca10b5b3'
+    che.eclipse.org/scm-userid: '2'
+    che.eclipse.org/scm-username: 'user-foo'
+    che.eclipse.org/scm-url: 'https://bitbucket.apps.cluster-example.com'
+data:
+  token: TlRnNE1UazRORFl5TWpNeU9sMTI1aDFFT2dRbXBlTUYvbmhiLzNQUC9hT08=

--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -15,6 +15,7 @@
 ** xref:authorizing-users.adoc[]
 ** xref:configuring-authorization.adoc[]
 ** xref:removing-user-data.adoc[]
+** xref:authenticating-users-3rd-party-services.adoc[]
 
 * xref:retrieving-che-logs.adoc[]
 ** xref:configuring-server-logging.adoc[]

--- a/modules/administration-guide/pages/authenticating-users-3rd-party-services.adoc
+++ b/modules/administration-guide/pages/authenticating-users-3rd-party-services.adoc
@@ -1,0 +1,7 @@
+[id="authenticating-users-3rd-party-services"]
+// = Authenticating users on 3-rd party services
+:navtitle: Authenticating users on 3-rd party services
+:keywords: administration-guide, authenticating-users
+:page-aliases: .:authenticating-users-3rd party services
+
+include::partial$assembly_authenticating-users-on-3rd-party-services.adoc[]

--- a/modules/administration-guide/partials/assembly_authenticating-users-on-3rd-party-services.adoc
+++ b/modules/administration-guide/partials/assembly_authenticating-users-on-3rd-party-services.adoc
@@ -1,0 +1,15 @@
+
+:parent-context-of-authorizing-users: {context}
+
+[id="authenticating-users-on-3rd-party-services_{context}"]
+= Authenticating users on 3-rd party services
+
+:context: authenticating-users-on-3rd-party-services
+
+This topic covers authentication of users on 3-rd party services such as Bitbucket.
+
+include::partial$proc_configuring_bitbucket_servers.adoc[leveloffset=+1]
+
+include::partial$proc_configuring_bitbucket_authentication.adoc[leveloffset=+1]
+
+:context: {parent-context-of-authorizing-users}

--- a/modules/administration-guide/partials/assembly_managing-users.adoc
+++ b/modules/administration-guide/partials/assembly_managing-users.adoc
@@ -17,4 +17,6 @@ This section describes how to configure authorization and authentication in {pro
 
 * xref:removing-user-data.adoc[]
 
+* xref:authenticating-users-3rd-party-services.adoc[]
+
 :context: {parent-context-of-managing-users}

--- a/modules/administration-guide/partials/proc_configuring_bitbucket_authentication.adoc
+++ b/modules/administration-guide/partials/proc_configuring_bitbucket_authentication.adoc
@@ -1,0 +1,69 @@
+// configuring-bitbucket-authentication
+
+[id="configuring_bitbucket_authentication_{context}"]
+= Authentication on Bitbucket servers
+
+{prod} users may use public or private repositories Bitbucket SCM (Source Code Management) system as a source of their projects. The standard
+factory flow using devfile at the root of the repository is available starting of 7.25 version of {prod}.
+
+The use of private repositories, requires some additional configuration described below.
+
+Bitbucket authentication is based on using personal access tokens. Each Bitbucket user is able to request some
+amount of personal access tokens with different names, permissions, expiration times, and so on. Those tokens
+can be used to sign Bitbucket REST API calls and perform Git repository operations.
+
+To allow Bitbucket authentication on {prod} side, personal tokens must be stored in user's namespace in a form of
+secret. The secret must look as follows:
+
+[source,yaml]
+----
+include::example$snip_bitbucket-personal-access-token-secret.adoc[]
+----
+
+The main parts of the secret are:
+
+[cols=3*]
+|===
+| Label
+| `app.kubernetes.io/component`
+| Indicates it is a SCM personal token secret. 
+
+| Annotation
+| `che.eclipse.org/che-userid`
+| {prod} id of the user token belongs to
+
+| Annotation
+| `che.eclipse.org/scm-userid`
+| Bitbucket user id to which token belongs
+
+| Annotation
+| `che.eclipse.org/scm-username`
+| Bitbucket user name to which token belongs
+
+| Annotation
+| `che.eclipse.org/scm-url`
+| Bitbucket server URL to which this token belong
+
+| Annotation
+| `che.eclipse.org/expired-after`
+| Personal access token expiration time
+
+| Data entry
+| `token`
+| Base-64 encoded value of the personal access token
+
+|===
+
+Bitbucket user id can be obtained with call to REST API:
+----
+https://{bitbucket-hostname}/rest/api/1.0/users/{username}
+----
+
+and for {prod} the user API URL is
+----
+https://{che-hostname}/api/user
+----
+
+Using the token credential provided in this secret, another one is automatically created to allow authorized Git operations. It will be mount
+into workspace containers as Git credentials file. Users don't have to perform any additional configurations to be able to work
+with private Git repositories.

--- a/modules/administration-guide/partials/proc_configuring_bitbucket_authentication.adoc
+++ b/modules/administration-guide/partials/proc_configuring_bitbucket_authentication.adoc
@@ -4,7 +4,7 @@
 = Authentication on Bitbucket servers
 
 {prod} users may use public or private repositories Bitbucket SCM (Source Code Management) system as a source of their projects. The standard
-factory flow using devfile at the root of the repository is available starting of 7.25 version of {prod}.
+factory flow using devfile at the root of the repository is available starting of 7.24 version of {prod}.
 
 The use of private repositories, requires some additional configuration described below.
 

--- a/modules/administration-guide/partials/proc_configuring_bitbucket_servers.adoc
+++ b/modules/administration-guide/partials/proc_configuring_bitbucket_servers.adoc
@@ -1,0 +1,13 @@
+// configuring-bitbucket-servers
+
+[id="configuring_bitbucket_servers_{context}"]
+= Configuring Bitbucket servers
+
+
+To make it possible to use the Bitbucket server as a project sources supplier, 
+Bitbucket server URL should be registered on {prod} using the `CHE_INTEGRATION_BITBUCKET_SERVER__ENDPOINTS` property.
+Value of the property must contain the hostname of the server to register.
+Examples on how to change configuration options using Helm/Operator can be found here:
+
+* xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc[]
+


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
This is the 7.24.x backport of original PR https://github.com/eclipse/che-docs/pull/1788 because feature is wanted in CRW 2.6
Code backport is https://github.com/eclipse/che/pull/18804

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

