### PR TITLE
Eclipse Che hosted by Red Hat: Updating the IDE link to the developer-sandbox

### DIFF
--- a/modules/hosted-che/partials/proc_registering-to-hosted-che.adoc
+++ b/modules/hosted-che/partials/proc_registering-to-hosted-che.adoc
@@ -17,4 +17,4 @@ This section describes how to register to Eclipse Che hosted by Red Hat.
 
 IMPORTANT: A valid telephone number is required for reducing the creation of fraudulent accounts on the Developer Sandbox for Red Hat OpenShift. Red Hat will not use this information for any other reason, and you will never receive a telephone call from Red Hat or any third-party as a result of trying the sandbox.
 
-. Once the account is provisioned, Eclipse Che hosted by Red Hat will be ready for use from both link:https://developers.redhat.com/developer-sandbox#assembly-field-sections-59571[Developer Sandbox] and https://workspaces.openshift.com pages.
+. Once the account is provisioned, Eclipse Che hosted by Red Hat will be ready for use from both link:https://developers.redhat.com/developer-sandbox/ide[Developer Sandbox] and https://workspaces.openshift.com pages.


### PR DESCRIPTION

Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Updating the IDE link to the developer-sandbox - https://developers.redhat.com/developer-sandbox/ide

### What issues does this PR fix or reference?
N/A

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been set up on the docs side):
    - [ ] Dashboard [branding.json](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.json)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)

