### PR TITLE
Refresh che-docs container: vale version bump, add missing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 
 FROM golang:1.15.6-alpine3.12 as vale-builder
 WORKDIR /vale
-RUN wget -qO- https://github.com/errata-ai/vale/archive/v2.8.0.tar.gz | tar --strip-components=1 -zxvf -
+RUN wget -qO- https://github.com/errata-ai/vale/archive/v2.10.0.tar.gz | tar --strip-components=1 -zxvf -
 RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
     GOOS=linux GOARCH=${ARCH} CGO_ENABLED=0 go build -tags closed -o bin/vale ./cmd/vale
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,12 +44,15 @@ RUN apk add --no-cache --update \
     curl \
     findutils \
     git \
+    grep \
     jq \
     nodejs \
+    perl \
     py3-pip \
     py3-wheel \
     shellcheck \
     tar \
+    xmlstarlet \
     yarn \
     && pip3 install --no-cache-dir --no-input jinja2-cli linkchecker yq \
     && yarnpkg global add --ignore-optional --non-interactive @antora/cli@latest @antora/site-generator-default@latest asciidoctor gulp gulp-connect \


### PR DESCRIPTION
### What does this PR do?

* Bump vale version to 2.10.0 before rebuilding the che-docs container
* Add grep, perl, xmlstarlet to run test-adoc.sh.

### What issues does this PR fix or reference?

* Fix vale runtime error, see:  https://github.com/eclipse/che-docs/runs/2084703488?check_suite_focus=true
* Add grep, perl, xmlstarlet to run test-adoc.sh - fixes eclipse/che#19228

### Specify the version of the product this PR applies to.

main 

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

