### PR TITLE
Fix TOC overflow

### DIFF
--- a/.github/workflows/build-and-validate-on-pr.yaml
+++ b/.github/workflows/build-and-validate-on-pr.yaml
@@ -7,9 +7,11 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-name: Build and validate PR
+name: Build and validate PR # Name reused in publish-netlify.yml
+
 on:
   - pull_request
+
 jobs:
   build:
     name: link checker # This job name is set as mandatory in the GitHub configuration.

--- a/.github/workflows/build-and-validate-on-pr.yaml
+++ b/.github/workflows/build-and-validate-on-pr.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-name: Build and validate
+name: Build and validate PR
 on:
   - pull_request
 jobs:

--- a/.github/workflows/publish-netlify.yml
+++ b/.github/workflows/publish-netlify.yml
@@ -15,7 +15,7 @@ name: Publish doc-content using netlify
 on:
   workflow_run:
     workflows:
-      - Build and validate PR
+      - build-and-validate-on-pr
     types:
       - completed
 

--- a/.github/workflows/publish-netlify.yml
+++ b/.github/workflows/publish-netlify.yml
@@ -14,7 +14,8 @@ name: Publish doc-content using netlify
 
 on:
   workflow_run:
-    workflows: ["Build and validate PR"]
+    workflows:
+      - link checker
     types:
       - completed
 

--- a/.github/workflows/publish-netlify.yml
+++ b/.github/workflows/publish-netlify.yml
@@ -14,7 +14,7 @@ name: Publish doc-content using netlify
 
 on:
   workflow_run:
-    workflows: ["build-documentation-pr"]
+    workflows: ["Build and validate PR"]
     types:
       - completed
 

--- a/.github/workflows/publish-netlify.yml
+++ b/.github/workflows/publish-netlify.yml
@@ -15,7 +15,7 @@ name: Publish doc-content using netlify
 on:
   workflow_run:
     workflows:
-      - build-and-validate-on-pr
+      - "Build and validate PR"
     types:
       - completed
 

--- a/.github/workflows/publish-netlify.yml
+++ b/.github/workflows/publish-netlify.yml
@@ -15,7 +15,7 @@ name: Publish doc-content using netlify
 on:
   workflow_run:
     workflows:
-      - link checker
+      - Build and validate PR
     types:
       - completed
 

--- a/supplemental-ui/css/extra.css
+++ b/supplemental-ui/css/extra.css
@@ -73,3 +73,7 @@ i.fa.icon-caution::before {
     padding: 0!important;
     border: none!important;
 }
+
+aside.toc.sidebar {
+    overflow-block: scroll;
+}


### PR DESCRIPTION
fixes https://github.com/eclipse/che/issues/18660

The TOC stays at the top of the page.

Also fixes the trigger to run the `Publish doc-content using netlify` workflow.
