### PR TITLE
Fix language errors in assembly_introduction-to-eclipse-che.adoc. 

### DIFF
--- a/.github/workflows/build-and-validate-on-pr.yaml
+++ b/.github/workflows/build-and-validate-on-pr.yaml
@@ -7,7 +7,8 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-name: Build and validate PR # Name reused in publish-netlify.yml
+# Name is reused in publish-netlify.yml
+name: "Build and validate PR"
 
 on:
   - pull_request

--- a/.vale/styles/Vocab/Che/accept.txt
+++ b/.vale/styles/Vocab/Che/accept.txt
@@ -70,6 +70,7 @@ npm
 NuGet
 OAuth
 ocp
+onboarding|Onboarding
 OpenShift
 OpenTracing
 Operator
@@ -88,8 +89,6 @@ rollout
 rollouts
 Sharding
 Spring Boot
-stack
-stacks
 subnetwork
 subpath
 subpaths|Subpaths

--- a/modules/overview/partials/assembly_introduction-to-eclipse-che.adoc
+++ b/modules/overview/partials/assembly_introduction-to-eclipse-che.adoc
@@ -8,11 +8,11 @@
 :context: introduction-to-eclipse-che
 
 * A centralized developer environment running on {platforms-name}.
-* A multicontainer workspace for each developer with the ability to replicate with a single click using {prod} factories.
+* A multi-container workspace for each developer with the ability to replicate with a single click using {prod} factories.
 * Pre-built stacks with the ability to create custom stacks for any language or runtime.
-* An enterprise integration that uses {identity-provider} for Active Directory (AD) database and Lightweight Directory Access Protocol (LDAP) related actions.
+* An enterprise integration using {identity-provider} for Active Directory (AD) database and Lightweight Directory Access Protocol (LDAP) related actions.
 * Browser-based IDEs; integration with Che-Theia or any other web IDE, such as Jupyter.
-* Support of tooling protocols, such as the Language Server Protocol or Debug Adapter Protocol.
+* Support of tools protocols, such as the Language Server Protocol or Debug Adapter Protocol.
 * A plug-in mechanism compatible with Visual Studio Code extensions.
 * A software development kit (SDK) for creating custom cloud developer platforms.
 
@@ -52,7 +52,7 @@ Learn about the latest of {prod} and submit your blog posts to the link:https://
 
 Weekly meetings::
 
-Join us in our link:https://github.com/eclipse/che/wiki/{prod-short}-Dev-Meetings[{prod-short} community meeting] every Monday.
+Join us in the link:https://github.com/eclipse/che/wiki/{prod-short}-Dev-Meetings[{prod-short} community meeting] every Monday.
 
 Roadmap:: 
 
@@ -74,7 +74,7 @@ To achieve those core goals, {prod} provides:
 * *Workspaces:* Container-based developer workspaces providing all the tools and dependencies needed to code, build, test, run, and debug applications.
 * *Browser-based IDEs:* Bundled browser-based IDEs with language tools, debuggers, terminal, VCS integration, and much more.
 * *Extensible platform:* Bring your own IDE. Define, configure, and extend the tools that you need for your application by using plug-ins, which are compatible with Visual Studio Code extensions.
-* *Enterprise Integration:* Multiuser capabilities, including {identity-provider} for authentication and integration with LDAP or AD.
+* *Enterprise Integration:* Multi-user capabilities, including {identity-provider} for authentication and integration with LDAP or AD.
 
 === Workspace model
 
@@ -82,7 +82,7 @@ To achieve those core goals, {prod} provides:
 
 Workspaces are isolated from one another and are responsible for managing the lifecycle of their components.
 
-Developers using {prod} use their containers directly in their developer workspaces. *{prod-short} workspaces are {platforms-name} pods, which allow to replicate the application runtimes (and its microservices) used in production* and provide a “dev mode” layer on top of those, adding intelligent code completion and IDE tools.
+Developers using {prod} use their containers directly in their developer workspaces. *{prod-short} workspaces are {platforms-name} Pods, which allow to replicate the application runtimes (and its microservices) used in production* and provide a “developer mode” layer on top of those, adding intelligent code completion and IDE tools.
 
 === Browser-based IDEs
 
@@ -94,7 +94,7 @@ Developers using {prod} use their containers directly in their developer workspa
 * *Command palette:* Do everything from your keyboard
 * *Task support:* Tasks from Visual Studio Code are extended and support {prod-short} commands
 * *Embedded preview:* Preview your application directly from the IDE, including Markdown preview
-* *Customizable layout:* Adapt the layout using drag and drop
+* *Customizable layout:* Adapt the layout using drag-and-drop
 * *And more:* Outline view, search, Git
 
 
@@ -111,7 +111,7 @@ video::B6aCqywKpyY[youtube]
 +
 video::VooNzKxRFgw[youtube]
 
-For situations in which the default IDE does not cover the use cases of the users or to use a dedicated tool instead of an IDE.
+For situations in which the default IDE does not cover the use cases of the users or to use a dedicated tool rather than an IDE.
 
 
 === Extensible platform
@@ -122,10 +122,10 @@ For situations in which the default IDE does not cover the use cases of the user
 
 * *Plug-ins* to add capabilities to the IDE. Che-Theia plug-ins rely on APIs compatible with Visual Studio Code. Plug-ins are isolated and provide their own dependencies packaged in containers.
 * *Stacks* to create pre-configured {prod-short} workspaces with a dedicated set of tools.
-* *Alternative IDEs* to provide specialized tools within {prod}. Build your own, based on Eclipse Theia, or pick existing ones like Jupyter.
+* *Alternative IDEs* to provide specialized tools within {prod}. Build your own, based on Eclipse Theia, or pick existing ones such as Jupyter.
 * *Marketplace (soon)* to easily distribute tools and custom IDEs, which can be tried online, to users and communities.
 
-{prod} uses Che-Theia as its default browser-based IDE. Che-Theia provides a framework to build web IDEs. It is built in TypeScript and gives contributors a programming model that is flexible, relies on state-of-the-art tooling protocols, and makes it faster to build new tools.
+{prod} uses Che-Theia as its default browser-based IDE. Che-Theia provides a framework to build web IDEs. It is built in TypeScript and gives contributors a programming model that is flexible, relies on state-of-the-art tools protocols, and makes it faster to build new tools.
 
 In {prod}, the dependencies needed for the tools running in the user's workspace are available when needed. This means that a Che-Theia plug-in provides its dependencies, its back-end services (which could be running in a sidecar container connected to the user’s workspace), and the IDE UI extension. {prod-short} packages all these elements together, so that the user does not have to configure different tools together.
 


### PR DESCRIPTION
Fix language errors in assembly_introduction-to-eclipse-che.adoc. 

From 676 to 662 errors in complete codebase.




### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

