### PR TITLE
Fix release script and documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,22 +1,3 @@
-# Eclipse Che release process
+# Eclipse Che Docs release
 
-##### 1. Create branch for release preparation and next bugfixes:
-* `git branch {branchname} #e.g 7.7.x`
-* `git push --set-upstream origin {branchname}`
-##### 2. Create PR for switch master to the next development version :
-* `git branch set_next_version_in_master_{next_version} #e.g 7.8.0-SNAPSHOT`
-* `mvn versions:set versions:commit -DnewVersion=${next_version}`
-* Update parent version : `mvn versions:update-parent  versions:commit -DallowSnapshots=true -DparentVersion={next_version}`
-* `git push --set-upstream origin set_next_version_in_master_{next_version}`
-* Create PR
-##### 3. Merge branch to the `release` branch and push changes, release process will start by webhook:
-* `git checkout release`
-* `git merge -X theirs {branchname}`
-* `git push -f`
-##### 4. Close/release staging repository on Nexus 
- https://oss.sonatype.org/#stagingRepositories
-
- > **Note:** For bugfix release procedure will be similar except creating new branch on first step and update version in master branch
-
-# Script
-`make-release.sh` performs the first 3 steps. Release to Nexus is still a manual process for now.
+See `release.yml` workflow, which performs release procedures for Che Docs.

--- a/make-release.sh
+++ b/make-release.sh
@@ -15,7 +15,7 @@ while [[ "$#" -gt 0 ]]; do
     '-t'|'--trigger-release') TAG_RELEASE=1; docommit=1; shift 0;;
     '-v'|'--version') VERSION="$2"; shift 1;;
     '-n'|'--nocommit') docommit=0; shift 0;;
-    '-tmp'|'--use-tmp-dir') USE_TMP_DIR=0; shift 0;;
+    '-tmp'|'--use-tmp-dir') USE_TMP_DIR=1; shift 0;;
   esac
   shift 1
 done

--- a/make-release.sh
+++ b/make-release.sh
@@ -39,7 +39,7 @@ if [[ ! ${VERSION} ]]; then
   exit 1
 fi
 
-if [[ ${USE_TMP_DIR} ]]; then
+if [[ ${USE_TMP_DIR} -eq 1 ]]; then
   cd /tmp/ && tmpdir=tmp-${0##*/}-$VERSION && git clone $REPO $tmpdir && cd /tmp/$tmpdir
 fi
 
@@ -95,7 +95,9 @@ bump_version() {
     git commit -s -m "${COMMIT_MSG}" $playbookfile
     git pull origin "${BUMP_BRANCH}"
 
+    set +e
     PUSH_TRY="$(git push origin "${BUMP_BRANCH}")"
+
     # shellcheck disable=SC2181
     if [[ $? -gt 0 ]] || [[ $PUSH_TRY == *"protected branch hook declined"* ]] || [[ $PUSH_TRY == *"Protected branch update"* ]]; then
     PR_BRANCH=pr-${BUMP_BRANCH}-to-${NEXTVERSION}
@@ -107,6 +109,7 @@ bump_version() {
       lastCommitComment="$(git log -1 --pretty=%B)"
       hub pull-request -f -m "${lastCommitComment}" -b "${BUMP_BRANCH}" -h "${PR_BRANCH}"
     fi 
+    set -e
   fi
   git checkout ${CURRENT_BRANCH}
 }
@@ -150,6 +153,6 @@ if [[ $TAG_RELEASE -eq 1 ]]; then
   git push origin "${VERSION}" || true
 fi
 
-if [[ ${USE_TMP_DIR} ]]; then
+if [[ ${USE_TMP_DIR} -eq 1 ]]; then
   rm -fr /tmp/$tmpdir
 fi


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Fix release script using improper variable.
Remove old documentation in RELEASE.md

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

