### PR TITLE
Add IMAGE_PULL_SECRETS to image puller parameters

### DIFF
--- a/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
+++ b/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
@@ -57,6 +57,10 @@ endif::[]
 |`NODE_SELECTOR` 
 |Node selector to apply to the Pods created by the DaemonSet 
 |`'{}'`
+
+|`IMAGE_PULL_SECRETS` 
+| List of image pull secrets, in the format `pullsecret1;...` to add to pods created by the daemonset 
+| `""`
 |===
 
 

--- a/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
+++ b/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
@@ -59,7 +59,7 @@ endif::[]
 |`'{}'`
 
 |`IMAGE_PULL_SECRETS` 
-| List of image pull secrets, in the format `pullsecret1;...` to add to pods created by the daemonset 
+| List of image pull secrets, in the format `pullsecret1;...` to add to pods created by the daemonset. Those secrets need to be in the same namespace as the image puller and need to be created by a cluster admin.
 | `""`
 |===
 

--- a/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
+++ b/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
@@ -59,7 +59,7 @@ endif::[]
 |`'{}'`
 
 |`IMAGE_PULL_SECRETS` 
-| List of image pull secrets, in the format `pullsecret1;...` to add to pods created by the daemonset. Those secrets need to be in the same namespace as the image puller and need to be created by a cluster admin.
+| List of image pull secrets, in the format `pullsecret1;...` to add to pods created by the DaemonSet. Those secrets need to be in the image puller's namespace and a cluster administrator must create them.
 | `""`
 |===
 


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
This PR updates the docs after the PR https://github.com/che-incubator/kubernetes-image-puller/pull/39 

### What issues does this PR fix or reference?
https://github.com/che-incubator/kubernetes-image-puller/pull/39#pullrequestreview-639867617

### Specify the version of the product this PR applies to.
https://github.com/che-incubator/kubernetes-image-puller/pull/39 

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

