### PR TITLE
Add AFFINITY to image puller parameters

### DIFF
--- a/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
+++ b/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
@@ -57,6 +57,10 @@ endif::[]
 |`NODE_SELECTOR` 
 |Node selector to apply to the Pods created by the DaemonSet 
 |`'{}'`
+
+| `AFFINITY` 
+| Affinity applied to pods created by the DaemonSet 
+| `'{}'`
 |===
 
 


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
This PR updates the docs after the PR https://github.com/che-incubator/kubernetes-image-puller/pull/41

### What issues does this PR fix or reference?
https://github.com/che-incubator/kubernetes-image-puller/pull/41

### Specify the version of the product this PR applies to.
https://github.com/che-incubator/kubernetes-image-puller/pull/41

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

