### PR TITLE
fixing podman error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,7 +19,7 @@ const watchPatterns = playbook.content.sources.filter((source) => !source.url.in
 }, [])
 
 
-function generate (done) {
+async function generate (done) {
   generator(antoraArgs, process.env)
     .then(() => done())
     .catch((err) => {


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?

When I was running the ./tools/podmanpreview.sh script, the following errors occurred:
* The following tasks did not complete: default, generate
* Did you forget to signal async completion?

@themr0c advised me to add the `async` part for the `function generate` function in the following code:


async function generate (done) {
  generator(antoraArgs, process.env)
    .then(() => done())
    .catch((err) => {
      console.log(err)
      done()
    })
}


### What issues does this PR fix or reference?
Fixing the following errors:

* The following tasks did not complete: default, generate
* Did you forget to signal async completion?




