### PR TITLE
Fix self-signed certificates usage in Maven projects

### DIFF
--- a/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-maven-projects.adoc
+++ b/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-maven-projects.adoc
@@ -42,7 +42,7 @@ Certificate was added to keystore
     env:
        -name: MAVEN_OPTS
         value: >-
-          -Duser.home=/projects/maven -Djavax.net.ssl.trustStore=/projects/maven/truststore.jks
+          -Duser.home=/projects/maven -Djavax.net.ssl.trustStore=/projects/maven/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit
 ----
 +
 .. Restart the workspace.


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Fix self-signed certificates usage in Maven projects

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1538


As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

