### PR TITLE
docs: Backport Remove references to outdated parts of dashboard

### DIFF
--- a/modules/end-user-guide/partials/assembly_adding-a-vs-code-extension-to-a-workspace.adoc
+++ b/modules/end-user-guide/partials/assembly_adding-a-vs-code-extension-to-a-workspace.adoc
@@ -9,13 +9,11 @@
 
 :context: adding-{prod-id-short}-plug-in-registry-vs-code-extension-to-a-workspace
 
-This section describes how to add a VS Code extension to a workspace using the *{prod-short} Plugins* panel or the workspace configuration.
+This section describes how to add a VS Code extension to a workspace using the workspace configuration.
 
 .Prerequisites
 
 * The VS Code extension is available in the {prod-short} plug-in registry, or metadata for the VS Code extension are available. See xref:publishing-metadata-for-a-vs-code-extension.adoc[].
-
-include::partial$proc_adding-the-vs-code-extension-using-the-che-plugins-panel.adoc[leveloffset=+1]
 
 include::partial$proc_adding-the-vs-code-extension-using-the-workspace-configuration.adoc[leveloffset=+1]
 

--- a/modules/end-user-guide/partials/con_additional-tools-in-the-che-workspace.adoc
+++ b/modules/end-user-guide/partials/con_additional-tools-in-the-che-workspace.adoc
@@ -14,8 +14,6 @@ The Che-Theia IDE is generally compatible with the VS Code extensions API and VS
 .Adding a plug-in
  
 * Using the Dashboard: 
-** Add a plug-in from the plug-in registry using the *Plugins* tab in the *Workspace details* page.
-
 ** Add a plug-in directly into a devfile using the *Devfile* tab.
 +
 The devfile can also further the plug-in configuration, such as defining memory or CPU consumption.

--- a/modules/end-user-guide/partials/proc_adding-language-support-plug-in-to-the-che-workspace.adoc
+++ b/modules/end-user-guide/partials/proc_adding-language-support-plug-in-to-the-che-workspace.adoc
@@ -9,7 +9,6 @@ This procedure describes adding a tool to an existing workspace by enabling a de
 
 To add tools that are available as plug-ins into a {prod-short} workspace, use one of the following methods:
 
-* xref:installing-the-plug-in-from-the-plugin-tab_{context}[Enable the plug-in from the Dashboard *Plugins* tab.]
 * xref:installing-the-plug-in-by-adding-content-to-the-devfile_{context}[Edit the workspace devfile from the Dashboard *Devfile* tab.]
 
 This procedure uses the Language Support for Java plug-in as an example.
@@ -35,15 +34,6 @@ This procedure uses the Language Support for Java plug-in as an example.
 .Procedure
 
 To add the plug-in from the Plug-in registry to an existing {prod-short} workspace, use one of the following methods:
-
-[id="installing-the-plug-in-from-the-plugin-tab_{context}"]
-
-//<<installing-the-plug-in-from-the-plugin-tab_{context}>>
-
-** Installing the plug-in from the *Plugins* tab.
-. Navigate to the *Plugins* tab. The list of available plug-ins is displayed.
-. Enable the desired plug-in, for example, the Language Support for Java 11, by using the *Enable* slide-toggle. This will add the plug-in's ID to the workspace's devfile, enabling the plug-in.
-. On the bottom right side of the screen, save the changes with the btn:[Save] button. After changes are saved, the workspace can be restarted and will include the new plug-in.
 
 [id="installing-the-plug-in-by-adding-content-to-the-devfile_{context}"]
 

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-by-importing-the-source-code-of-a-project.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-by-importing-the-source-code-of-a-project.adoc
@@ -133,9 +133,9 @@ image::workspaces/git-clone-terminal.png[Run git clone in a terminal]
 
 [NOTE]
 ====
-Importing or deleting workspace projects in the terminal does not update the workspace configuration, and the IDE does not reflect the changes in the *Project* and *Devfile* tabs in the dashboard.
+Importing or deleting workspace projects in the terminal does not update the workspace configuration, and the IDE does not reflect the changes in the *Devfile* tab in the dashboard.
 
-Similarly, when you add a project using the *Dashboard*, then delete it with `rm -fr myproject`, it may still appear in the *Projects* or *Devfile* tab.
+Similarly, when you add a project using the *Dashboard*, then delete it with `rm -fr myproject`, it may still appear in the *Devfile* tab.
 ====
 
 :context: {parent-context-of-creating-a-workspace-by-importing-the-source-code-of-a-project}


### PR DESCRIPTION
### What does this PR do?
Backport Remove references to outdated parts of dashboard https://github.com/eclipse/che-docs/pull/1984 to pull it into CRW 2.8 docs 

### What issues does this PR fix or reference?
It should fix https://issues.redhat.com/browse/RHDEVDOCS-2994

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [x] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
