### PR TITLE
Report breakdown of vale errors per module

### DIFF
--- a/.github/workflows/build-and-validate-on-pr.yaml
+++ b/.github/workflows/build-and-validate-on-pr.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-# Name is reused in publish-netlify.yml
+# Name is reused in `publish-netlify.yml`
 name: "Build and validate PR"
 
 on:
@@ -51,20 +51,6 @@ jobs:
           name: pull-request-sha
           path: PR_SHA
 
-      # htmltest:
-      #   name: link checker # This name is set as mandatory in the GitHub configuration.
-      #   runs-on: ubuntu-20.04
-      #   container: "quay.io/eclipse/che-docs:latest"
-      #   needs: build
-      #   steps:
-      #     - name: Checkout code
-      #       uses: actions/checkout@v2
-
-      #     - name: Download artifacts
-      #       uses: actions/download-artifact@v2
-      #       with:
-      #         name: doc-content
-
       - name: Cache htmltest status code of checked external URLs # See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
         uses: actions/cache@v2
         env:
@@ -77,29 +63,8 @@ jobs:
         id: validate-links
         run: htmltest
 
-      # unusedimages:
-      #   name: Report unused images
-      #   runs-on: ubuntu-20.04
-      #   steps:
-      #     - name: Checkout code
-      #       uses: actions/checkout@v2
-
       - name: Report Unused Images
         run: tools/detect-unused-images.sh
 
-      # vale-diff:
-      #   name: Validate language on new and modified files in PR
-      #   runs-on: ubuntu-20.04
-      #   container: "quay.io/eclipse/che-docs:latest"
-      #   steps:
-      #     - name: Checkout code
-      #       uses: actions/checkout@v2
-      #       with:
-      #         fetch-depth: 0
-
       - name: Validate language on files added or modified
-        run: |
-          vale -v
-          echo "Changed files, in comparison to branch $GITHUB_BASE_REF"
-          git diff --name-only --diff-filter=AM origin/$GITHUB_BASE_REF
-          vale $(git diff --name-only --diff-filter=AM origin/$GITHUB_BASE_REF)
+        run: tools/validate_language_changes.sh

--- a/.github/workflows/build-and-validate-on-push.yaml
+++ b/.github/workflows/build-and-validate-on-push.yaml
@@ -80,6 +80,4 @@ jobs:
       #       with:
       #         fetch-depth: 0
       - name: Count Vale errors
-        run: |
-          vale -v
-          vale --minAlertLevel=error --output=line . | wc -l
+        run: tools/count_vale_errors.sh

--- a/.vale.ini
+++ b/.vale.ini
@@ -40,7 +40,7 @@ properties = r
 
 # What file types should Vale test?
 # ----------------------------------
-[*.{adoc,properties,r,yaml}]
+[*.{adoc,properties,r}]
 
 # Styles to load
 # --------------

--- a/tools/count_vale_errors.sh
+++ b/tools/count_vale_errors.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+vale -v 
+echo "# Breakdown of vale errors per module:"
+
+for module in modules/*
+    do
+    echo -n "$module: "
+    vale --minAlertLevel=error --output=line "$module" | wc -l
+done

--- a/tools/count_vale_errors.sh
+++ b/tools/count_vale_errors.sh
@@ -1,9 +1,19 @@
 #!/bin/sh
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+set -e
+
 vale -v 
 echo "# Breakdown of vale errors per module:"
 
 for module in modules/*
     do
-    echo -n "$module: "
+    printf '%s: ' "$module"
     vale --minAlertLevel=error --output=line "$module" | wc -l
 done

--- a/tools/validate_language_changes.sh
+++ b/tools/validate_language_changes.sh
@@ -18,4 +18,5 @@ FILES=$(git diff --name-only --diff-filter=AM "$BRANCH")
 echo "Files added or modified, in comparison to branch $BRANCH:
 $FILES"
 
-vale "${FILES}"
+# shellcheck disable=SC2086 (We want to split on spaces)
+vale ${FILES}

--- a/tools/validate_language_changes.sh
+++ b/tools/validate_language_changes.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+set -e
+
+vale -v 
+
+BRANCH=origin/${GITHUB_BASE_REF:-master}
+
+FILES=$(git diff --name-only --diff-filter=AM "$BRANCH")
+
+echo "Files added or modified, in comparison to branch $BRANCH:
+$FILES"
+
+vale "${FILES}"


### PR DESCRIPTION
Report breakdown of vale errors per module

* Script in the tools directory
* Workflow on push using this script

Current output:

```
./tools/count_vale_errors.sh                                                                                                                                                                             
vale version 2.10.2
# Breakdown of vale errors per module:
modules/administration-guide: 0
modules/contributor-guide: 11
modules/end-user-guide: 0
modules/extensions: 40
modules/glossary: 0
modules/hosted-che: 8
modules/installation-guide: 193
modules/overview: 0
```