### PR TITLE
Add che-docs project to devfile

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -2,6 +2,12 @@
 apiVersion: 1.0.0
 metadata:
   generateName: che-docs-
+  
+projects:
+  - name: che-docs
+    source:
+      type: git
+      location: "https://github.com/eclipse/che-docs.git"
 
 components:
   - alias: che-docs


### PR DESCRIPTION
### What does this PR do?
PR is adding che-docs project to devfile so that it it will be pre-loaded.
![Screenshot from 2021-03-10 18-45-09](https://user-images.githubusercontent.com/1197777/110665649-40c91500-81d1-11eb-860d-140619f5c0f1.png)

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

