### PR TITLE
fix: typos

### DIFF
--- a/modules/installation-guide/examples/che-pvc-strategies.adoc
+++ b/modules/installation-guide/examples/che-pvc-strategies.adoc
@@ -15,11 +15,11 @@ One PVC for all workspaces in one {platforms-namespace}
 
 One PVC for one workspace
 
-| Easier to manage and control storage compared to unique strategy  | PV count is not known and depends on workspaces number
+| Easier to manage and control storage compared to unique strategy  | PV count is not known and depends on the number of workspaces
 |*unique* |
 
 One PVC per workspace volume or user-defined PVC
 
-| Storage isolation | An undefined number of PVs is required
+| Storage isolation | An undefined number of PVs are required
 |===
 

--- a/modules/installation-guide/pages/upgrading-che-namespace-strategies-other-than-per-user.adoc
+++ b/modules/installation-guide/pages/upgrading-che-namespace-strategies-other-than-per-user.adoc
@@ -1,6 +1,6 @@
 [id="upgrading-che-namespace-strategies-other-than-per-user"]
-// = Updating che that is used namespace strategies other than 'per user'
-:navtitle: Updating che that is used namespace strategies other than 'per user'
+// = Updating Che namespace strategies other than 'per user'
+:navtitle: Updating Che namespace strategies other than 'per user'
 :keywords: installation-guide, upgrading-che-namespace-strategies-other-than-per-user.
 :page-aliases: .:upgrading-che-namespace-strategies-other-than-per-user.
 

--- a/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
+++ b/modules/installation-guide/partials/proc_configuring-namespace-strategies.adoc
@@ -151,7 +151,7 @@ On {kubernetes}, `che` ServiceAccount must have a cluster-wide `list` and `get` 
 ====
 
 == Labeling the namespaces
-{prod-short} updates the workspace's {orch-namespace} on workspace startup by adding the labels defined in `CHE_INFRA_KUBERNETES_NAMESPACE_LABELS`. To do so, `che` ServiceAccout has to have the following cluster-wide permissions to `update` and `get` `namespaces`:
+{prod-short} updates the workspace's {orch-namespace} on workspace startup by adding the labels defined in `CHE_INFRA_KUBERNETES_NAMESPACE_LABELS`. To do so, `che` ServiceAccount has to have the following cluster-wide permissions to `update` and `get` `namespaces`:
 
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -184,7 +184,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ----
 <1> name of the cluster role binding
-<2> name of the che service account
+<2> name of the `che` ServiceAccount
 <3> {prod-short} installation namespace
 <4> name of the cluster role created in previous step
 

--- a/modules/installation-guide/partials/proc_installing-che-on-kubespray-using-chectl.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-kubespray-using-chectl.adoc
@@ -3,7 +3,7 @@
 // installing-{prod-id-short}-with-kubespray
 
 [id="installing-{prod-id-short}-on-kubespray-using-{prod-cli}_{context}"]
-= Installing che on Kubespray using {prod-cli}
+= Installing {prod-short} on Kubespray using {prod-cli}
 
 This section describes how to install {prod-short} on {kubernetes} provisioned by Kubespray.
 

--- a/modules/overview/partials/assembly_introduction-to-eclipse-che.adoc
+++ b/modules/overview/partials/assembly_introduction-to-eclipse-che.adoc
@@ -19,7 +19,7 @@
 [id="getting-started-with-{prod-id-short}_{context}"]
 == Getting started with {prod-short}
 
-* xref:what-is-{prod-id-short}_{context}[].
+* xref:what-is-{prod-id-short}_{context}[]
 * xref:che-architecture.adoc[]
 * xref:hosted-che.adoc[]
 * xref:installation-guide:running-che-locally.adoc[]


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

Hello, I made some small fixes to the documentation.

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
