### PR TITLE
 Backports for 7.26.x 2021 02 24

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -12,9 +12,8 @@ Vocab = Che
 # If integrated into CI, builds fail by default on error-level alerts,
 # unless you execute Vale with the --no-exit flag
 MinAlertLevel = suggestion
-IgnoredScopes = code, tt, img, url, a
-SkippedScopes = script, style, pre, figure, code, tt
-
+IgnoredScopes = code, tt, img, url, a, blockquote
+SkippedScopes = script, style, pre, figure, code, tt, blockquote
 
 # What file types should Vale test?
 # ----------------------------------

--- a/.vale/styles/IBM/Terms.yml
+++ b/.vale/styles/IBM/Terms.yml
@@ -147,7 +147,6 @@ swap:
   on-ramp: access method
   pain point: challenge|concern|difficulty|issue
   parent task: parent process
-  patch: fix|test fix|interim fix|fix pack|program temporary fix
   perimeter network: DMZ
   phone: telephone|cell phone|mobile phone
   power down: turn on|turn off

--- a/.vale/styles/Vocab/Che/accept.txt
+++ b/.vale/styles/Vocab/Che/accept.txt
@@ -41,6 +41,7 @@ Intelephense
 Java
 jvm|JVM
 helm
+hostname
 kbd
 Keycloak
 Keycloak

--- a/.vale/styles/Vocab/Che/accept.txt
+++ b/.vale/styles/Vocab/Che/accept.txt
@@ -3,6 +3,7 @@ adoc
 Antora
 API
 AsciiDoc
+autostart
 AWS
 Bitbucket
 boolean|Boolean
@@ -17,7 +18,7 @@ ConfigMap
 ConfigMaps
 DaemonSet
 Developer Perspective
-devfile
+devfile|Devfile
 devfiles
 DNS
 Docker
@@ -46,6 +47,7 @@ kbd
 Keycloak
 Keycloak
 Kubernetes
+loopback
 Mattermost
 Maven
 mebibytes
@@ -96,6 +98,7 @@ URLs
 Velero
 Visual Studio Code
 VS Code
+Woopra
 workspace|Workspace
 workspaces
 YAML

--- a/.vale/styles/Vocab/Che/reject.txt
+++ b/.vale/styles/Vocab/Che/reject.txt
@@ -26,7 +26,6 @@ probably
 refer
 repo
 set up
-should
 Stack
 start up
 take care of

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
- 
+
   agent {
     kubernetes {
       label 'che-docs-pod'
@@ -30,25 +30,25 @@ spec:
 """
     }
   }
- 
+
   environment {
     PROJECT_NAME = "che"
     PROJECT_BOT_NAME = "CHE Bot"
     CI = true
   }
- 
-  triggers { pollSCM('H/10 * * * *') 
- 
+
+  triggers { pollSCM('H/10 * * * *')
+
  }
- 
+
   options {
     buildDiscarder(logRotator(numToKeepStr: '5'))
     checkoutToSubdirectory('che-docs')
     timeout(time: 15, unit: 'MINUTES')
   }
- 
+
   stages {
-    
+
     stage('Checkout www repo (master)') {
       when {
         branch 'master'
@@ -76,6 +76,7 @@ spec:
         container('che-docs') {
           dir('che-docs') {
                 sh './tools/environment_docs_gen.sh'
+                sh './tools/checluster_docs_gen.sh'
                 sh 'CI=true antora generate antora-playbook.yml --stacktrace'
             }
         }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,22 +1,3 @@
-# Eclipse Che release process
+# Eclipse Che Docs release
 
-##### 1. Create branch for release preparation and next bugfixes:
-* `git branch {branchname} #e.g 7.7.x`
-* `git push --set-upstream origin {branchname}`
-##### 2. Create PR for switch master to the next development version :
-* `git branch set_next_version_in_master_{next_version} #e.g 7.8.0-SNAPSHOT`
-* `mvn versions:set versions:commit -DnewVersion=${next_version}`
-* Update parent version : `mvn versions:update-parent  versions:commit -DallowSnapshots=true -DparentVersion={next_version}`
-* `git push --set-upstream origin set_next_version_in_master_{next_version}`
-* Create PR
-##### 3. Merge branch to the `release` branch and push changes, release process will start by webhook:
-* `git checkout release`
-* `git merge -X theirs {branchname}`
-* `git push -f`
-##### 4. Close/release staging repository on Nexus 
- https://oss.sonatype.org/#stagingRepositories
-
- > **Note:** For bugfix release procedure will be similar except creating new branch on first step and update version in master branch
-
-# Script
-`make-release.sh` performs the first 3 steps. Release to Nexus is still a manual process for now.
+See `release.yml` workflow, which performs release procedures for Che Docs.

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -31,12 +31,18 @@ components:
     type: chePlugin
 
 commands:
-  - name: Generate reference tables
+  - name: Generate reference tables for environment variables
     actions:
       - type: exec
         component: che-docs
         workdir: /projects/che-docs
         command: bash tools/environment_docs_gen.sh
+  - name: Generate reference tables for CheCluster
+    actions:
+      - type: exec
+        component: che-docs
+        workdir: /projects/che-docs
+        command: bash tools/checluster_docs_gen.sh
   - name: Start preview server
     actions:
       - type: exec

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -21,7 +21,7 @@ components:
         port: 4000
         attributes:
           path: /che-7/overview/introduction-to-eclipse-che/
-  - id: testthedocs/vale/latest
+  - id: errata-ai/vale-server/latest
     type: chePlugin
   - id: ms-vscode/vscode-github-pullrequest/latest
     type: chePlugin

--- a/make-release.sh
+++ b/make-release.sh
@@ -95,6 +95,7 @@ bump_version() {
 
     set +e
     PUSH_TRY="$(git push origin "${BUMP_BRANCH}")"
+
     # shellcheck disable=SC2181
     if [[ $? -gt 0 ]] || [[ $PUSH_TRY == *"protected branch hook declined"* ]] || [[ $PUSH_TRY == *"Protected branch update"* ]]; then
     PR_BRANCH=pr-${BUMP_BRANCH}-to-${NEXTVERSION}
@@ -106,6 +107,7 @@ bump_version() {
       lastCommitComment="$(git log -1 --pretty=%B)"
       hub pull-request -f -m "${lastCommitComment}" -b "${BUMP_BRANCH}" -h "${PR_BRANCH}"
     fi 
+    set -e
   fi
   git checkout ${CURRENT_BRANCH}
 }
@@ -149,6 +151,6 @@ if [[ $TAG_RELEASE -eq 1 ]]; then
   git push origin "${VERSION}" || true
 fi
 
-if [[ ${USE_TMP_DIR} ]]; then
+if [[ ${USE_TMP_DIR} -eq 1 ]]; then
   rm -fr /tmp/$tmpdir
 fi

--- a/modules/administration-guide/partials/proc_configuring-bitbucket-server-oauth1.adoc
+++ b/modules/administration-guide/partials/proc_configuring-bitbucket-server-oauth1.adoc
@@ -23,7 +23,7 @@ It enables {prod-short} to obtain and renew link:https://confluence.atlassian.co
 
 .Procedure
 
-. Generate a RSA key pair and a stripped down version of the public key: 
+. Generate a RSA key pair and a stripped down version of the public key:
 +
 [subs="+quotes,+attributes"]
 ----
@@ -41,7 +41,7 @@ openssl rand -base64 24 > __<bitbucket_server_consumer_key>__
 openssl rand -base64 24 > __<bitbucket_shared_secret>__
 ----
 
-. Create a Kubernetes Secret in {prod-short} namespace containing the RSA key pair, the consumer key and the shared secret.
+. Create a Kubernetes Secret in {prod-short} namespace containing the consumer and private keys.
 +
 [subs="+quotes,+attributes"]
 ----
@@ -49,40 +49,24 @@ $ {orch-cli} apply -f - <<EOF
 kind: Secret
 apiVersion: v1
 metadata:
-  name: github-oauth-credentials
+  name: bitbucket-oauth-config
   namespace: <...> <1>
   labels:
     app.kubernetes.io/part-of: che.eclipse.org
-    app.kubernetes.io/component: che-secret
+    app.kubernetes.io/component: oauth-scm-configuration
   annotations:
-    che.eclipse.org/mount-path: /home/user/eclipse-che/conf/oauth1/bitbucket
-    che.eclipse.org/mount-as: file
-data:
-  private.key: <...> <2>
-  consumer.key: <...> <3>
-  shared_secret: <...> <4>
+    che.eclipse.org/oauth-scm-server: bitbucket
+    che.eclipse.org/scm-server-endpoint: <...> <2>
 type: Opaque
+data:
+  private.key: <...> <3>
+  consumer.key: <...> <4>
 EOF
 ----
 <1> {prod-short} namespace. The default is {prod-namespace}
-<2> base64 encoded content of the __<privatepkcs8.pem>__ file without first and last lines.
-<3> base64 encoded content of the `__<bitbucket_server_consumer_key>__` file.
-<4> base64 encoded content of the `__<bitbucket_shared_secret>__` file.
-
-. Configure the {prod-short} server environment variables:
-+
-[subs="+quotes,macros"]
-----
-spec:
- server:
-   customCheProperties:
-     pass:[CHE_OAUTH1_BITBUCKET_CONSUMERKEYPATH]: '/home/user/eclipse-che/conf/oauth1/bitbucket/consumer.key'
-     pass:[CHE_OAUTH1_BITBUCKET_SHAREDSECRETPATH]: '/home/user/eclipse-che/conf/oauth1/bitbucket/shared_secret'
-     pass:[CHE_OAUTH1_BITBUCKET_PRIVATEKEYPATH]: '/home/user/eclipse-che/conf/oauth1/bitbucket/private.key'
-     pass:[CHE_OAUTH1_BITBUCKET_ENDPOINT]: '__<Bitbucket Server URL>__'
-     pass:[CHE_INTEGRATION_BITBUCKET_SERVER__ENDPOINTS]: '__<Bitbucket Server URL>__'
-
-----
+<2> Bitbucket Server URL
+<3> base64 encoded content of the __<privatepkcs8.pem>__ file without first and last lines.
+<4> base64 encoded content of the `__<bitbucket_server_consumer_key>__` file.
 
 . Configure an link:https://confluence.atlassian.com/adminjiraserver/using-applinks-to-link-to-other-applications-938846918.html[Application Link] in Bitbucket to enable the communication from {prod-short} to Bitbucket Server.
 
@@ -136,5 +120,5 @@ Public Key:: Paste the content of the `__<public-stripped.pub>__` file.
 * link:https://bitbucket.org/product/download[Download Bitbucket Server]
 * link:https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html[Bitbucket Server Personal access tokens]
 * link:https://confluence.atlassian.com/jirakb/how-to-generate-public-key-to-application-link-3rd-party-applications-913214098.html[How to generate public key to application link 3rd party applications]
-* link:https://confluence.atlassian.com/adminjiraserver/using-applinks-to-link-to-other-applications-938846918.html[Using AppLinks to link to other applications] 
+* link:https://confluence.atlassian.com/adminjiraserver/using-applinks-to-link-to-other-applications-938846918.html[Using AppLinks to link to other applications]
 * xref:end-user-guide:authentication-against-bitbucket-server-with-the-personal-access-token.adoc[].

--- a/modules/administration-guide/partials/proc_configuring-github-oauth.adoc
+++ b/modules/administration-guide/partials/proc_configuring-github-oauth.adoc
@@ -29,20 +29,17 @@ $ {orch-cli} apply -f - <<EOF
 kind: Secret
 apiVersion: v1
 metadata:
-  name: github-oauth-credentials
+  name: github-oauth-config
   namespace: <...> <1>
   labels:
     app.kubernetes.io/part-of: che.eclipse.org
-    app.kubernetes.io/component: keycloak-secret
+    app.kubernetes.io/component: oauth-scm-configuration
   annotations:
-    che.eclipse.org/github-oauth-credentials: 'true'
-    che.eclipse.org/mount-as: env
-    che.eclipse.org/id_env-name: GITHUB_CLIENT_ID
-    che.eclipse.org/secret_env-name: GITHUB_SECRET
+    che.eclipse.org/oauth-scm-server: github
+type: Opaque
 data:
   id: <...> <2>
   secret: <...> <3>
-type: Opaque
 EOF
 ----
 <1> {prod-short} namespace. The default is {prod-namespace}

--- a/modules/administration-guide/partials/proc_configuring-openshift-oauth-with-initial-user.adoc
+++ b/modules/administration-guide/partials/proc_configuring-openshift-oauth-with-initial-user.adoc
@@ -1,5 +1,5 @@
-[id="configuring-openshift-oauth_{context}"]
-= Configuring OpenShift OAuth
+[id="configuring-openshift-oauth-with-initial-user_{context}"]
+= Configuring OpenShift OAuth with initial user
 
 .Prerequisites
 
@@ -11,13 +11,15 @@
 * Configure OpenShift identity providers on the cluster. See the link:https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html#identity-provider-overview_understanding-identity-provider[Understanding identity provider configuration].
 +
 ====
-If skip this step and there are identity providers configured on the OpenShift cluster, then {prod} will create initial OpenShift user for HTPasswd identity provider and put user's credentials in `openshift-oauth-user-credentials` secret in {prod-namespace} namespace. Follow these steps to obtain credentials to log in into OpenShift cluster and {prod}:
+When a user skips the Configuring step of OpenShift identity providers, and the OpenShift cluster does not already contain configured identity providers, {prod-short} creates an initial OpenShift user for the `HTPasswd` identity provider. Credentials of this user are stored in the `openshift-oauth-user-credentials` secret, located in the {prod-namespace} namespace. 
+
+Obtain the credentials for logging in to an OpenShift cluster and {prod-short} instance:
 
 . Obtain OpenShift user name:
 +
 [subs="+attributes,+quotes"]
 ----
-$ oc get secret openshift-oauth-user-credentials  -n {prod-namespace} -o json | jq -r '.data.user' | base64 -d
+$ oc get secret openshift-oauth-user-credentials -n {prod-namespace} -o json | jq -r '.data.user' | base64 -d
 ----
 . Obtain OpenShift user password:
 +

--- a/modules/administration-guide/partials/proc_configuring-openshift-oauth-with-initial-user.adoc
+++ b/modules/administration-guide/partials/proc_configuring-openshift-oauth-with-initial-user.adoc
@@ -1,0 +1,80 @@
+[id="configuring-openshift-oauth_{context}"]
+= Configuring OpenShift OAuth
+
+.Prerequisites
+
+* The `oc` tool is available.
+* `{prod-cli}` management tool is available. See xref:overview:using-the-chectl-management-tool.adoc[].
+
+.Procedure
+
+* Configure OpenShift identity providers on the cluster. See the link:https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html#identity-provider-overview_understanding-identity-provider[Understanding identity provider configuration].
++
+====
+If skip this step and there are identity providers configured on the OpenShift cluster, then {prod} will create initial OpenShift user for HTPasswd identity provider and put user's credentials in `openshift-oauth-user-credentials` secret in {prod-namespace} namespace. Follow these steps to obtain credentials to log in into OpenShift cluster and {prod}:
+
+. Obtain OpenShift user name:
++
+[subs="+attributes,+quotes"]
+----
+$ oc get secret openshift-oauth-user-credentials  -n {prod-namespace} -o json | jq -r '.data.user' | base64 -d
+----
+. Obtain OpenShift user password:
++
+[subs="+attributes,+quotes"]
+----
+$ oc get secret openshift-oauth-user-credentials -n {prod-namespace} -o json | jq -r '.data.password' | base64 -d
+----
+====
++
+* Deploy {prod-short} using xref:installation-guide:installing-che-on-openshift-4-using-operatorhub.adoc[OperatorHub] or the {prod-cli}, see the
+link:{link-cli-github}#user-content-{prod-cli}-serverdeploy[`{prod-cli} server:deploy` specification] chapter. OpenShift OAuth will be enabled by default.
+
+ifeval::["{project-context}" == "che"]
+* For {prod-short} deployed in single-user mode:
++
+====
+. Register {prod-short} OAuth client in OpenShift. See the link:https://docs.openshift.com/container-platform/4.3/authentication/configuring-internal-oauth.html#oauth-register-additional-client_configuring-internal-oauth[Register an OAuth client in OpenShift] chapter.
++
+[subs="+quotes,+attributes"]
+----
+$ oc create -f <(echo '
+kind: OAuthClient
+apiVersion: oauth.openshift.io/v1
+metadata:
+ name: che
+secret: "<random set of symbols>"
+redirectURIs:
+ - "<{prod-short} api url>/oauth/callback"
+grantMethod: prompt
+')
+----
+
+. Add the OpenShift TLS certificate to the {prod-short} Java trust store.
++
+* See xref:installation-guide:importing-untrusted-tls-certificates.adoc[].
+. Update the OpenShift deployment configuration.
++
+[subs="+quotes,macros"]
+----
+CHE_OAUTH_OPENSHIFT_CLIENTID: _<client-ID>_
+CHE_OAUTH_OPENSHIFT_CLIENTSECRET: _<openshift-secret>_
+pass:[CHE_OAUTH_OPENSHIFT_OAUTH__ENDPOINT]: _<oauth-endpoint>_
+pass:[CHE_OAUTH_OPENSHIFT_VERIFY__TOKEN__URL]: _<verify-token-url>_
+----
++
+* `_<client-ID>_` a name specified in the OpenShift OAuthClient.
+* `_<openshift-secret>_` a secret specified in the OpenShift OAuthClient.
+* `_<oauth-endpoint>_` the URL of the OpenShift OAuth service:
+** For OpenShift 3 specify the OpenShift master URL.
+** For OpenShift 4 specify the `oauth-openshift` route.
+* `_<verify-token-url>_` request URL that is used to verify the token. `<OpenShift master url>/api` can be used for OpenShift 3 and 4.
++
+* See {link-advanced-configuration-options}.
+====
+
+.Additional resources
+
+* See xref:administration-guide:authenticating-users.adoc[].
+
+endif::[]

--- a/modules/administration-guide/partials/proc_configuring-openshift-oauth-without-initial-user.adoc
+++ b/modules/administration-guide/partials/proc_configuring-openshift-oauth-without-initial-user.adoc
@@ -1,0 +1,37 @@
+[id="proc_configuring_openshift-oauth-without-initial-user_{context}"]
+= Configuring OpenShift OAuth without provisioning OpenShift initial OAuth user
+
+The following procedure describes how to configure OpenShift OAuth without provisioning OpenShift initial OAuth user.
+
+.Prerequisites
+
+* `{prod-cli}` management tool is available. See xref:overview:using-the-chectl-management-tool.adoc[].
+
+.Procedure
+
+. Deploy and update {prod-short} instance using OperatorHub and wait for the process to finish:
++
+[subs="+quotes,+attributes"]
+----
+$ {prod-cli} server:deploy --che-operator-cr-patch-yaml=patch.yaml ...
+----
++
+`patch.yaml` must contain the following:
++
+[source,yaml,subs="+quotes"]
+----
+spec:
+  auth:
+    openShiftoAuth: true
+    initialOpenShiftOAuthUser: ''
+----
++
+. Set the following values in {prod-checluster} Custom Resource (CR):
++
+[source,yaml,subs="+quotes"]
+----
+spec:
+  auth:
+    openShiftoAuth: true
+    initialOpenShiftOAuthUser: ''
+----

--- a/modules/administration-guide/partials/proc_configuring-openshift-oauth.adoc
+++ b/modules/administration-guide/partials/proc_configuring-openshift-oauth.adoc
@@ -2,15 +2,18 @@
 //
 // Configuring OpenShift OAuth
 
+:parent-context-of-configuring-openshift-oauth: {context}
+
 [id="configuring-openshift-oauth_{context}"]
 = Configuring OpenShift OAuth
+
+:context: configuring-openshift-oauth
 
 For users to interact with OpenShift, they must first authenticate to the OpenShift cluster. OpenShift OAuth is a process in which users prove themselves to a cluster through an API with obtained OAuth access tokens.
 
 Authentication with the xref:extensions:openshift-connector-overview.adoc[] is a possible way for {prod-short} users to authenticate with an OpenShift cluster.
 
-The following section describes the OpenShift OAuth configuration options
-and its use with a {prod}.
+The following section describes the OpenShift OAuth configuration options and its use with a {prod-short}.
 
 include::partial$proc_configuring-openshift-oauth-with-initial-user.adoc[leveloffset=+1]
 
@@ -18,3 +21,4 @@ include::partial$proc_configuring-openshift-oauth-without-initial-user.adoc[leve
 
 include::partial$proc_removing-initial-openshift-user.adoc[leveloffset=+1]
 
+:context: {parent-context-of-configuring-openshift-oauth}

--- a/modules/administration-guide/partials/proc_configuring-openshift-oauth.adoc
+++ b/modules/administration-guide/partials/proc_configuring-openshift-oauth.adoc
@@ -10,66 +10,11 @@ For users to interact with OpenShift, they must first authenticate to the OpenSh
 Authentication with the xref:extensions:openshift-connector-overview.adoc[] is a possible way for {prod-short} users to authenticate with an OpenShift cluster.
 
 The following section describes the OpenShift OAuth configuration options
-and its use with a {prod-short}.
+and its use with a {prod}.
 
-.Prerequisites
+include::partial$proc_configuring-openshift-oauth-with-initial-user.adoc[leveloffset=+1]
 
-* The `oc` tool is available.
-* `{prod-cli}` management tool is available. See xref:overview:using-the-chectl-management-tool.adoc[].
-* Openshift identity providers are configured on the cluster. See the link:https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html#identity-provider-overview_understanding-identity-provider[Understanding identity provider configuration]
+include::partial$proc_configuring-openshift-oauth-without-initial-user.adoc[leveloffset=+1]
 
-.Procedure
-
-* OpenShift OAuth will be enabled by default, deploy {prod-short} using xref:installation-guide:installing-che-on-openshift-4-using-operatorhub.adoc[OperatorHub] or the {prod-cli}, see the
-link:{link-cli-github}#user-content-{prod-cli}-serverdeploy[`{prod-cli} server:deploy` specification] chapter.
-
-ifeval::["{project-context}" == "che"]
-* For {prod-short} deployed in single-user mode:
-+
-====
-. Register {prod-short} OAuth client in OpenShift. See the link:https://docs.openshift.com/container-platform/4.3/authentication/configuring-internal-oauth.html#oauth-register-additional-client_configuring-internal-oauth[Register an OAuth client in OpenShift] chapter.
-+
-[subs="+quotes,+attributes"]
-----
-$ oc create -f <(echo '
-kind: OAuthClient
-apiVersion: oauth.openshift.io/v1
-metadata:
- name: che
-secret: "<random set of symbols>"
-redirectURIs:
- - "<{prod-short} api url>/oauth/callback"
-grantMethod: prompt
-')
-----
-
-. Add the OpenShift TLS certificate to the {prod-short} Java trust store.
-+
-* See xref:installation-guide:importing-untrusted-tls-certificates.adoc[].
-. Update the OpenShift deployment configuration.
-+
-[subs="+quotes,macros"]
-----
-CHE_OAUTH_OPENSHIFT_CLIENTID: _<client-ID>_
-CHE_OAUTH_OPENSHIFT_CLIENTSECRET: _<openshift-secret>_
-pass:[CHE_OAUTH_OPENSHIFT_OAUTH__ENDPOINT]: _<oauth-endpoint>_
-pass:[CHE_OAUTH_OPENSHIFT_VERIFY__TOKEN__URL]: _<verify-token-url>_
-----
-+
-* `_<client-ID>_` a name specified in the OpenShift OAuthClient.
-* `_<openshift-secret>_` a secret specified in the OpenShift OAuthClient.
-* `_<oauth-endpoint>_` the URL of the OpenShift OAuth service:
-** For OpenShift 3 specify the OpenShift master URL.
-** For OpenShift 4 specify the `oauth-openshift` route.
-* `_<verify-token-url>_` request URL that is used to verify the token. `<OpenShift master url>/api` can be used for OpenShift 3 and 4.
-+
-* See {link-advanced-configuration-options}.
-====
-
-.Additional resources
-
-* See xref:administration-guide:authenticating-users.adoc[].
-
-endif::[]
-
+include::partial$proc_removing-initial-openshift-user.adoc[leveloffset=+1]
 

--- a/modules/administration-guide/partials/proc_enabling-self-registration.adoc
+++ b/modules/administration-guide/partials/proc_enabling-self-registration.adoc
@@ -3,9 +3,9 @@
 [id="enabling-self-registration_{context}"]
 = Enabling self-registration
 
-Self-registration allows users to register themselves in a {prod-short} instance by accessing the {prod-short} server URL. 
+Self-registration allows users to register themselves in a {prod-short} instance by accessing the {prod-short} server URL.
 
-For {prod-short} installed without OpenShift OAuth support, self-registration is disabled by default, therefore the option to register a new user is not available on the login page. 
+For {prod-short} installed without OpenShift OAuth support, self-registration is disabled by default, therefore the option to register a new user is not available on the login page.
 
 .Prerequisites
 
@@ -15,6 +15,6 @@ For {prod-short} installed without OpenShift OAuth support, self-registration is
 
 To enable self-registration of users:
 
-. Navigate to the *Realm Settings* menu on the left and open the *Login* tab. 
+. Navigate to the *Realm Settings* menu on the left and open the *Login* tab.
 
 . Set *User registration* option to *On*.

--- a/modules/administration-guide/partials/proc_removing-initial-openshift-user.adoc
+++ b/modules/administration-guide/partials/proc_removing-initial-openshift-user.adoc
@@ -1,0 +1,20 @@
+[id="proc_removing-initial-openshift-user_{context}"]
+= Removing OpenShift initial OAuth user
+
+The following procedure describes how to remove OpenShift initial OAuth user provisioned by {prod}.
+
+.Prerequisites
+
+* The `oc` tool installed.
+* An instance of {prod} running on OpenShift.
+* Logged in to OpenShift cluster using the `oc` tool.
+
+.Procedure
+
+. Update {prod-checluster} custom resource:
++
+[subs="+quotes,+attributes"]
+----
+$ oc patch checluster {prod-checluster} -n {prod-namespace} --type=json -p \
+'[{"op": "replace", "path": "/spec/auth/initialOpenShiftOAuthUser", "value": false}]'
+----

--- a/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-maven-projects.adoc
+++ b/modules/end-user-guide/partials/proc_using-self-signed-certificates-in-maven-projects.adoc
@@ -42,7 +42,7 @@ Certificate was added to keystore
     env:
        -name: MAVEN_OPTS
         value: >-
-          -Duser.home=/projects/maven -Djavax.net.ssl.trustStore=/projects/maven/truststore.jks
+          -Duser.home=/projects/maven -Djavax.net.ssl.trustStore=/projects/maven/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit
 ----
 +
 .. Restart the workspace.

--- a/modules/extensions/partials/proc_authenticating-with-openshift-connector-from-che.adoc
+++ b/modules/extensions/partials/proc_authenticating-with-openshift-connector-from-che.adoc
@@ -1,53 +1,64 @@
 // using-openshift-connector-in-eclipse-che
 
-
-
 [id="authenticating-with-openshift-connector-from-{prod-id-short}_{context}"]
-= Authenticating with OpenShift Connector from {prod-short}
+= Authenticating with OpenShift Connector from {prod-short} when the OpenShift OAuth service does not authenticate the {prod-short} instance
 
-The following section is relevant only when the OpenShift OAuth service does not already authenticate a {prod-short} instance; otherwise, the OpenShift Connector plug-in automatically establishes the authentication with the Openshift instance where {prod-short} runs.
+This section describes how to authenticate with an OpenShift cluster when the OpenShift OAuth service does not authenticate the {prod-short} instance. It enables the user to develop and push Components from {prod-short} to the OpenShift instance that contains {prod-short}.
 
-Before the user can develop and push Components from {prod-short}, they need to authenticate with an OpenShift cluster.
+[NOTE]
+====
+When the OpenShift OAuth service authenticates the {prod-short} instance, the OpenShift Connector plug-in automatically establishes the authentication with the OpenShift instance containing {prod-short}.
+====
 
 OpenShift Connector offers the following methods for logging in to the OpenShift Cluster from the {prod-short} instance:
 
-* Using the notification that asks to log in to the OpenShift cluster where {prod-short} is deployed to.
+* Using the notification asking to log in to the OpenShift instance containing {prod-short}.
 * Using the btn:[Log in to the cluster] button.
 * Using the Command Palette.
 
 [NOTE]
 ====
-.In {prod-short} {prod-ver}, Openshift Connector plug-in requires manual connecting to the target cluster
+OpenShift Connector plug-in requires manual connecting to the target cluster.
 
-By default, the Openshift Connector plug-in logs into the cluster as `inClusterUser`, which may not have the manage project permission. This causes an error message to be displayed when a new project is being created using Openshift Application Explorer:
-----
+The OpenShift Connector plug-in logs in to the cluster as `inClusterUser`. If this user does not have manage project permission, this error message appears when creating a project using OpenShift Application Explorer:
+
+[quote]
+____
 Failed to create Project with error 'Error: Command failed: "/tmp/vscode-unpacked/redhat.vscode-openshift -connector.latest.qvkozqtkba.openshift-connector-0.1.4-523.vsix/extension/out/tools/linux/odo" project create test-project ✗ projectrequests.project.openshift.io is forbidden
-----
+____
 
-To work around this temporary issue, log out from the local cluster and relog in to OpenShift cluster using the OpenShift user's credentials.
+To work around this issue:
+
+. Log out from the local cluster.
+. Log in to OpenShift cluster using the OpenShift user's credentials.
 ====
 
-When using a local instance of OpenShift (such as CodeReady Containers or Minishift), the user’s credentials are stored in the workspace `~/.kube/config` file, and may be used for automatic authentication in subsequent logins. In the context of {prod-short}, the `~/.kube/config` is stored as a part of the plug-in sidecar container.
+ifeval::["{project-context}" == "che"]
+When using a local instance of OpenShift such as CodeReady Containers or Minishift, {prod-short} stores the user’s credentials in a `~/.kube/config` file in the workspace. Use this file for automatic authentication in subsequent logins. In the context of {prod-short}, the `~/.kube/config` is stored as a part of the plug-in sidecar container.
+endif::[]
 
 .Prerequisites
-* A running instance of {prod-short}. To install an instance of {prod-short}, see xref:installation-guide:installing-che.adoc[].
-* A {prod-short} workspace has been created.
-* The OpenShift Connector plug-in is available.
-* The OpenShift OAuth provider is configured (only for the auto-login to the OpenShift cluster where {prod-short} is deployed. See xref:administration-guide:configuring-openshift-oauth.adoc[]).
+
+* A running instance of {prod-short}. See xref:installation-guide:installing-che.adoc[].
+
+* A {prod-short} workspace is available. See xref:end-user-guide:workspaces-overview.adoc[].
+
+* The OpenShift Connector plug-in is available. See xref:installing-openshift-connector-in-che.adoc[].
+
+* The OpenShift OAuth provider is available only for the auto-login to the OpenShift instance containing {prod-short}. See xref:administration-guide:configuring-openshift-oauth.adoc[].
+
 
 .Procedure
 
-. In the left panel, select the *OpenShift Application Explorer* icon.
-+
-The OpenShift Connector panel is displayed.
-. Log in using the OpenShift Application Explorer. Use one of the following methods:
+. In the left panel, click the *OpenShift Application Explorer* icon.
+
+. In the OpenShift Connector panel, log in using the OpenShift Application Explorer. Use one of the following methods:
 ** Click the btn:[Log in to cluster] button in the top left corner of the pane.
-** Press kbd:[F1] to open the Command Palette, or navigate to *View -> Find Command* in the top menu.
+** Press kbd:[F1] to open the Command Palette, or navigate to *View > Find Command* in the top menu.
 +
 Search for *OpenShift: Log in to cluster* and press kbd:[Enter].
 . If a *You are already logged in a cluster.* message appears, click *Yes*.
+
+. Select the method to log in to the cluster: *Credentials* or *Token*, and follow the login instructions.
 +
-A selection whether to log in using *Credentials* or *Token* is displayed at the top of the screen.
-. Select the method to log in to the cluster and follow the login instructions.
-+
-NOTE: For authenticating with a token, the required token information is in the top right corner of the main {ocp} screen, under *__<User name>__ -> Copy Login Command*.
+NOTE: To authenticate with a token, the required token information is in the upper right corner of the main {ocp} screen, under *__<User name>__ > Copy Login Command*.

--- a/modules/hosted-che/partials/assembly_hosted-che.adoc
+++ b/modules/hosted-che/partials/assembly_hosted-che.adoc
@@ -7,7 +7,7 @@
 
 :context: hosted-che
 
-WARNING: link:https://che.openshift.io[Eclipse Che hosted by Red Hat] is going to be shut down on **March 1, 2021 at 00:01 GMT**. A new service based on link:https://developers.redhat.com/developer-sandbox#assembly-field-sections-59571[CodeReady Workspaces] is available now. Details about the new service, including signing up for it, can be found link:https://developers.redhat.com/developer-sandbox[here].
+WARNING: link:https://che.openshift.io[Eclipse Che hosted by Red Hat] is going to be shut down on **March 1, 2021 at 00:01 GMT**. A new service based on link:https://developers.redhat.com/developer-sandbox#assembly-field-sections-59571[CodeReady Workspaces] is available now. link:https://developers.redhat.com/developer-sandbox[Developer Sandbox for Red Hat OpenShift] provides more details about the new service.
 
 This section describes procedures to get started with Eclipse Che hosted by Red Hat that are not covered by xref:end-user-guide:workspaces-overview.adoc[].
 

--- a/modules/hosted-che/partials/assembly_hosted-che.adoc
+++ b/modules/hosted-che/partials/assembly_hosted-che.adoc
@@ -7,6 +7,8 @@
 
 :context: hosted-che
 
+WARNING: link:https://che.openshift.io[Eclipse Che hosted by Red Hat] is going to be shut down on **March 1, 2021 at 00:01 GMT**. A new service based on link:https://developers.redhat.com/developer-sandbox#assembly-field-sections-59571[CodeReady Workspaces] is available now. Details about the new service, including signing up for it, can be found link:https://developers.redhat.com/developer-sandbox[here].
+
 This section describes procedures to get started with Eclipse Che hosted by Red Hat that are not covered by xref:end-user-guide:workspaces-overview.adoc[].
 
 include::partial$ref_about-hosted-che.adoc[leveloffset=+1]

--- a/modules/installation-guide/examples/checluster-properties.adoc
+++ b/modules/installation-guide/examples/checluster-properties.adoc
@@ -1,0 +1,168 @@
+[id="checluster-custom-resource-server-settings_{context}"]
+.`CheCluster` Custom Resource `server` settings, related to the {prod-short} server component.
+
+[cols="2,5", options="header"]
+:=== 
+ Property: Description 
+airGapContainerRegistryHostname: Optional host name, or URL, to an alternate container registry to pull images from. This value overrides the container registry host name defined in all the default container images involved in a Che deployment. This is particularly useful to install Che in a restricted environment.
+airGapContainerRegistryOrganization: Optional repository name of an alternate container registry to pull images from. This value overrides the container registry organization defined in all the default container images involved in a Che deployment. This is particularly useful to install {prod-short} in a restricted environment.
+allowUserDefinedWorkspaceNamespaces: Defines that a user is allowed to specify a Kubernetes namespace, or an OpenShift project, which differs from the default. It's NOT RECOMMENDED to set to `true` without OpenShift OAuth configured. The OpenShift infrastructure also uses this property.
+cheClusterRoles: A comma-separated list of ClusterRoles that will be assigned to Che ServiceAccount. Be aware that the Che Operator has to already have all permissions in these ClusterRoles to grant them.
+cheDebug: Enables the debug mode for Che server. Defaults to `false`.
+cheFlavor: Specifies a variation of the installation. The options are `che` for upstream Che installations, or `codeready` for link\:https\://developers.redhat.com/products/codeready-workspaces/overview[CodeReady Workspaces] installation. Override the default value only on necessary occasions.
+cheHost: Public host name of the installed Che server. When value is omitted, the value it will be automatically set by the Operator. See the `cheHostTLSSecret` field.
+cheHostTLSSecret: Name of a secret containing certificates to secure ingress or route for the custom host name of the installed Che server. See the `cheHost` field.
+cheImage: Overrides the container image used in Che deployment. This does NOT include the container image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+cheImagePullPolicy: Overrides the image pull policy used in Che deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+cheImageTag: Overrides the tag of the container image used in Che deployment. Omit it or leave it empty to use the default image tag provided by the Operator.
+cheLogLevel: Log level for the Che server\: `INFO` or `DEBUG`. Defaults to `INFO`.
+cheServerIngress: The Che server ingress custom settings.
+cheServerRoute: The Che server route custom settings.
+cheWorkspaceClusterRole: Custom cluster role bound to the user for the Che workspaces. The default roles are used when omitted or left blank.
+customCheProperties: Map of additional environment variables that will be applied in the generated `che` ConfigMap to be used by the Che server, in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). When `customCheProperties` contains a property that would be normally generated in `che` ConfigMap from other CR fields, the value defined in the `customCheProperties` is used instead.
+devfileRegistryCpuLimit: Overrides the CPU limit used in the devfile registry deployment. In cores. (500m = .5 cores). Default to 500m.
+devfileRegistryCpuRequest: Overrides the CPU request used in the devfile registry deployment. In cores. (500m = .5 cores). Default to 100m.
+devfileRegistryImage: Overrides the container image used in the devfile registry deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+devfileRegistryIngress: The devfile registry ingress custom settings.
+devfileRegistryMemoryLimit: Overrides the memory limit used in the devfile registry deployment. Defaults to 256Mi.
+devfileRegistryMemoryRequest: Overrides the memory request used in the devfile registry deployment. Defaults to 16Mi.
+devfileRegistryPullPolicy: Overrides the image pull policy used in the devfile registry deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+devfileRegistryRoute: The devfile registry route custom settings.
+devfileRegistryUrl: Public URL of the devfile registry, that serves sample, ready-to-use devfiles. Set this ONLY when a use of an external devfile registry is needed. See the `externalDevfileRegistry` field. By default, this will be automatically calculated by the Operator.
+externalDevfileRegistry: Instructs the Operator on whether to deploy a dedicated devfile registry server. By default, a dedicated devfile registry server is started. When `externalDevfileRegistry` is `true`, no such dedicated server will be started by the Operator and you will have to manually set the `devfileRegistryUrl` field
+externalPluginRegistry: Instructs the Operator on whether to deploy a dedicated plugin registry server. By default, a dedicated plugin registry server is started. When `externalPluginRegistry` is `true`, no such dedicated server will be started by the Operator and you will have to manually set the `pluginRegistryUrl` field.
+gitSelfSignedCert: When enabled, the certificate from `che-git-self-signed-cert` ConfigMap will be propagated to the Che components and provide particular configuration for Git.
+nonProxyHosts: List of hosts that will be reached directly, bypassing the proxy. Specify wild card domain use the following form `.<DOMAIN>` and `|` as delimiter, for example\: `localhost|.my.host.com|123.42.12.32` Only use when configuring a proxy is required. Operator respects OpenShift cluster wide proxy configuration and no additional configuration is required, but defining `nonProxyHosts` in a custom resource leads to merging non proxy hosts lists from the cluster proxy configuration and ones defined in the custom resources. See the doc https\://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html). See also the `proxyURL` fields.
+pluginRegistryCpuLimit: Overrides the CPU limit used in the plugin registry deployment. In cores. (500m = .5 cores). Default to 500m.
+pluginRegistryCpuRequest: Overrides the CPU request used in the plugin registry deployment. In cores. (500m = .5 cores). Default to 100m.
+pluginRegistryImage: Overrides the container image used in the plugin registry deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+pluginRegistryIngress: Plugin registry ingress custom settings.
+pluginRegistryMemoryLimit: Overrides the memory limit used in the plugin registry deployment. Defaults to 256Mi.
+pluginRegistryMemoryRequest: Overrides the memory request used in the plugin registry deployment. Defaults to 16Mi.
+pluginRegistryPullPolicy: Overrides the image pull policy used in the plugin registry deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+pluginRegistryRoute: Plugin registry route custom settings.
+pluginRegistryUrl: Public URL of the plugin registry that serves sample ready-to-use devfiles. Set this ONLY when a use of an external devfile registry is needed. See the `externalPluginRegistry` field. By default, this will be automatically calculated by the Operator.
+proxyPassword: Password of the proxy server. Only use when proxy configuration is required. See the `proxyURL`, `proxyUser` and `proxySecret` fields.
+proxyPort: Port of the proxy server. Only use when configuring a proxy is required. See also the `proxyURL` and `nonProxyHosts` fields.
+proxySecret: The secret that contains `user` and `password` for a proxy server. When the secret is defined, the `proxyUser` and `proxyPassword` are ignored.
+proxyURL: URL (protocol+host name) of the proxy server. This drives the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy` variables in the Che server and workspaces containers. Only use when configuring a proxy is required. Operator respects OpenShift cluster wide proxy configuration and no additional configuration is required, but defining `proxyUrl` in a custom resource leads to overrides the cluster proxy configuration with fields `proxyUrl`, `proxyPort`, `proxyUser` and `proxyPassword` from the custom resource. See the doc https\://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html). See also the `proxyPort` and `nonProxyHosts` fields.
+proxyUser: User name of the proxy server. Only use when configuring a proxy is required. See also the `proxyURL`, `proxyPassword` and `proxySecret` fields.
+selfSignedCert: Deprecated. The value of this flag is ignored. The Che Operator will automatically detect whether the router certificate is self-signed and propagate it to other components, such as the Che server.
+serverCpuLimit: Overrides the CPU limit used in the Che server deployment In cores. (500m = .5 cores). Default to 1.
+serverCpuRequest: Overrides the CPU request used in the Che server deployment In cores. (500m = .5 cores). Default to 100m.
+serverExposureStrategy: Sets the server and workspaces exposure type. Possible values are `multi-host`, `single-host`, `default-host`. Defaults to `multi-host`, which creates a separate ingress, or OpenShift routes, for every required endpoint. `single-host` makes Che exposed on a single host name with workspaces exposed on subpaths. Read the docs to learn about the limitations of this approach. Also consult the `singleHostExposureType` property to further configure how the Operator and the Che server make that happen on Kubernetes. `default-host` exposes the Che server on the host of the cluster. Read the docs to learn about the limitations of this approach.
+serverMemoryLimit: Overrides the memory limit used in the Che server deployment. Defaults to 1Gi.
+serverMemoryRequest: Overrides the memory request used in the Che server deployment. Defaults to 512Mi.
+serverTrustStoreConfigMapName: Name of the ConfigMap with public certificates to add to Java trust store of the Che server. This is often required when adding the OpenShift OAuth provider, which has HTTPS endpoint signed with self-signed cert. The Che server must be aware of its CA cert to be able to request it. This is disabled by default.
+singleHostGatewayConfigMapLabels: The labels that need to be present in the ConfigMaps representing the gateway configuration.
+singleHostGatewayConfigSidecarImage: The image used for the gateway sidecar that provides configuration to the gateway. Omit it or leave it empty to use the default container image provided by the Operator.
+singleHostGatewayImage: The image used for the gateway in the single host mode. Omit it or leave it empty to use the default container image provided by the Operator.
+tlsSupport: Deprecated. Instructs the Operator to deploy Che in TLS mode. This is enabled by default. Disabling TLS sometimes cause malfunction of some Che components.
+useInternalClusterSVCNames: Use internal cluster SVC names to communicate between components to speed up the traffic and avoid proxy issues. The default value is `false`.
+workspaceNamespaceDefault: Defines Kubernetes default namespace in which user's workspaces are created for a case when a user does not override it. It's possible to use `<username>`, `<userid>` and `<workspaceid>` placeholders, such as che-workspace-<username>. In that case, a new namespace will be created for each user or workspace.
+:=== 
+
+[id="checluster-custom-resource-database-settings_{context}"]
+.`CheCluster` Custom Resource `database` configuration settings related to the database used by {prod-short}.
+
+[cols="2,5", options="header"]
+:=== 
+ Property: Description 
+chePostgresContainerResources: PostgreSQL container custom settings
+chePostgresDb: PostgreSQL database name that the Che server uses to connect to the DB. Defaults to `dbche`.
+chePostgresHostName: PostgreSQL Database host name that the Che server uses to connect to. Defaults is `postgres`. Override this value ONLY when using an external database. See field `externalDb`. In the default case it will be automatically set by the Operator.
+chePostgresPassword: PostgreSQL password that the Che server uses to connect to the DB. When omitted or left blank, it will be set to an automatically generated value.
+chePostgresPort: PostgreSQL Database port that the Che server uses to connect to. Defaults to 5432. Override this value ONLY when using an external database. See field `externalDb`. In the default case it will be automatically set by the Operator.
+chePostgresSecret: The secret that contains PosgreSQL`user` and `password` that the Che server uses to connect to the DB. When the secret is defined, the `chePostgresUser` and `chePostgresPassword` are ignored. When the value is omitted or left blank, the one of following scenarios applies\: 1. `chePostgresUser` and `chePostgresPassword` are defined, then they will be used to connect to the DB. 2. `chePostgresUser` or `chePostgresPassword` are not defined, then a new secret with the name `che-postgres-secret` will be created with default value of `pgche` for `user` and with an auto-generated value for `password`.
+chePostgresUser: PostgreSQL user that the Che server uses to connect to the DB. Defaults to `pgche`.
+externalDb: Instructs the Operator on whether to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the Che installation. When `externalDb` is `true`, no dedicated database will be deployed by the Operator and you will need to provide connection details to the external DB you are about to use. See also all the fields starting with\: `chePostgres`.
+postgresImage: Overrides the container image used in the PosgreSQL database deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+postgresImagePullPolicy: Overrides the image pull policy used in the PosgreSQL database deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+:=== 
+
+[id="checluster-custom-resource-auth-settings_{context}"]
+.Custom Resource `auth` configuration settings related to authentication used by {prod-short}.
+
+[cols="2,5", options="header"]
+:=== 
+ Property: Description 
+externalIdentityProvider: Instructs the Operator on whether to deploy a dedicated Identity Provider (Keycloak or RH-SSO instance). By default, a dedicated Identity Provider server is deployed as part of the Che installation. When `externalIdentityProvider` is `true`, no dedicated identity provider will be deployed by the Operator and you will need to provide details about the external identity provider you are about to use. See also all the other fields starting with\: `identityProvider`.
+identityProviderAdminUserName: Overrides the name of the Identity Provider administrator user. Defaults to `admin`.
+identityProviderClientId: Name of a Identity provider, Keycloak or RH-SSO, `client-id` that is used for Che. Override this when an external Identity Provider is in use. See the `externalIdentityProvider` field. When omitted or left blank, it is set to the value of the `flavour` field suffixed with `-public`.
+identityProviderContainerResources: Identity provider container custom settings.
+identityProviderImage: Overrides the container image used in the Identity Provider, Keycloak or RH-SSO, deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
+identityProviderImagePullPolicy: Overrides the image pull policy used in the Identity Provider, Keycloak or RH-SSO, deployment. Default value is `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases.
+identityProviderIngress: Ingress custom settings.
+identityProviderPassword: Overrides the password of Keycloak administrator user. Override this when an external Identity Provider is in use. See the `externalIdentityProvider` field. When omitted or left blank, it is set to an auto-generated password.
+identityProviderPostgresPassword: Password for a Identity Provider, Keycloak or RH-SSO, to connect to the database. Override this when an external Identity Provider is in use. See the `externalIdentityProvider` field. When omitted or left blank, it is set to an auto-generated password.
+identityProviderPostgresSecret: The secret that contains `password` for the Identity Provider, Keycloak or RH-SSO, to connect to the database. When the secret is defined, the `identityProviderPostgresPassword` is ignored. When the value is omitted or left blank, the one of following scenarios applies\: 1. `identityProviderPostgresPassword` is defined, then it will be used to connect to the database. 2. `identityProviderPostgresPassword` is not defined, then a new secret with the name `che-identity-postgres-secret` will be created with an auto-generated value for `password`.
+identityProviderRealm: Name of a Identity provider, Keycloak or RH-SSO, realm that is used for Che. Override this when an external Identity Provider is in use. See the `externalIdentityProvider` field. When omitted or left blank, it is set to the value of the `flavour` field.
+identityProviderRoute: Route custom settings.
+identityProviderSecret: The secret that contains `user` and `password` for Identity Provider. When the secret is defined, the `identityProviderAdminUserName` and `identityProviderPassword` are ignored. When the value is omitted or left blank, the one of following scenarios applies\: 1. `identityProviderAdminUserName` and `identityProviderPassword` are defined, then they will be used. 2. `identityProviderAdminUserName` or `identityProviderPassword` are not defined, then a new secret with the name `che-identity-secret` will be created with default value `admin` for `user` and with an auto-generated value for `password`.
+identityProviderURL: Public URL of the Identity Provider server (Keycloak / RH-SSO server). Set this ONLY when a use of an external Identity Provider is needed. See the `externalIdentityProvider` field. By default, this will be automatically calculated and set by the Operator.
+oAuthClientName: Name of the OpenShift `OAuthClient` resource used to setup identity federation on the OpenShift side. Auto-generated when left blank. See also the `OpenShiftoAuth` field.
+oAuthSecret: Name of the secret set in the OpenShift `OAuthClient` resource used to setup identity federation on the OpenShift side. Auto-generated when left blank. See also the `OAuthClientName` field.
+openShiftoAuth: Enables the integration of the identity provider (Keycloak / RHSSO) with OpenShift OAuth. Empty value on OpenShift by default. This will allow users to directly login with their OpenShift user through the OpenShift login, and have their workspaces created under personal OpenShift namespaces. WARNING\: the `kubeadmin` user is NOT supported, and logging through it will NOT allow accessing the Che Dashboard.
+updateAdminPassword: Forces the default `admin` Che user to update password on first login. Defaults to `false`.
+:=== 
+
+[id="checluster-custom-resource-storage-settings_{context}"]
+.`CheCluster` Custom Resource `storage` configuration settings related to persistent storage used by {prod-short}.
+
+[cols="2,5", options="header"]
+:=== 
+ Property: Description 
+postgresPVCStorageClassName: Storage class for the Persistent Volume Claim dedicated to the PosgreSQL database. When omitted or left blank, a default storage class is used.
+preCreateSubPaths: Instructs the Che server to start a special Pod to pre-create a sub-path in the Persistent Volumes. Defaults to `false`, however it will need to enable it according to the configuration of your Kubernetes cluster.
+pvcClaimSize: Size of the persistent volume claim for workspaces. Defaults to `1Gi`.
+pvcJobsImage: Overrides the container image used to create sub-paths in the Persistent Volumes. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator. See also the `preCreateSubPaths` field.
+pvcStrategy: Persistent volume claim strategy for the Che server. This Can be\:`common` (all workspaces PVCs in one volume), `per-workspace` (one PVC per workspace for all declared volumes) and `unique` (one PVC per declared volume). Defaults to `common`.
+workspacePVCStorageClassName: Storage class for the Persistent Volume Claims dedicated to the Che workspaces. When omitted or left blank, a default storage class is used.
+:=== 
+
+[id="checluster-custom-resource-k8s-settings_{context}"]
+.`CheCluster` Custom Resource `k8s` configuration settings specific to {prod-short} installations on {platforms-name}.
+
+[cols="2,5", options="header"]
+:=== 
+ Property: Description 
+ingressClass: Ingress class that will define the which controller will manage ingresses. Defaults to `nginx`. NB\: This drives the `kubernetes.io/ingress.class` annotation on Che-related ingresses.
+ingressDomain: Global ingress domain for a Kubernetes cluster. This MUST be explicitly specified\: there are no defaults.
+ingressStrategy: Strategy for ingress creation. Options are\: `multi-host` (host is explicitly provided in ingress), `single-host` (host is provided, path-based rules) and `default-host` (no host is provided, path-based rules). Defaults to `multi-host` Deprecated in favor of `serverExposureStrategy` in the `server` section, which defines this regardless of the cluster type. When both are defined, the `serverExposureStrategy` option takes precedence.
+securityContextFsGroup: The FSGroup in which the Che Pod and workspace Pods containers runs in. Default value is `1724`.
+securityContextRunAsUser: ID of the user the Che Pod and workspace Pods containers run as. Default value is `1724`.
+singleHostExposureType: When the serverExposureStrategy is set to `single-host`, the way the server, registries and workspaces are exposed is further configured by this property. The possible values are `native`, which means that the server and workspaces are exposed using ingresses on K8s or `gateway` where the server and workspaces are exposed using a custom gateway based on link\:https\://doc.traefik.io/traefik/[Traefik]. All the endpoints whether backed by the ingress or gateway `route` always point to the subpaths on the same domain. Defaults to `native`.
+tlsSecretName: Name of a secret that will be used to setup ingress TLS termination when TLS is enabled. When the field is empty string, the default cluster certificate will be used. See also the `tlsSupport` field.
+:=== 
+
+[id="checluster-custom-resource-metrics-settings_{context}"]
+.`CheCluster` Custom Resource `metrics` settings, related to the {prod-short} metrics collection used by {prod-short}.
+
+[cols="2,5", options="header"]
+:=== 
+ Property: Description 
+enable: Enables `metrics` the Che server endpoint. Default to `true`.
+:=== 
+
+[id="checluster-custom-resource-status-settings_{context}"]
+.`CheCluster` Custom Resource `status` defines the observed state of {prod-short} installation
+
+[cols="2,5", options="header"]
+:=== 
+ Property: Description 
+cheClusterRunning: Status of a Che installation. Can be `Available`, `Unavailable`, or `Available, Rolling Update in Progress`.
+cheURL: Public URL to the Che server.
+cheVersion: Current installed Che version.
+dbProvisioned: Indicates that a PosgreSQL instance has been correctly provisioned or not.
+devfileRegistryURL: Public URL to the devfile registry.
+gitHubOAuthProvisioned: Indicates whether an Identity Provider instance, Keycloak or RH-SSO, has been configured to integrate with the GitHub OAuth.
+helpLink: A URL that points to some URL where to find help related to the current Operator status.
+keycloakProvisioned: Indicates whether an Identity Provider instance, Keycloak or RH-SSO, has been provisioned with realm, client and user.
+keycloakURL: Public URL to the Identity Provider server, Keycloak or RH-SSO,.
+message: A human readable message indicating details about why the Pod is in this condition.
+openShiftoAuthProvisioned: Indicates whether an Identity Provider instance, Keycloak or RH-SSO, has been configured to integrate with the OpenShift OAuth.
+pluginRegistryURL: Public URL to the plugin registry.
+reason: A brief CamelCase message indicating details about why the Pod is in this state.
+:=== 
+
+

--- a/modules/installation-guide/examples/system-variables.adoc
+++ b/modules/installation-guide/examples/system-variables.adoc
@@ -310,7 +310,7 @@
 ,=== 
  Environment Variable Name,Default value, Description 
  
- `+CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER+`,"`+NULL+`","Alias of the Openshift identity provider registered in Keycloak, that should be used to create workspace OpenShift resources in Openshift namespaces owned by the current {prod-short} user. Should be set to NULL if `che.infra.openshift.project` is set to a non-empty value. For more information see the following documentation: \https://www.keycloak.org/docs/latest/server_admin/index.html#openshift-4" 
+ `+CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER+`,"`+NULL+`","Alias of the Openshift identity provider registered in Keycloak, which will be used to create workspace OpenShift resources in Openshift namespaces owned by the current {prod-short} user. Should be set to NULL if `che.infra.openshift.project` is set to a non-empty value. For more information see the following documentation: \https://www.keycloak.org/docs/latest/server_admin/index.html#openshift-4" 
 ,=== 
 
 [id="keycloak-configuration"]

--- a/modules/installation-guide/partials/con_understanding-the-checluster-custom-resource.adoc
+++ b/modules/installation-guide/partials/con_understanding-the-checluster-custom-resource.adoc
@@ -28,7 +28,7 @@ Role of the {orch-name} platform::
 
 .Additional resources
 
-* link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Understanding Operators].
+* link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Understanding Operators].
 
 * link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Understanding Custom Resources].
 

--- a/modules/installation-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
+++ b/modules/installation-guide/partials/proc_configuring-a-che-workspace-with-a-persistent-volume-strategy.adoc
@@ -90,7 +90,7 @@ The following section describes how to configure workspace persistent volume cla
 
 WARNING: It is not recommended to reconfigure PVC strategies on an existing {prod-short} cluster with existing workspaces. Doing so causes data loss.
 
-link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operators] are software extensions to {platforms-name} that use link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Custom Resources] to manage applications and their components.
+link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operators] are software extensions to {platforms-name} that use link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Custom Resources] to manage applications and their components.
 
 When deploying {prod-short} using the Operator, configure the intended strategy by modifying the `spec.storage.pvcStrategy` property of the CheCluster Custom Resource object YAML file.
 

--- a/modules/installation-guide/partials/proc_configuring-che-hostname.adoc
+++ b/modules/installation-guide/partials/proc_configuring-che-hostname.adoc
@@ -22,16 +22,16 @@ IMPORTANT: Ask a DNS provider to point the custom hostname to the cluster ingres
 $ {orch-cli} create {orch-namespace} {prod-namespace}
 ----
 
-. Create a tls secret:
+. Create a TLS secret:
 +
 [subs="+quotes,attributes"]
 ----
-$ {orch-cli} create secret tls $\{secret} \  <1>
+$ {orch-cli} create secret TLS $\{secret} \  <1>
 --key $\{key_file} \                       <2>
 --cert $\{cert_file} \                     <3>
 -n {prod-namespace}
 ----
-<1> The tls secret name
+<1> The TLS secret name
 <2> A file with the private key
 <3> A file with the certificate
 
@@ -46,8 +46,12 @@ spec:
     cheHostTLSSecret: <secret>  <2>
 ----
 <1> Custom {prod} server hostname
-<2> The tls secret name
+<2> The TLS secret name
 
 . If {prod-short} has been already deployed and {prod-short} reconfiguring to use a new {prod-short} hostname is required, log in using {identity-provider} and select the `{prod-deployment}-public` client in the `{prod-short}` realm and update `Validate Redirect URIs` and `Web Origins` fields with the value of the {prod-short} hostname.
 +
 image::keycloak/keycloak_che_public_client.png[]
++
+For logging in to {identity-provider}, follow the procedure below.
+
+include::partial$proc_logging-in-to-identity-provider.adoc[]

--- a/modules/installation-guide/partials/proc_configuring-che-hostname.adoc
+++ b/modules/installation-guide/partials/proc_configuring-che-hostname.adoc
@@ -51,12 +51,18 @@ spec:
 <1> Custom {prod} server hostname
 <2> The TLS secret name
 
+pass:[<!-- vale Vale.Spelling = NO -->]
+
+pass:[<!-- vale Vale.Terms = NO -->]
+
 . If {prod-short} has been already deployed and {prod-short} reconfiguring to use a new {prod-short} hostname is required, log in using {identity-provider} and select the `{prod-deployment}-public` client in the `{prod-short}` realm and update `Validate Redirect URIs` and `Web Origins` fields with the value of the {prod-short} hostname.
 +
 image::keycloak/keycloak_che_public_client.png[]
 +
-For logging in to {identity-provider}, follow the procedure below.
+For logging in to {identity-provider}, follow the xref:setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc#logging-in-to-identity-provider_che[Logging in to {identity-provider}] procedure.
 
-include::partial$proc_logging-in-to-identity-provider.adoc[]
+pass:[<!-- vale Vale.Spelling = YES -->]
+
+pass:[<!-- vale Vale.Terms = YES -->]
 
 :context: {parent-context-of-customize-chehost}

--- a/modules/installation-guide/partials/proc_configuring-che-hostname.adoc
+++ b/modules/installation-guide/partials/proc_configuring-che-hostname.adoc
@@ -1,6 +1,9 @@
+:parent-context-of-customize-chehost: {context}
 
 [id="customize-chehost_{context}"]
 = Configuring {prod} server hostname
+
+:context: customize-chehost
 
 This procedure describes how to configure {prod} to use custom hostname.
 
@@ -55,3 +58,5 @@ image::keycloak/keycloak_che_public_client.png[]
 For logging in to {identity-provider}, follow the procedure below.
 
 include::partial$proc_logging-in-to-identity-provider.adoc[]
+
+:context: {parent-context-of-customize-chehost}

--- a/modules/installation-guide/partials/proc_configuring-che-hostname.adoc
+++ b/modules/installation-guide/partials/proc_configuring-che-hostname.adoc
@@ -59,7 +59,7 @@ pass:[<!-- vale Vale.Terms = NO -->]
 +
 image::keycloak/keycloak_che_public_client.png[]
 +
-For logging in to {identity-provider}, follow the xref:setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc#logging-in-to-identity-provider_che[Logging in to {identity-provider}] procedure.
+For logging in to {identity-provider}, follow the xref:setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc#logging-in-to-identity-provider_{context}[Logging in to {identity-provider}] procedure.
 
 pass:[<!-- vale Vale.Spelling = YES -->]
 

--- a/modules/installation-guide/partials/proc_configuring-workspace-exposure-strategies-using-an-operator.adoc
+++ b/modules/installation-guide/partials/proc_configuring-workspace-exposure-strategies-using-an-operator.adoc
@@ -5,7 +5,7 @@
 [id="configuring-workspace-exposure-strategies-using-an-operator_{context}"]
 = Configuring workspace exposure strategies using an Operator
 
-link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operators] are software extensions to {platforms-name} that use link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Custom Resources] to manage applications and their components.
+link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operators] are software extensions to {platforms-name} that use link:https://docs.openshift.com/container-platform/latest/operators/understanding/crds/crd-managing-resources-from-crds.html[Custom Resources] to manage applications and their components.
 
 .Prerequisites
 

--- a/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates-old.adoc
+++ b/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates-old.adoc
@@ -62,7 +62,7 @@ To apply more than one certificate, add another `--from-file=_<certificate-file-
 . During the installation process, when creating the `CheCluster` custom resource, take care of configuring the right name for the created ConfigMap.
 +
 ====
-For a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operator] deployment,
+For a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment,
 ensure you add the `spec.server.ServerTrustStoreConfigMapName` field with the name of the ConfigMap, to the `CheCluster` Custom Resource you will create during the installation:
 
 [source,yaml,subs="+quotes",options="nowrap",role=white-space-pre]
@@ -93,7 +93,7 @@ endif::[]
 * You should first gather the name of the ConfigMap used to import certificates:
 +
 ====
-On instances of {prod-short} deployed with the {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operator],
+On instances of {prod-short} deployed with the {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator],
 retrieve the name of the ConfigMap by reading the `spec.server.ServerTrustStoreConfigMapName` `CheCluster` Custom Resource property:
 
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
@@ -134,7 +134,7 @@ To apply more than one certificate, add another `--from-file=_<certificate-file-
 . Configure the {prod-short} installation to use the ConfigMap:
 +
 ====
-For a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operators] deployment:
+For a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operators] deployment:
 
 . Edit the `spec.server.ServerTrustStoreConfigMapName` `CheCluster` Custom Resource property to match the name of the ConfigMap:
 +
@@ -188,7 +188,7 @@ and higher.
 
 If you added the certificates without error, the {prod-short} server starts and obtains {identity-provider} configuration over https. Otherwise here is a list of things to verify:
 
-. In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operator] deployment, the `CheCluster` attribute `serverTrustStoreConfigMapName` value matches the name of the ConfigMap. Get the value using the following command :
+. In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment, the `CheCluster` attribute `serverTrustStoreConfigMapName` value matches the name of the ConfigMap. Get the value using the following command :
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----

--- a/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates.adoc
+++ b/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates.adoc
@@ -120,7 +120,7 @@ endif::[]
 
 If after adding the certificates something does not work as expected, here is a list of things to verify:
 
-- In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/olm-what-operators-are.html[Operator] deployment, namespace where `CheCluster` located contains labeled ConfigMaps with right content:
+- In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment, namespace where `CheCluster` located contains labeled ConfigMaps with right content:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----

--- a/modules/installation-guide/partials/proc_logging-in-to-identity-provider.adoc
+++ b/modules/installation-guide/partials/proc_logging-in-to-identity-provider.adoc
@@ -1,4 +1,4 @@
-[id="proc_logging-in-to-identity-provider_{context}"]
+[id="logging-in-to-identity-provider_{context}"]
 == Logging in to {identity-provider}
 
 The following procedure describes how to log in to {identity-provider}, which acts as a route for OpenShift platforms. To log in to {identity-provider}, a user has to obtain the {identity-provider} URL and a user's credentials first.

--- a/modules/installation-guide/partials/proc_logging-in-to-identity-provider.adoc
+++ b/modules/installation-guide/partials/proc_logging-in-to-identity-provider.adoc
@@ -1,0 +1,34 @@
+[id="proc_logging-in-to-identity-provider_{context}"]
+== Logging in to {identity-provider}
+
+The following procedure describes how to log in to {identity-provider}, which acts as a route for OpenShift platforms. To log in to {identity-provider}, a user has to obtain the {identity-provider} URL and a user's credentials first.
+ 
+.Prerequisites
+ 
+* The `{orch-cli}` tool installed.
+* Logged in to OpenShift cluster using the `{orch-cli}` tool.
+ 
+.Procedure
+ 
+. Obtain a user {identity-provider} login:
++
+[subs="+attributes,+quotes"]
+----
+{orch-cli} get secret che-identity-secret  -n {prod-namespace} -o json | jq -r '.data.user' | base64 -d
+----
+ 
+. Obtain a user {identity-provider} password:
++
+[subs="+attributes,+quotes"]
+----
+{orch-cli} get secret che-identity-secret  -n {prod-namespace} -o json | jq -r '.data.password' | base64 -d 
+----
+ 
+. Obtain the {identity-provider} URL:
++
+[subs="+attributes,+quotes"]
+----
+{orch-cli}  get ingress -n {prod-namespace} -l app=che,component=keycloak   -o 'custom-columns=URL:.spec.rules[0].host' --no-headers
+----
+ 
+. Open the URL in a browser and log in to {identity-provider} using the obtained login and password. 

--- a/modules/installation-guide/partials/proc_setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc
+++ b/modules/installation-guide/partials/proc_setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc
@@ -1,9 +1,12 @@
+:parent-context-of-setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page: {context}
 // Module included in the following assemblies:
 //
 // configuring-che
 
 [id="setting-up-the-{identity-provider-id}-{prod-id-short}-username-readonly-theme-for-the-{prod-id}-login-page_{context}"]
 = Setting up the {identity-provider} {prod-id-short}-username-readonly theme for the {prod} login page
+
+:context: setting-up-the-{identity-provider-id}-{prod-id-short}-username-readonly-theme-for-the-{prod-id}-login-page
 
 The following procedure is relevant for all {prod-short} instances with the OpenShift OAuth service enabled.
 
@@ -32,3 +35,4 @@ image::keycloak/{project-context}-keycloak-username-readonly-theme.png[link="../
 
 . In the *Login Theme* field, select the `{prod-id-short}-username-readonly` option and click the btn:[Save] button to apply the changes.
 
+:context: {parent-context-of-setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page}

--- a/modules/installation-guide/partials/proc_setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc
+++ b/modules/installation-guide/partials/proc_setting-up-the-keycloak-che-username-readonly-theme-for-the-eclipse-che-login-page.adoc
@@ -7,8 +7,13 @@
 
 The following procedure is relevant for all {prod-short} instances with the OpenShift OAuth service enabled.
 
-When a user with pre-created namespaces logs in to {prod} Dashboard for the first time, a page allowing the user to update account information is displayed. It is possible to change the username, but choosing a username that doesn't match the OpenShift username, prevents the user's workspaces from running. This is caused by {prod-short} attempts to use a non-existing namespace, the name of which is derived from a user OpenShift username, to create a workspace. To prevent this, modify the {identity-provider} settings using the steps below. 
+When a user with pre-created namespaces logs in to {prod} Dashboard for the first time, a page allowing the user to update account information is displayed. It is possible to change the username, but choosing a username that doesn't match the OpenShift username, prevents the user's workspaces from running. This is caused by {prod-short} attempts to use a non-existing namespace, the name of which is derived from a user OpenShift username, to create a workspace. To prevent this, log in to {identity-provider} and modify the theme settings.
 
+
+include::partial$proc_logging-in-to-identity-provider.adoc[]
+
+
+== Setting up the {identity-provider} {prod-id-short}-username-readonly theme
 
 .Prerequisites
 
@@ -20,7 +25,7 @@ When a user with pre-created namespaces logs in to {prod} Dashboard for the firs
 After changing a username, set the *Login Theme* option to `readonly`.
 
 . In the main *Configure* menu on the left, select *Realm Settings*:
-+
+
 image::keycloak/{project-context}-keycloak-username-readonly-theme.png[link="../_images/keycloak/{project-context}-keycloak-username-readonly-theme.png"]
 
 . Navigate to the *Themes* tab.

--- a/modules/installation-guide/partials/ref_checluster-custom-resource-fields-reference.adoc
+++ b/modules/installation-guide/partials/ref_checluster-custom-resource-fields-reference.adoc
@@ -8,12 +8,13 @@
 This section describes all fields available to customize the `CheCluster` Custom Resource.
 
 * xref:a-minimal-checluster-custom-resource-example_{context}[]
-* xref:checluster-custom-resource-auth-settings_{context}[]
-* xref:checluster-custom-resource-database-settings_{context}[]
 * xref:checluster-custom-resource-server-settings_{context}[]
+* xref:checluster-custom-resource-database-settings_{context}[]
+* xref:checluster-custom-resource-auth-settings_{context}[]
 * xref:checluster-custom-resource-storage-settings_{context}[]
 * xref:checluster-custom-resource-k8s-settings_{context}[]
-* xref:checluster-custom-resource-installation-settings_{context}[]
+* xref:checluster-custom-resource-metrics-settings_{context}[]
+* xref:checluster-custom-resource-status-settings_{context}[]
 
 [id="a-minimal-checluster-custom-resource-example_{context}"]
 .A minimal `CheCluster` Custom Resource example.
@@ -24,130 +25,4 @@ include::example$checluster-custom-resource.yaml[]
 ----
 ====
 
-
-
-[id="checluster-custom-resource-server-settings_{context}"]
-.`CheCluster` Custom Resource `server` settings, related to the {prod-short} server component.
-[cols="1,1,3", options="header"]
-:===
-Property: Default value: Description
-
-`airGapContainerRegistryHostname`: omit: An optional host name or URL to an alternative container registry to pull images from. This value overrides the container registry host name defined in all default container images involved in a {prod-short} deployment. This is particularly useful to install {prod-short} in an air-gapped environment.
-`airGapContainerRegistryOrganization`: omit: Optional repository name of an alternative container registry to pull images from. This value overrides the container registry organization defined in all the default container images involved in a {prod-short} deployment. This is particularly useful to install {prod-short} in an air-gapped environment.
-`cheDebug`: `false`: Enables the debug mode for {prod-short} server.
-`cheFlavor`: `{prod-id-short}`: Flavor of the installation.
-`cheHost`: The Operator automatically sets the value.: A public host name of the installed {prod-short} server.
-`cheImagePullPolicy`:  `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases: Overrides the image pull policy used in {prod-short} deployment.
-`cheImageTag`: omit:  Overrides the tag of the container image used in {prod-short} deployment. Omit it or leave it empty to use the default image tag provided by the Operator.
-`cheImage`: omit: Overrides the container image used in {prod-short} deployment. This does not include the container image tag. Omit it or leave it empty to use the default container image provided by the Operator.
-`cheLogLevel`: `INFO`: Log level for the {prod-short} server\: `INFO` or `DEBUG`.
-`cheClusterRoles`: `che-namespace-editor`: Comma-separated list of ClusterRoles that will be assigned to che ServiceAccount. Che uses default `che-namespace-editor` ClusterRole to label workspace namespaces. Be aware that che-operator has to already have all permissions in these ClusterRoles to be able to grant them.
-`cheWorkspaceClusterRole`: omit: Custom cluster role bound to the user for the {prod-short} workspaces. Omit or leave empty to use the default roles.
-`customCheProperties`: omit: Map of additional environment variables that will be applied in the generated `{prod-id-short}` ConfigMap to be used by the {prod-short} server, in addition to the values already generated from other fields of the `CheCluster` Custom Resource (CR). If `customCheProperties` contains a property that would be normally generated in `{prod-id-short}` ConfigMap from other CR fields, then the value defined in the `customCheProperties` will be used instead.
-`devfileRegistryImage`: omit: Overrides the container image used in the Devfile registry deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
-`devfileRegistryMemoryLimit`: `256Mi`: Overrides the memory limit used in the Devfile registry deployment.
-`devfileRegistryMemoryRequest`: `16Mi`: Overrides the memory request used in the Devfile registry deployment.
-`devfileRegistryPullPolicy`: `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases: Overrides the image pull policy used in the Devfile registry deployment.
-`devfileRegistryUrl`: The Operator automatically sets the value.: Public URL of the Devfile registry that serves sample, ready-to-use devfiles. Set it if you use an external devfile registry (see the `externalDevfileRegistry` field).
-`externalDevfileRegistry`: `false`: Instructs the Operator to deploy a dedicated Devfile registry server. By default a dedicated devfile registry server is started. If `externalDevfileRegistry` set to `true`, the Operator does not start a dedicated registry server automatically and you need to set the `devfileRegistryUrl` field manually.
-`externalPluginRegistry`: `false`: Instructs the Operator to deploy a dedicated Plugin registry server. By default, a dedicated plug-in registry server is started. If `externalPluginRegistry` set to `true`, the Operator does not deploy a dedicated server automatically and you need to set the `pluginRegistryUrl` field manually.
-`nonProxyHosts`: omit: List of hosts that will not use the configured proxy. Use `|`` as delimiter, for example `localhost|my.host.com|123.42.12.32` Only use when configuring a proxy is required (see also the `proxyURL` field).
-`pluginRegistryImage`: omit: Overrides the container image used in the Plugin registry deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
-`pluginRegistryMemoryLimit`: `256Mi`: Overrides the memory limit used in the Plugin registry deployment.
-`pluginRegistryMemoryRequest`: `16Mi`: Overrides the memory request used in the Plugin registry deployment.
-`pluginRegistryPullPolicy`: `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases: Overrides the image pull policy used in the Plugin registry deployment.
-`pluginRegistryUrl`: the Operator sets the value automatically: Public URL of the Plugin registry that serves sample ready-to-use devfiles. Set it only when using an external devfile registry (see the `externalPluginRegistry` field).
-`proxyPassword`: omit: Password of the proxy server. Only use when proxy configuration is required.
-`proxyPort`: omit: Port of the proxy server. Only use when configuring a proxy is required (see also the `proxyURL` field).
-`proxyURL`: omit: URL (protocol+host name) of the proxy server. This drives the appropriate changes in the `JAVA_OPTS` and `https(s)_proxy` variables in the {prod-short} server and workspaces containers. Only use when configuring a proxy is required.
-`proxyUser`: omit: User name of the proxy server. Only use when configuring a proxy is required (see also the `proxyURL` field).
-`serverMemoryLimit`: `1Gi`: Overrides the memory limit used in the {prod-short} server deployment.
-`serverMemoryRequest`: `512Mi`: Overrides the memory request used in the {prod-short} server deployment.
-`tlsSupport`: `true`: Instructs the Operator to deploy {prod-short} in TLS mode.
-:===
-
-[id="checluster-custom-resource-database-settings_{context}"]
-.`CheCluster` Custom Resource `database` configuration settings related to the database used by {prod-short}
-[cols="1,1,3", options="header"]
-:===
-Property: Default value: Description
-
-`chePostgresDb`: `dbche`: PostgreSQL database name that the {prod-short} server uses to connect to the database.
-`chePostgresHostName`: the Operator sets the value automatically: PostgreSQL Database host name that the {prod-short} server uses to connect to. Defaults to `postgres`. Override this value only when using an external database. (See the field `externalDb`.)
-`chePostgresPassword`: auto-generated value: PostgreSQL password that the {prod-short} server uses to connect to the database.
-`chePostgresPort`: `5432`: PostgreSQL Database port that the {prod-short} server uses to connect to. Override this value only when using an external database (see field `externalDb`).
-`chePostgresUser`: `pgche`: PostgreSQL user that the {prod-short} server uses to connect to the database.
-`externalDb`: `false`: Instructs the Operator to deploy a dedicated database. By default, a dedicated PostgreSQL database is deployed as part of the {prod-short} installation. If set to `true`, the Operator does not deploy a dedicated database automatically, you need to provide connection details to an external database. See all the fields starting with\: `chePostgres`.
-`postgresImagePullPolicy`: Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases: Overrides the image pull policy used in the PostgreSQL database deployment.
-`postgresImage`: omit: Overrides the container image used in the PostgreSQL database deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
-:===
-
-[id="checluster-custom-resource-auth-settings_{context}"]
-.`CheCluster` Custom Resource `auth` configuration settings related to authentication used by {prod-short} installation
-[cols="1,1,3", options="header"]
-:===
-Property: Default value: Description
-
-`externalIdentityProvider`: `false`: By default, a dedicated Identity Provider server is deployed as part of the {prod-short} installation. But if `externalIdentityProvider` is `true`, then no dedicated identity provider will be deployed by the Operator and you might need to provide details about the external identity provider you want to use. See also all the other fields starting with\: `identityProvider`.
-`identityProviderAdminUserName`:`admin`:  Overrides the name of the Identity Provider admin user.
-`identityProviderClientId`: omit: Name of an Identity provider ({identity-provider}) `client-id` that must be used for {prod-short}. This is useful to override it ONLY if you use an external Identity Provider (see the `externalIdentityProvider` field). If omitted or left blank, it will be set to the value of the `flavor` field suffixed with `-public`.
-`identityProviderImagePullPolicy`: `Always` for `nightly` or `latest` images, and `IfNotPresent` in other cases: Overrides the image pull policy used in the Identity Provider ({identity-provider}) deployment.
-`identityProviderImage`: omit: Overrides the container image used in the Identity Provider ({identity-provider}) deployment. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator.
-`identityProviderPassword`: omit: Overrides the password of {identity-provider} admin user. Override it only when using an external Identity Provider (see the `externalIdentityProvider` field). Omit or leave empty to set an auto-generated password.
-`identityProviderPostgresPassword`: the Operator sets the value automatically: Password for The Identity Provider ({identity-provider}) to connect to the database. This is useful to override it ONLY if you use an external Identity Provider (see the `externalIdentityProvider` field).
-`identityProviderRealm`: omit: Name of an Identity provider ({identity-provider}) realm. Override it only when using an external Identity Provider (see the `externalIdentityProvider` field). Omit or leave empty blank to set it to the value of the `flavor` field.
-`identityProviderURL`: the Operator sets the value automatically: Instructs the Operator to deploy a dedicated Identity Provider ({identity-provider} instance). Public URL of the Identity Provider server ({identity-provider} server). Set it only when using an external Identity Provider (see the `externalIdentityProvider` field).
-`oAuthClientName`: the Operator sets the value automatically: Name of the OpenShift `OAuthClient` resource used to setup identity federation on the OpenShift side. See also the `OpenShiftoAuth` field.
-`oAuthSecret`: the Operator sets the value automatically: Name of the secret set in the OpenShift `OAuthClient` resource used to setup identity federation on the OpenShift side. See also the `OAuthClientName` field.
-`openShiftoAuth`: `true` on OpenShift: Enables the integration of the identity provider ({identity-provider} / RHSSO) with OpenShift OAuth. This allows users to log in with their OpenShift login and have their workspaces created under personal OpenShift {orch-namespace}s. The `kubeadmin` user is not supported, and logging through does not allow access to the {prod-short} Dashboard.
-`updateAdminPassword`: `false`: Forces the default `admin` {prod-short} user to update password on first login.
-:===
-
-[id="checluster-custom-resource-storage-settings_{context}"]
-.`CheCluster` Custom Resource `storage` configuration settings related to persistent storage used by {prod-short}
-[cols="1,1,3", options="header"]
-:===
-Property: Default value: Description
-
-`postgresPVCStorageClassName`: omit: Storage class for the Persistent Volume Claim dedicated to the PostgreSQL database. Omitted or leave empty to use a default storage class.
-`preCreateSubPaths`: `false`: Instructs the {prod-short} server to launch a special Pod to pre-create a subpath in the Persistent Volumes. Enable it according to the configuration of your K8S cluster.
-`pvcClaimSize`: `1Gi`: Size of the persistent volume claim for workspaces.
-`pvcJobsImage`: omit: Overrides the container image used to create sub-paths in the Persistent Volumes. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator. See also the `preCreateSubPaths` field.
-`pvcStrategy`: `common`: Available options\:`common` (all workspaces PVCs in one volume), `per-workspace` (one PVC per workspace for all declared volumes) and `unique` (one PVC per declared volume).
-`workspacePVCStorageClassName`: omit: Storage class for the Persistent Volume Claims dedicated to the {prod-short} workspaces. Omit or leave empty to use a default storage class.
-:===
-
-
-[id="checluster-custom-resource-k8s-settings_{context}"]
-.`CheCluster` Custom Resource `k8s` configuration settings specific to {prod-short} installations on {platforms-name}
-[cols="1,1,3", options="header"]
-:===
-Property: Default value: Description
-
-`ingressClass`: `nginx`: Ingress class that defines which controller manages ingresses.
-`ingressDomain`: omit: Global ingress domain for a K8S cluster. This field must be explicitly specified. This drives the `is kubernetes.io/ingress.class` annotation on {prod-short}-related ingresses.
-`ingressStrategy`: `multi-host`: Strategy for ingress creation. This can be `multi-host` (host is explicitly provided in ingress), `single-host` (host is provided, path-based rules) and `default-host.*`(no host is provided, path-based rules).
-`securityContextFsGroup,omitempty`: `1724`: FSGroup the {prod-short} Pod and Workspace Pods containers run in.
-`securityContextRunAsUser`: `1724`: ID of the user the {prod-short} Pod and Workspace Pods containers run as.
-`tlsSecretName`: che-tls: Name of a secret that is used to set ingress TLS termination if TLS is enabled. If the specified secret does not exist, a self-signed certificate will be created. If the value is empty or omitted, the default ingress controller certificate will be used. See also the `tlsSupport` field. Note, when switching to the default ingress controller certificate, `self-signed-certificate` secret should be deleted manually.
-:===
-
-[id="checluster-custom-resource-installation-settings_{context}"]
-.`CheCluster` Custom Resource `status` defines the observed state of {prod-short} installation
-[cols="1,3", options="header"]
-:===
-Property: Description
-
-`cheClusterRunning`: Status of a {prod-short} installation. Can be `Available`, `Unavailable`, or `Available, Rolling Update in Progress`.
-`cheURL`: Public URL to the {prod-short} server.
-`cheVersion`: Currently installed {prod-short} version.
-`dbProvisioned`: Indicates whether a PostgreSQL instance has been correctly provisioned.
-`devfileRegistryURL`: Public URL to the Devfile registry.
-`helpLink`: A URL to where to find help related to the current Operator status.
-`keycloakProvisioned`: Indicates whether an Identity Provider instance ({identity-provider} / RH SSO) has been provisioned with realm, client and user.
-`keycloakURL`: Public URL to the Identity Provider server ({identity-provider} / RH SSO).
-`message`: A human-readable message with details about why the Pod is in this state.
-`openShiftoAuthProvisioned`: Indicates whether an Identity Provider instance ({identity-provider} / RH SSO) has been configured to integrate with the OpenShift OAuth.
-`pluginRegistryURL`: Public URL to the Plugin registry.
-`reason`: A brief CamelCase message with details about why the Pod is in this state.
-:===
+include::example$checluster-properties.adoc[leveloffset=+1]

--- a/tools/checluster_docs_gen.sh
+++ b/tools/checluster_docs_gen.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+set -o pipefail
+set -e
+
+CURRENT_VERSION=""
+PRODUCT=""
+RAW_CONTENT=""
+NEWLINE=$'\n'
+NEWLINEx2="$NEWLINE$NEWLINE"
+TABLE_HEADER="$NEWLINE[cols=\"2,5\", options=\"header\"]$NEWLINE:=== $NEWLINE Property: Description $NEWLINE"
+TABLE_FOOTER=":=== $NEWLINEx2"
+PARENT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd -P)
+BUFF=""
+OUTPUT_PATH="$PARENT_PATH/modules/installation-guide/examples/checluster-properties.adoc"
+
+fetch_current_version() {
+  echo "Trying to read current product version from $PARENT_PATH/antora-playbook.yml..." >&2
+  CURRENT_VERSION=$(yq -M '.asciidoc.attributes."prod-ver"' "$PARENT_PATH/antora-playbook.yml").x
+  if [[ "$CURRENT_VERSION" == *-SNAPSHOT ]]; then
+     CURRENT_VERSION="master"
+  fi
+  echo "Detected version: $CURRENT_VERSION" >&2
+}
+
+fetch_product_name() {
+  echo "Trying to read product name from $PARENT_PATH/antora-playbook.yml..." >&2
+  PRODUCT=$(yq -M '.asciidoc.attributes."prod-id-short"' "$PARENT_PATH/antora-playbook.yml")
+  echo "Detected product: $PRODUCT" >&2
+}
+
+fetch_conf_files_content() {
+  echo "Fetching property files content from GitHub..." >&2
+
+  if [[ $PRODUCT == "\"che\"" ]]; then
+    CHECLUSTER_PROPERTIES_URL="https://raw.githubusercontent.com/eclipse/che-operator/$CURRENT_VERSION/deploy/crds/org_v1_che_crd.yaml"
+  else
+    CHECLUSTER_PROPERTIES_URL="https://raw.githubusercontent.com/redhat-developer/codeready-workspaces-operator/crw-$CURRENT_VERSION-rhel-8/deploy/crds/org_v1_che_crd.yaml"
+  fi
+
+  RAW_CONTENT=$(curl -sf "$CHECLUSTER_PROPERTIES_URL")
+  echo "Fetching content done. Trying to parse it." >&2
+}
+
+parse_content() {
+  parse_section "server" "\`CheCluster\` Custom Resource \`server\` settings, related to the {prod-short} server component."
+  parse_section "database" "\`CheCluster\` Custom Resource \`database\` configuration settings related to the database used by {prod-short}."
+  parse_section "auth" "Custom Resource \`auth\` configuration settings related to authentication used by {prod-short}."
+  parse_section "storage" "\`CheCluster\` Custom Resource \`storage\` configuration settings related to persistent storage used by {prod-short}."
+  if [[ $PRODUCT == "\"che\"" ]]; then
+    parse_section "k8s" "\`CheCluster\` Custom Resource \`k8s\` configuration settings specific to {prod-short} installations on {platforms-name}."
+  fi
+  parse_section "metrics" "\`CheCluster\` Custom Resource \`metrics\` settings, related to the {prod-short} metrics collection used by {prod-short}."
+  parse_section "status" "\`CheCluster\` Custom Resource \`status\` defines the observed state of {prod-short} installation"
+
+  echo "$BUFF" > "$OUTPUT_PATH"
+  echo "Processing done. Output file is $OUTPUT_PATH" >&2
+}
+
+
+parse_section() {
+  local section
+  local sectionName=$1
+  local id="[id=\"checluster-custom-resource-$sectionName-settings_{context}\"]"
+  local caption=$2
+
+  if [[ $sectionName == "status" ]]; then
+    section=$(echo "$RAW_CONTENT" | yq -M '.spec.validation.openAPIV3Schema.properties.status')
+  else
+    section=$(echo "$RAW_CONTENT" | yq -M '.spec.validation.openAPIV3Schema.properties.spec.properties.'"$sectionName")
+  fi
+
+  local properties=(
+    $(echo "$section" | yq -M '.properties | keys[]' )
+  )
+
+  BUFF="$BUFF$id$NEWLINE"
+  BUFF="$BUFF.$caption$NEWLINE"
+  BUFF="$BUFF$TABLE_HEADER"
+  for PROP in "${properties[@]}"
+  do
+    PROP="${PROP//\"}"
+    DESCR_BUFF=$(echo "$section" | yq -M '.properties.'"$PROP"'.description')
+    DESCR_BUFF="${DESCR_BUFF//\"}"
+    DESCR_BUFF="${DESCR_BUFF//:/\\:}"
+    DESCR_BUFF="$(sed 's|Eclipse Che|{prod-short}|g' <<< $DESCR_BUFF)"
+    BUFF="$BUFF${PROP}: ${DESCR_BUFF}$NEWLINE"
+  done
+  BUFF="$BUFF$TABLE_FOOTER"
+}
+
+fetch_current_version
+fetch_product_name
+fetch_conf_files_content
+parse_content


### PR DESCRIPTION
Cherry-picking all merge commits except for Dashboard Next.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

