### PR TITLE
Add direct references to non-CRW available plugins

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -21,14 +21,17 @@ components:
         port: 4000
         attributes:
           path: /che-7/overview/introduction-to-eclipse-che/
-  - id: errata-ai/vale-server/latest
-    type: chePlugin
+  - type: chePlugin
+    reference: https://che-plugin-registry-main.surge.sh/v3/plugins/errata-ai/vale-server/latest/meta.yaml
+    alias: vale-server
   - id: ms-vscode/vscode-github-pullrequest/latest
     type: chePlugin
-  - id: joaompinto/asciidoctor-vscode/latest
-    type: chePlugin
-  - id: timonwong/shellcheck/latest
-    type: chePlugin
+  - type: chePlugin
+    reference: https://che-plugin-registry-main.surge.sh/v3/plugins/joaompinto/asciidoctor-vscode/latest/meta.yaml
+    alias: asciidoctor-vscode
+  - type: chePlugin
+    reference: https://che-plugin-registry-main.surge.sh/v3/plugins/timonwong/shellcheck/latest/meta.yaml
+    alias: shellcheck
 
 commands:
   - name: Generate reference tables for environment variables

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -23,7 +23,9 @@ components:
           path: /che-7/overview/introduction-to-eclipse-che/
   - type: chePlugin
     reference: https://che-plugin-registry-main.surge.sh/v3/plugins/errata-ai/vale-server/latest/meta.yaml
-    alias: vale-server
+    alias: vale-vscode
+    preferences:
+      vale.core.useCLI: true
   - id: ms-vscode/vscode-github-pullrequest/latest
     type: chePlugin
   - type: chePlugin


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Add direct links to the nightly plugin definitions of:
* vale plugin
* asciidoc plugin
* shellcheck plugin

### What issues does this PR fix or reference?
Fixes eclipse/che#18580

### Specify the version of the product this PR applies to.
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

