### PR TITLE
Use the linkchecker configuration in GitHub action

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -23,4 +23,4 @@ jobs:
           gulp &
           sleep 20
           # Run link checker
-          linkchecker -f /doc/linkcheckerrc http://localhost:4000
+          linkchecker -f linkcheckerrc http://localhost:4000


### PR DESCRIPTION
Fix this error:

```
WARNING linkcheck.cmdline 2021-02-11 09:39:52,408 MainThread Unreadable config file: '/doc/linkcheckerrc'
```

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

