### PR TITLE
Backport to 7.26.x: PR 1896 Fix erroneous usage of non existent che-hostname attribute

### DIFF
--- a/modules/end-user-guide/partials/proc_configuring_bitbucket_authentication.adoc
+++ b/modules/end-user-guide/partials/proc_configuring_bitbucket_authentication.adoc
@@ -67,7 +67,7 @@ https://__<bitbucket-hostname>__/rest/api/1.0/users/__<username>__
 +
 [subs="+attributes,+quotes"]
 ----
-https://{che-hostname}/api/user
+{prod-url}/api/user
 ----
 
 * With the token credentials obtained from a secret, another secret is automatically created, allowing authorization to Git operations. This secret is mounted into a workspace container as a Git credentials file, and any additional configurations are not required to work with private Git repositories.


### PR DESCRIPTION
Backport to 7.26.x: https://github.com/eclipse/che-docs/pull/1896 Fix erroneous usage of non existent che-hostname attribute
