### PR TITLE
Update doc to mention that OpenShift initial user credentials are stored into openshift-config namespace

### DIFF
--- a/modules/administration-guide/partials/proc_configuring-openshift-oauth-with-initial-user.adoc
+++ b/modules/administration-guide/partials/proc_configuring-openshift-oauth-with-initial-user.adoc
@@ -11,7 +11,7 @@
 * Configure OpenShift identity providers on the cluster. See the link:https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html#identity-provider-overview_understanding-identity-provider[Understanding identity provider configuration].
 +
 ====
-When a user skips the Configuring step of OpenShift {platforms-identity-provider}, and the OpenShift cluster does not already contain a configured {identity provider}, {prod-short} creates an initial OpenShift user for the `HTPasswd` identity provider. Credentials of this user are stored in the `openshift-oauth-user-credentials` secret, located in the {prod-namespace} namespace. 
+When a user skips the Configuring step of OpenShift {platforms-identity-provider}, and the OpenShift cluster does not already contain a configured {identity-provider}, {prod-short} creates an initial OpenShift user for the `HTPasswd` identity provider. Credentials of this user are stored in the `openshift-oauth-user-credentials` secret, located in the `openshift-config` namespace.
 
 Obtain the credentials for logging in to an OpenShift cluster and {prod-short} instance:
 
@@ -19,13 +19,13 @@ Obtain the credentials for logging in to an OpenShift cluster and {prod-short} i
 +
 [subs="+attributes,+quotes"]
 ----
-$ oc get secret openshift-oauth-user-credentials -n {prod-namespace} -o json | jq -r '.data.user' | base64 -d
+$ oc get secret openshift-oauth-user-credentials -n openshift-config -o json | jq -r '.data.user' | base64 -d
 ----
 . Obtain OpenShift user password:
 +
 [subs="+attributes,+quotes"]
 ----
-$ oc get secret openshift-oauth-user-credentials -n {prod-namespace} -o json | jq -r '.data.password' | base64 -d
+$ oc get secret openshift-oauth-user-credentials -n openshift-config -o json | jq -r '.data.password' | base64 -d
 ----
 ====
 +


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Update doc to mention that OpenShift initial user credentials are stored into openshift-config namespace

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19380

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [x] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

