### PR TITLE
disable Concurrent Builds in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,7 @@ spec:
   options {
     buildDiscarder(logRotator(numToKeepStr: '5'))
     checkoutToSubdirectory('che-docs')
+    disableConcurrentBuilds()
     timeout(time: 15, unit: 'MINUTES')
   }
 


### PR DESCRIPTION
disableConcurrentBuilds as followup of https://bugs.eclipse.org/bugs/show_bug.cgi?id=572415