### PR TITLE
Fix - Followup on rename of making-a-workspace-portable-using-a-devfile

### DIFF
--- a/modules/administration-guide/partials/proc_building-a-custom-devfile-registry-image.adoc
+++ b/modules/administration-guide/partials/proc_building-a-custom-devfile-registry-image.adoc
@@ -12,7 +12,7 @@ The image contains all sample projects referenced in devfiles.
 
 * A running installation of link:http://podman.io[podman] or link:http://docker.io[docker].
 
-* Valid content for the devfile to add. See: xref:end-user-guide:making-a-workspace-portable-using-a-devfile.adoc[].
+* Valid content for the devfile to add. See: xref:end-user-guide:configuring-a-workspace-using-a-devfile.adoc[].
 
 .Procedure
 
@@ -67,6 +67,6 @@ To display full options for the `build.sh` script, use the `--help` parameter.
 
 .Additional resources
 
-* xref:end-user-guide:making-a-workspace-portable-using-a-devfile.adoc[].
+* xref:end-user-guide:configuring-a-workspace-using-a-devfile.adoc[].
 
 * xref:running-custom-registries.adoc[].


### PR DESCRIPTION
Followup on rename of making-a-workspace-portable-using-a-devfile  into  configuring-a-workspace-using-a-devfile