### PR TITLE
Make checluster_docs_gen.sh script compatible with CRD v1

### DIFF
--- a/tools/checluster_docs_gen.sh
+++ b/tools/checluster_docs_gen.sh
@@ -107,7 +107,7 @@ parse_section() {
   BUFF="$BUFF$TABLE_FOOTER"
 }
 
-# fetch_current_version
-# fetch_product_name
-# fetch_conf_files_content
+fetch_current_version
+fetch_product_name
+fetch_conf_files_content
 parse_content

--- a/tools/checluster_docs_gen.sh
+++ b/tools/checluster_docs_gen.sh
@@ -25,28 +25,29 @@ fetch_current_version() {
   echo "Trying to read current product version from $PARENT_PATH/antora-playbook.yml..." >&2
   CURRENT_VERSION=$(yq -M '.asciidoc.attributes."prod-ver"' "$PARENT_PATH/antora-playbook.yml").x
   if [[ "$CURRENT_VERSION" == *-SNAPSHOT ]]; then
-     CURRENT_VERSION="master"
+    CURRENT_VERSION="master"
   fi
   echo "Detected version: $CURRENT_VERSION" >&2
 }
 
 fetch_product_name() {
   echo "Trying to read product name from $PARENT_PATH/antora-playbook.yml..." >&2
-  PRODUCT=$(yq -M '.asciidoc.attributes."prod-id-short"' "$PARENT_PATH/antora-playbook.yml")
+  PRODUCT=$(yq -rM '.asciidoc.attributes."prod-id-short"' "$PARENT_PATH/antora-playbook.yml")
   echo "Detected product: $PRODUCT" >&2
 }
 
 fetch_conf_files_content() {
   echo "Fetching property files content from GitHub..." >&2
 
-  if [[ $PRODUCT == "\"che\"" ]]; then
+  if [[ $PRODUCT == "che" ]]; then
     CHECLUSTER_PROPERTIES_URL="https://raw.githubusercontent.com/eclipse/che-operator/$CURRENT_VERSION/deploy/crds/org_v1_che_crd.yaml"
   else
     CHECLUSTER_PROPERTIES_URL="https://raw.githubusercontent.com/redhat-developer/codeready-workspaces-operator/crw-$CURRENT_VERSION-rhel-8/deploy/crds/org_v1_che_crd.yaml"
   fi
 
   RAW_CONTENT=$(curl -sf "$CHECLUSTER_PROPERTIES_URL")
-  echo "Fetching content done. Trying to parse it." >&2
+  local crdVersion=$(echo "$RAW_CONTENT" | yq -r '.apiVersion')
+  echo "Fetching content done. CRD version: $crdVersion. Trying to parse it." >&2
 }
 
 parse_content() {
@@ -54,7 +55,7 @@ parse_content() {
   parse_section "database" "\`CheCluster\` Custom Resource \`database\` configuration settings related to the database used by {prod-short}."
   parse_section "auth" "Custom Resource \`auth\` configuration settings related to authentication used by {prod-short}."
   parse_section "storage" "\`CheCluster\` Custom Resource \`storage\` configuration settings related to persistent storage used by {prod-short}."
-  if [[ $PRODUCT == "\"che\"" ]]; then
+  if [[ $PRODUCT == "che" ]]; then
     parse_section "k8s" "\`CheCluster\` Custom Resource \`k8s\` configuration settings specific to {prod-short} installations on {platforms-name}."
   fi
   parse_section "metrics" "\`CheCluster\` Custom Resource \`metrics\` settings, related to the {prod-short} metrics collection used by {prod-short}."
@@ -70,11 +71,21 @@ parse_section() {
   local sectionName=$1
   local id="[id=\"checluster-custom-resource-$sectionName-settings_{context}\"]"
   local caption=$2
+  local crdVersion=$(echo "$RAW_CONTENT" | yq -r '.apiVersion')
+  echo "Parsing section: "$sectionName
 
   if [[ $sectionName == "status" ]]; then
-    section=$(echo "$RAW_CONTENT" | yq -M '.spec.validation.openAPIV3Schema.properties.status')
+    if [[ $crdVersion == "apiextensions.k8s.io/v1beta1" ]]; then
+      section=$(echo "$RAW_CONTENT" | yq -M '.spec.validation.openAPIV3Schema.properties.status')
+    else
+      section=$(echo "$RAW_CONTENT" | yq -M '.spec.versions[] | select(.name == "v1") | .schema.openAPIV3Schema.properties.status')
+    fi
   else
-    section=$(echo "$RAW_CONTENT" | yq -M '.spec.validation.openAPIV3Schema.properties.spec.properties.'"$sectionName")
+    if [[ $crdVersion == "apiextensions.k8s.io/v1beta1" ]]; then
+      section=$(echo "$RAW_CONTENT" | yq -M '.spec.validation.openAPIV3Schema.properties.spec.properties.'"$sectionName")
+    else
+      section=$(echo "$RAW_CONTENT" | yq -M '.spec.versions[] | select(.name == "v1") | .schema.openAPIV3Schema.properties.spec.properties.'"$sectionName")
+    fi
   fi
 
   local properties=(
@@ -96,7 +107,7 @@ parse_section() {
   BUFF="$BUFF$TABLE_FOOTER"
 }
 
-fetch_current_version
-fetch_product_name
-fetch_conf_files_content
+# fetch_current_version
+# fetch_product_name
+# fetch_conf_files_content
 parse_content


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Make checluster_docs_gen.sh script compatible with CRD v1

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19460

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

