### PR TITLE
chore(linkchecker) Use of che-docs image to find linkchecker

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -26,4 +26,4 @@ jobs:
           ./node_modules/.bin/gulp &
           sleep 10
           # Run link checker
-          docker run --net=host --rm -v $(pwd):/doc linkchecker/linkchecker -f /doc/linkcheckerrc http://localhost:4000
+          docker run --net=host --rm -v $(pwd):/doc --entrypoint=bash quay.io/eclipse/che-docs -c "/usr/bin/linkchecker -f /doc/linkcheckerrc http://localhost:4000"


### PR DESCRIPTION

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Use linkchecker provided by che-docs image instead of the official image

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18865

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

Change-Id: I80126fa4c2a8026e87508c8a23e57ac492768613
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
