### PR TITLE
Removing the misleading information about the official plugin registry, which does not exist anymore

### DIFF
--- a/modules/contributor-guide/partials/con_che-theia-plug-in-registries.adoc
+++ b/modules/contributor-guide/partials/con_che-theia-plug-in-registries.adoc
@@ -54,15 +54,6 @@ latestUpdateDate: "2019-12-09"
 
 For more details about the `meta.yaml` structure, see xref:end-user-guide:what-is-a-che-theia-plug-in.adoc#che-theia-plug-in-metadata_{context}[Che-Theia plug-in metadata].
 
-
-[id="official-plug-in-registry_{context}"]
-== Official plug-in registry
-
-The official {prod-short} plug-in registry is at link:https://che-plugin-registry.openshift.io[che-plugin-registry.openshift.io]. By default, the {prod-short} dashboard shows editors and plug-ins from this registry.
-
-The source is located at link:https://github.com/eclipse/che-plugin-registry[github.com/eclipse/che-plugin-registry].
-
-
 [id="custom-plug-in-registries_{context}"]
 == Custom plug-in registries
 

--- a/modules/contributor-guide/partials/proc_adding-a-che-theia-plug-in-to-the-che-plug-in-registry.adoc
+++ b/modules/contributor-guide/partials/proc_adding-a-che-theia-plug-in-to-the-che-plug-in-registry.adoc
@@ -29,5 +29,4 @@ After the new Che-Theia plug-ins are added and merged into the repository, the l
 
 .Additional resources
 
-* link:https://che-plugin-registry.openshift.io/v3/plugins/[{prod-short} plug-in registry]
 * link:https://github.com/eclipse/che-plugin-registry/[che-plugin-registry GitHub repository]


### PR DESCRIPTION
### What does this PR do?


### What issues does this PR fix or reference?
Removing the misleading information about the official plugin registry, which does not exist anymore

### Specify the version of the product this PR applies to.
https://issues.redhat.com/browse/RHDEVDOCS-2511

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

