### PR TITLE
Fix erroneous usage of non existent che-hostname attribute

### DIFF
--- a/modules/end-user-guide/partials/proc_configuring_bitbucket_authentication.adoc
+++ b/modules/end-user-guide/partials/proc_configuring_bitbucket_authentication.adoc
@@ -67,7 +67,7 @@ https://__<bitbucket-hostname>__/rest/api/1.0/users/__<username>__
 +
 [subs="+attributes,+quotes"]
 ----
-https://{che-hostname}/api/user
+{prod-url}/api/user
 ----
 
 * With the token credentials obtained from a secret, another secret is automatically created, allowing authorization to Git operations. This secret is mounted into a workspace container as a Git credentials file, and any additional configurations are not required to work with private Git repositories.


### PR DESCRIPTION
### What does this PR do?

Fix erroneous usage of non existent che-hostname attribute

### What issues does this PR fix or reference?

Fix build error:

```
asciidoctor: WARNING: skipping reference to missing attribute: che-hostname
```

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

