### PR TITLE
Increasing the Eclipse Che hosted by Red Hat usage time limit to 30 days

### DIFF
--- a/modules/hosted-che/partials/ref_about-hosted-che.adoc
+++ b/modules/hosted-che/partials/ref_about-hosted-che.adoc
@@ -25,9 +25,9 @@ Eclipse Che hosted by Red Hat has the following usage limits and terms of servic
 * Concurrent workspaces: 1
 * Number of workspaces: Unlimited
 * Number of projects per workspace: Unlimited
-* Usage time limit: 14 days
+* Usage time limit: 30 days
 + 
-NOTE: The account will be active for 14 days. At the end of the active period, the access will be revoked and all the data will be deleted. All existing workspaces will be lost. In order to start using Eclipse Che hosted by Red Hat again, a user must re-register.
+NOTE: The account will be active for 30 days. At the end of the active period, the access will be revoked and all the data will be deleted. All existing workspaces will be lost. In order to start using Eclipse Che hosted by Red Hat again, a user must re-register.
 
 * Maximum time for a running workspace: 8 hours
 +


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Increasing the usage time limit to 30 days

### What issues does this PR fix or reference?
N/A
Related to the https://github.com/codeready-toolchain/host-operator/pull/389

### Specify the version of the product this PR applies to.
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

