### PR TITLE
New URL for olm-what-operators-are.html

### DIFF
--- a/modules/installation-guide/partials/con_understanding-the-checluster-custom-resource.adoc
+++ b/modules/installation-guide/partials/con_understanding-the-checluster-custom-resource.adoc
@@ -28,7 +28,7 @@ Role of the {orch-name} platform::
 
 .Additional resources
 
-* link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Understanding Operators].
+* link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Understanding Operators].
 
 * link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Understanding Custom Resources].
 

--- a/modules/installation-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
+++ b/modules/installation-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
@@ -90,7 +90,7 @@ The following section describes how to configure workspace persistent volume cla
 
 WARNING: It is not recommended to reconfigure PVC strategies on an existing {prod-short} cluster with existing workspaces. Doing so causes data loss.
 
-link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operators] are software extensions to {platforms-name} that use link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Custom Resources] to manage applications and their components.
+link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operators] are software extensions to {platforms-name} that use link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Custom Resources] to manage applications and their components.
 
 When deploying {prod-short} using the Operator, configure the intended strategy by modifying the `spec.storage.pvcStrategy` property of the CheCluster Custom Resource object YAML file.
 

--- a/modules/installation-guide/partials/proc_configuring-workspace-exposure-strategies-using-an-operator.adoc
+++ b/modules/installation-guide/partials/proc_configuring-workspace-exposure-strategies-using-an-operator.adoc
@@ -5,7 +5,7 @@
 [id="configuring-workspace-exposure-strategies-using-an-operator_{context}"]
 = Configuring workspace exposure strategies using an Operator
 
-link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operators] are software extensions to {platforms-name} that use link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Custom Resources] to manage applications and their components.
+link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operators] are software extensions to {platforms-name} that use link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Custom Resources] to manage applications and their components.
 
 .Prerequisites
 

--- a/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates-old.adoc
+++ b/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates-old.adoc
@@ -62,7 +62,7 @@ To apply more than one certificate, add another `--from-file=_<certificate-file-
 . During the installation process, when creating the `CheCluster` custom resource, take care of configuring the right name for the created ConfigMap.
 +
 ====
-For a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operator] deployment,
+For a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment,
 ensure you add the `spec.server.ServerTrustStoreConfigMapName` field with the name of the ConfigMap, to the `CheCluster` Custom Resource you will create during the installation:
 
 [source,yaml,subs="+quotes",options="nowrap",role=white-space-pre]
@@ -93,7 +93,7 @@ endif::[]
 * You should first gather the name of the ConfigMap used to import certificates:
 +
 ====
-On instances of {prod-short} deployed with the {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operator],
+On instances of {prod-short} deployed with the {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator],
 retrieve the name of the ConfigMap by reading the `spec.server.ServerTrustStoreConfigMapName` `CheCluster` Custom Resource property:
 
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
@@ -134,7 +134,7 @@ To apply more than one certificate, add another `--from-file=_<certificate-file-
 . Configure the {prod-short} installation to use the ConfigMap:
 +
 ====
-For a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operators] deployment:
+For a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operators] deployment:
 
 . Edit the `spec.server.ServerTrustStoreConfigMapName` `CheCluster` Custom Resource property to match the name of the ConfigMap:
 +
@@ -188,7 +188,7 @@ and higher.
 
 If you added the certificates without error, the {prod-short} server starts and obtains {identity-provider} configuration over https. Otherwise here is a list of things to verify:
 
-. In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operator] deployment, the `CheCluster` attribute `serverTrustStoreConfigMapName` value matches the name of the ConfigMap. Get the value using the following command :
+. In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment, the `CheCluster` attribute `serverTrustStoreConfigMapName` value matches the name of the ConfigMap. Get the value using the following command :
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----

--- a/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates.adoc
+++ b/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates.adoc
@@ -120,7 +120,7 @@ endif::[]
 
 If after adding the certificates something does not work as expected, here is a list of things to verify:
 
-- In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operator] deployment, namespace where `CheCluster` located contains labeled ConfigMaps with right content:
+- In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment, namespace where `CheCluster` located contains labeled ConfigMaps with right content:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----


### PR DESCRIPTION
Fix linkchecker errors due to new URL for olm-what-operators-are.html in OpenShift docs.

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

