### PR TITLE
Backports for 7.26.x 2021 02 24

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -107,7 +107,7 @@ asciidoc:
     prod-url: \https://che-host:che-port
     prod-ver-major: 7
     prod-ver: 7.26
-    prod-ver-patch: 7.26.0
+    prod-ver-patch: 7.26.1
     prod-docs-url: https://www.eclipse.org/che/docs
     prod-workspace: che-ws
     prod: Eclipse&#160;Che

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -100,14 +100,14 @@ asciidoc:
     prod-operator: che-operator
     prod-operator-image-name: che-operator
     prod-prev-ver-major: 6
-    prod-prev-ver: 7.24
+    prod-prev-ver: 7.25
     prod-short: Che
     prod-upstream: Eclipse{nbsp}Che
     prod-url-secure: \https://che-host
     prod-url: \https://che-host:che-port
     prod-ver-major: 7
-    prod-ver: 7.25
-    prod-ver-patch: 7.25.0
+    prod-ver: 7.26
+    prod-ver-patch: 7.26.0
     prod-docs-url: https://www.eclipse.org/che/docs
     prod-workspace: che-ws
     prod: Eclipse&#160;Che

--- a/make-release.sh
+++ b/make-release.sh
@@ -15,7 +15,7 @@ while [[ "$#" -gt 0 ]]; do
     '-t'|'--trigger-release') TAG_RELEASE=1; docommit=1; shift 0;;
     '-v'|'--version') VERSION="$2"; shift 1;;
     '-n'|'--nocommit') docommit=0; shift 0;;
-    '-tmp'|'--use-tmp-dir') USE_TMP_DIR=0; shift 0;;
+    '-tmp'|'--use-tmp-dir') USE_TMP_DIR=1; shift 0;;
   esac
   shift 1
 done
@@ -39,7 +39,7 @@ if [[ ! ${VERSION} ]]; then
   exit 1
 fi
 
-if [[ ${USE_TMP_DIR} ]]; then
+if [[ ${USE_TMP_DIR} -eq 1 ]]; then
   cd /tmp/ && tmpdir=tmp-${0##*/}-$VERSION && git clone $REPO $tmpdir && cd /tmp/$tmpdir
 fi
 

--- a/make-release.sh
+++ b/make-release.sh
@@ -32,8 +32,6 @@ Options:
 "
 }
 
-set -e
-
 if [[ ! ${VERSION} ]]; then
   usage
   exit 1
@@ -95,6 +93,7 @@ bump_version() {
     git commit -s -m "${COMMIT_MSG}" $playbookfile
     git pull origin "${BUMP_BRANCH}"
 
+    set +e
     PUSH_TRY="$(git push origin "${BUMP_BRANCH}")"
     # shellcheck disable=SC2181
     if [[ $? -gt 0 ]] || [[ $PUSH_TRY == *"protected branch hook declined"* ]] || [[ $PUSH_TRY == *"Protected branch update"* ]]; then

--- a/modules/installation-guide/examples/system-variables.adoc
+++ b/modules/installation-guide/examples/system-variables.adoc
@@ -310,7 +310,7 @@
 ,=== 
  Environment Variable Name,Default value, Description 
  
- `+CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER+`,"`+NULL+`","Alias of the Openshift identity provider registered in Keycloak, that should be used to create workspace OpenShift resources in Openshift namespaces owned by the current {prod-short} user. Should be set to NULL if `che.infra.openshift.project` is set to a non-empty value. For more information see the following documentation: \https://www.keycloak.org/docs/latest/server_admin/index.html#openshift-4" 
+ `+CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER+`,"`+NULL+`","Alias of the Openshift identity provider registered in Keycloak, which will be used to create workspace OpenShift resources in Openshift namespaces owned by the current {prod-short} user. Should be set to NULL if `che.infra.openshift.project` is set to a non-empty value. For more information see the following documentation: \https://www.keycloak.org/docs/latest/server_admin/index.html#openshift-4" 
 ,=== 
 
 [id="keycloak-configuration"]

--- a/modules/installation-guide/partials/proc_configuring-che-hostname.adoc
+++ b/modules/installation-guide/partials/proc_configuring-che-hostname.adoc
@@ -22,16 +22,16 @@ IMPORTANT: Ask a DNS provider to point the custom hostname to the cluster ingres
 $ {orch-cli} create {orch-namespace} {prod-namespace}
 ----
 
-. Create a tls secret:
+. Create a TLS secret:
 +
 [subs="+quotes,attributes"]
 ----
-$ {orch-cli} create secret tls $\{secret} \  <1>
+$ {orch-cli} create secret TLS $\{secret} \  <1>
 --key $\{key_file} \                       <2>
 --cert $\{cert_file} \                     <3>
 -n {prod-namespace}
 ----
-<1> The tls secret name
+<1> The TLS secret name
 <2> A file with the private key
 <3> A file with the certificate
 
@@ -46,8 +46,12 @@ spec:
     cheHostTLSSecret: <secret>  <2>
 ----
 <1> Custom {prod} server hostname
-<2> The tls secret name
+<2> The TLS secret name
 
 . If {prod-short} has been already deployed and {prod-short} reconfiguring to use a new {prod-short} hostname is required, log in using {identity-provider} and select the `{prod-deployment}-public` client in the `{prod-short}` realm and update `Validate Redirect URIs` and `Web Origins` fields with the value of the {prod-short} hostname.
 +
 image::keycloak/keycloak_che_public_client.png[]
++
+For logging in to {identity-provider}, follow the procedure below.
+
+include::partial$proc_logging-in-to-identity-provider.adoc[]

--- a/modules/installation-guide/partials/proc_logging-in-to-identity-provider.adoc
+++ b/modules/installation-guide/partials/proc_logging-in-to-identity-provider.adoc
@@ -1,0 +1,34 @@
+[id="proc_logging-in-to-identity-provider_{context}"]
+== Logging in to {identity-provider}
+
+The following procedure describes how to log in to {identity-provider}, which acts as a route for OpenShift platforms. To log in to {identity-provider}, a user has to obtain the {identity-provider} URL and a user's credentials first.
+ 
+.Prerequisites
+ 
+* The `{orch-cli}` tool installed.
+* Logged in to OpenShift cluster using the `{orch-cli}` tool.
+ 
+.Procedure
+ 
+. Obtain a user {identity-provider} login:
++
+[subs="+attributes,+quotes"]
+----
+{orch-cli} get secret che-identity-secret  -n {prod-namespace} -o json | jq -r '.data.user' | base64 -d
+----
+ 
+. Obtain a user {identity-provider} password:
++
+[subs="+attributes,+quotes"]
+----
+{orch-cli} get secret che-identity-secret  -n {prod-namespace} -o json | jq -r '.data.password' | base64 -d 
+----
+ 
+. Obtain the {identity-provider} URL:
++
+[subs="+attributes,+quotes"]
+----
+{orch-cli}  get ingress -n {prod-namespace} -l app=che,component=keycloak   -o 'custom-columns=URL:.spec.rules[0].host' --no-headers
+----
+ 
+. Open the URL in a browser and log in to {identity-provider} using the obtained login and password. 

--- a/modules/installation-guide/partials/proc_setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc
+++ b/modules/installation-guide/partials/proc_setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc
@@ -7,8 +7,13 @@
 
 The following procedure is relevant for all {prod-short} instances with the OpenShift OAuth service enabled.
 
-When a user with pre-created namespaces logs in to {prod} Dashboard for the first time, a page allowing the user to update account information is displayed. It is possible to change the username, but choosing a username that doesn't match the OpenShift username, prevents the user's workspaces from running. This is caused by {prod-short} attempts to use a non-existing namespace, the name of which is derived from a user OpenShift username, to create a workspace. To prevent this, modify the {identity-provider} settings using the steps below. 
+When a user with pre-created namespaces logs in to {prod} Dashboard for the first time, a page allowing the user to update account information is displayed. It is possible to change the username, but choosing a username that doesn't match the OpenShift username, prevents the user's workspaces from running. This is caused by {prod-short} attempts to use a non-existing namespace, the name of which is derived from a user OpenShift username, to create a workspace. To prevent this, log in to {identity-provider} and modify the theme settings.
 
+
+include::partial$proc_logging-in-to-identity-provider.adoc[]
+
+
+== Setting up the {identity-provider} {prod-id-short}-username-readonly theme
 
 .Prerequisites
 
@@ -20,7 +25,7 @@ When a user with pre-created namespaces logs in to {prod} Dashboard for the firs
 After changing a username, set the *Login Theme* option to `readonly`.
 
 . In the main *Configure* menu on the left, select *Realm Settings*:
-+
+
 image::keycloak/{project-context}-keycloak-username-readonly-theme.png[link="../_images/keycloak/{project-context}-keycloak-username-readonly-theme.png"]
 
 . Navigate to the *Themes* tab.


### PR DESCRIPTION
Cherry-picking all merge commits except for Dashboard Next.

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

