### PR TITLE
Fix language on hosted che

### DIFF
--- a/modules/hosted-che/partials/proc_creating-a-workspace-from-template-in-hosted-che.adoc
+++ b/modules/hosted-che/partials/proc_creating-a-workspace-from-template-in-hosted-che.adoc
@@ -19,7 +19,11 @@ Various programming languages and frameworks are supported.
 
 . Choose the required type of a workspace.
 
+pass:[<!-- vale IBM.Terms = NO -->]
+
 . Click the btn:[Launch Workspace] button.
+
+pass:[<!-- vale IBM.Terms = YES -->]
 
 The workspace is created and displayed in the Eclipse Che hosted by Red hat.
 

--- a/modules/hosted-che/partials/proc_creating-a-workspace-from-the-user-dashboard.adoc
+++ b/modules/hosted-che/partials/proc_creating-a-workspace-from-the-user-dashboard.adoc
@@ -14,7 +14,7 @@ This section describes how to create a workspace from the user dashboard in Ecli
 
 .Procedure
 
-. Navigate to the link:https://workspaces.openshift.com.
+. Navigate to link:https://workspaces.openshift.com[`workspaces.openshift.com`].
 
 . Once login, the redirect to the user dashboard will happen.
 

--- a/modules/hosted-che/partials/proc_registering-to-hosted-che.adoc
+++ b/modules/hosted-che/partials/proc_registering-to-hosted-che.adoc
@@ -13,8 +13,8 @@ This section describes how to register to Eclipse Che hosted by Red Hat.
 
 . Register with an existing OpenShift Online, Red Hat Developer Program, or Red Hat Customer Portal account, *or* create a new Red Hat account.
 
-. Verify the phone number
+. Verify the telephone number
 
-IMPORTANT: A valid phone number is required for reducing the creation of fraudulent accounts on the Developer Sandbox for Red Hat OpenShift. Red Hat will not use this information for any other reason, and you will never receive a phone call from Red Hat or any third-party as a result of trying the sandbox.
+IMPORTANT: A valid telephone number is required for reducing the creation of fraudulent accounts on the Developer Sandbox for Red Hat OpenShift. Red Hat will not use this information for any other reason, and you will never receive a telephone call from Red Hat or any third-party as a result of trying the sandbox.
 
 . Once the account is provisioned, Eclipse Che hosted by Red Hat will be ready for use from both link:https://developers.redhat.com/developer-sandbox#assembly-field-sections-59571[Developer Sandbox] and https://workspaces.openshift.com pages.

--- a/modules/hosted-che/partials/ref_about-hosted-che.adoc
+++ b/modules/hosted-che/partials/ref_about-hosted-che.adoc
@@ -13,7 +13,7 @@ The new service is part of the link:https://developers.redhat.com/developer-sand
 
 Red Hat CodeReady Workspaces is the product that is built from the Eclipse Che project. The product is normally two versions behind the project. Red Hat also provides licensing, packaging, and support, so CodeReady Workspaces is considered a more stable product than the upstream Eclipse Che project. More details about the difference between Eclipse Che and Red Hat CodeReady Workspaces can be found on the official link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/2.6/html/release_notes_and_known_issues/installing_and_deploying_codeready_workspaces#difference-between-che-and-codready-workspaces[documentation].
 
-IMPORTANT: Eclipse Che and Red Hat CodeReady Workspaces share all of the features - all the product's functionality is available in the project and vice versa. However, not all the upstream plugins are available in the CodeReady Workspaces. In order to use an unsupported plugin inside the CodeReady Workspaces, one needs to explicitly refer to the raw `meta.yaml` of the plugin from the devfile. The procedure is described in the xref:end-user-guide:adding-a-vs-code-extension-to-a-workspace.adoc#adding-the-vs-code-extension-using-the-workspace-configuration_che[Adding a VS Code extension using the workspace configuration] section.
+IMPORTANT: Eclipse Che and Red Hat CodeReady Workspaces share all of the features - all the product's functionality is available in the project and vice versa. However, not all the upstream plugins are available in the CodeReady Workspaces. To use an unsupported plugin inside the CodeReady Workspaces, one needs to explicitly point to the raw `meta.yaml` of the plugin from the devfile. The procedure is described in the xref:end-user-guide:adding-a-vs-code-extension-to-a-workspace.adoc#adding-the-vs-code-extension-using-the-workspace-configuration_che[Adding a VS Code extension using the workspace configuration] section.
 
 [id="terms-of-service_{context}"]
 == Terms of service
@@ -27,7 +27,7 @@ Eclipse Che hosted by Red Hat has the following usage limits and terms of servic
 * Number of projects per workspace: Unlimited
 * Usage time limit: 30 days
 + 
-NOTE: The account will be active for 30 days. At the end of the active period, the access will be revoked and all the data will be deleted. All existing workspaces will be lost. In order to start using Eclipse Che hosted by Red Hat again, a user must re-register.
+NOTE: The account will be active for 30 days. At the end of the active period, the access will be revoked and all the data will be deleted. All existing workspaces will be lost. To start using Eclipse Che hosted by Red Hat again, a user must re-register.
 
 * Maximum time for a running workspace: 8 hours
 +


### PR DESCRIPTION
Fix vale errors on Hosted Che module


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

