### PR TITLE
Improving the Hosted Che EOL warning

### DIFF
--- a/modules/hosted-che/partials/assembly_hosted-che.adoc
+++ b/modules/hosted-che/partials/assembly_hosted-che.adoc
@@ -7,7 +7,7 @@
 
 :context: hosted-che
 
-WARNING: link:https://che.openshift.io[Eclipse Che hosted by Red Hat] is going to be shut down on **March 1, 2021 at 00:01 GMT**. A new service based on link:https://developers.redhat.com/developer-sandbox#assembly-field-sections-59571[CodeReady Workspaces] is available now. Details about the new service, including signing up for it, can be found link:https://developers.redhat.com/developer-sandbox[here].
+WARNING: link:https://che.openshift.io[Eclipse Che hosted by Red Hat] is going to be shut down on **March 1, 2021 at 00:01 GMT**. A new service based on link:https://developers.redhat.com/developer-sandbox#assembly-field-sections-59571[CodeReady Workspaces] is available now. link:https://developers.redhat.com/developer-sandbox[Developer Sandbox for Red Hat OpenShift] provides more details about the new service.
 
 This section describes procedures to get started with Eclipse Che hosted by Red Hat that are not covered by xref:end-user-guide:workspaces-overview.adoc[].
 


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Improving the Hosted Che EOL warning

![image](https://user-images.githubusercontent.com/1461122/108093745-589ff400-707e-11eb-90f4-0ab197b70ab1.png)


### What issues does this PR fix or reference?
N/A

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

