### PR TITLE
Ensure cloning links point to the proper repositories

### DIFF
--- a/modules/administration-guide/examples/snip_che-clone-the-devfile-registry-repository.adoc
+++ b/modules/administration-guide/examples/snip_che-clone-the-devfile-registry-repository.adoc
@@ -1,6 +1,6 @@
 [subs="+attributes,+quotes"]
 ----
-$ git clone git@github.com:eclipse/che-plugin-registry.git
+$ git clone git@github.com:eclipse/che-devfile-registry.git
 $ cd che-plugin-registry
 $ git checkout {prod-ver}.x
 ----

--- a/modules/administration-guide/examples/snip_che-clone-the-plug-in-registry-repository.adoc
+++ b/modules/administration-guide/examples/snip_che-clone-the-plug-in-registry-repository.adoc
@@ -1,6 +1,6 @@
 [subs="+attributes,+quotes"]
 ----
-$ git clone git@github.com:eclipse/che-devfile-registry.git
+$ git clone git@github.com:eclipse/che-plugin-registry.git
 $ cd che-devfile-registry
 $ git checkout {prod-ver}.x
 ----

--- a/modules/installation-guide/examples/snip_che-clone-the-devfile-registry-repository.adoc
+++ b/modules/installation-guide/examples/snip_che-clone-the-devfile-registry-repository.adoc
@@ -1,6 +1,6 @@
 [subs="+attributes,+quotes"]
 ----
-$ git clone git@github.com:eclipse/che-plugin-registry.git
+$ git clone git@github.com:eclipse/che-devfile-registry.git
 $ cd che-plugin-registry
 $ git checkout {prod-ver}.x
 ----

--- a/modules/installation-guide/examples/snip_che-clone-the-plug-in-registry-repository.adoc
+++ b/modules/installation-guide/examples/snip_che-clone-the-plug-in-registry-repository.adoc
@@ -1,6 +1,6 @@
 [subs="+attributes,+quotes"]
 ----
-$ git clone git@github.com:eclipse/che-devfile-registry.git
+$ git clone git@github.com:eclipse/che-plugin-registry.git
 $ cd che-devfile-registry
 $ git checkout {prod-ver}.x
 ----


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
See title.

### What issues does this PR fix or reference?
Fixes eclipse/che#19276

### Specify the version of the product this PR applies to.
master and 7.27

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

