### PR TITLE
fix: broken links after che-server repository move

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -74,8 +74,8 @@ asciidoc:
     link-identity-provider-oidc: "https://www.keycloak.org/docs/6.0/server_admin/#_oidc"
     link-identity-provider-saml: "https://www.keycloak.org/docs/6.0/server_admin/#saml-v2-0-identity-providers"
     link-installing-an-instance: xref:installation-guide:installing-che.adoc[]
-    link-postgres-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/postgres
-    link-server-identity-provider-dockerfile-location: https://github.com/eclipse/che/tree/master/dockerfiles/keycloak
+    link-postgres-dockerfile-location: https://github.com/eclipse-che/che-server/tree/main/dockerfiles/postgres
+    link-server-identity-provider-dockerfile-location: https://github.com/eclipse-che/che-server/tree/main/dockerfiles/keycloak
     link-viewing-the-state-of-the-cluster-deployment-using-openshift-4-cli-tools: xref:overview:installing-che-on-openshift-4-using-operatorhub.adoc[]
     namespace: namespace # In context: API namespace
     nodejs-stack: nodejs

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -21,7 +21,7 @@ include::example$prometheus-config.adoc[]
 ====
 ifeval::["{project-context}" == "che"]
 +
-Latest version: link:https://github.com/eclipse/che/blob/master/deploy/openshift/templates/monitoring/prometheus-config.yaml[example `prometheus-config.yaml` on GitHub].
+Latest version: link:https://github.com/eclipse-che/che-server/blob/main/deploy/openshift/templates/monitoring/prometheus-config.yaml[example `prometheus-config.yaml` on GitHub].
 endif::[]
 +
 <1> Rate, at which a target is scraped.

--- a/modules/end-user-guide/partials/con_a-minimal-devfile.adoc
+++ b/modules/end-user-guide/partials/con_a-minimal-devfile.adoc
@@ -17,7 +17,7 @@ metadata:
   name: {project-context}-in-{project-context}-out
 ----
 
-For a complete devfile example, see link:https://github.com/eclipse/che/blob/master/devfile.yaml[{prod} in {prod-short} devfile.yaml].
+For a complete devfile example, see link:https://github.com/eclipse-che/che-server/blob/main/devfile.yaml[{prod} in {prod-short} devfile.yaml].
 
 [NOTE]
 ====

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-using-chectl-and-a-local-devfile.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-using-chectl-and-a-local-devfile.adoc
@@ -16,7 +16,7 @@ A {prod-short} workspace can be created by pointing the `{prod-cli}` tool to a l
 
 ifeval::["{project-context}" == "che"]
 .Example
-Download the `devfile.yaml` file from the link:https://github.com/eclipse/che/blob/master/devfile.yaml[GitHub repository]  to the current working directory.
+Download the `devfile.yaml` file from the link:https://github.com/eclipse-che/che-server/blob/main/devfile.yaml[GitHub repository]  to the current working directory.
 endif::[]
 
 


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Fix links after che-server repository move.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19841 (partially)

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
