### PR TITLE
Update contribution guide with the workspaces.openshift.com URL

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -68,7 +68,7 @@ https://redhat-documentation.github.io/modular-docs/[Modular Documentation Initi
 
 .Procedure
 
-. Open a che-docs workspace running on Hosted Che: `++https++://che.openshift.io/factory?url=https://github.com/__<github-handle>__/che-docs/tree/__<branch-name>__/`
+. Open a che-docs workspace running on Hosted Che: `++https++://workspaces.openshift.com/factory?url=https://github.com/__<github-handle>__/che-docs/tree/__<branch-name>__/`
 
 . Create a branch `__<branch-name>__` for your work.
 


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Update the outdated Hosted Che link to a Dev Sandbox one in the Contribution guide.  

Tested on my fork:
![Screenshot from 2021-03-31 14-35-44](https://user-images.githubusercontent.com/24560978/113145376-a20f6180-922e-11eb-8bae-c3d9bb600859.png)


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-2509

### Specify the version of the product this PR applies to.
Current

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

