### PR TITLE
fix: More robust links

### DIFF
--- a/.vale/styles/CheDocs/Links.yml
+++ b/.vale/styles/CheDocs/Links.yml
@@ -6,3 +6,6 @@ message: Use '%s' instead of '%s.'
 swap:
   \slink\:https\://www.eclipse.org\S*\s: link:{site-baseurl}che-7/
   \shttps\://www.eclipse.org\S*\s: link:{site-baseurl}che-7/
+  github.com/eclipse/che/blob: github.com/eclipse-che/che-server/blob
+  github.com/eclipse/che/tree: github.com/eclipse-che/che-server/tree
+  github.com/eclipse/che-theia: github.com/eclipse-che/che-theia

--- a/modules/administration-guide/examples/snip_plugin-registry-build-output.adoc
+++ b/modules/administration-guide/examples/snip_plugin-registry-build-output.adoc
@@ -1,4 +1,4 @@
-. Observe the contents of `./{che-plugin-registry-directory}/v3/plugins/` present in the container after building the registry. All `meta.yaml` files resulting from a successful plugin registry build will be located here.
+. Observe the contents of `./{che-plugin-registry-directory}/v3/plugins/` present in the container after building the registry. All `meta.yaml` files resulting from a successful plug-ins registry build will be located here.
 +
 [subs="+attributes,quotes"]
 ----

--- a/modules/administration-guide/partials/assembly_calculating-che-resource-requirements.adoc
+++ b/modules/administration-guide/partials/assembly_calculating-che-resource-requirements.adoc
@@ -27,6 +27,6 @@ endif::[]
 * xref:end-user-guide:configuring-a-workspace-using-a-devfile.adoc[]
 * xref:end-user-guide:configuring-a-workspace-using-a-devfile.adoc#a-minimal-devfile_{context}[A minimal devfile]
 * xref:authenticating-users.adoc[]
-* link:https://github.com/eclipse-che/che-plugin-registry[{prod-short} plugin registry repository]
+* link:https://github.com/eclipse-che/che-plugin-registry[{prod-short} plug-ins registry repository]
 
 :context: {parent-context-of-calculating-che-resource-requirements}

--- a/modules/administration-guide/partials/assembly_calculating-che-resource-requirements.adoc
+++ b/modules/administration-guide/partials/assembly_calculating-che-resource-requirements.adoc
@@ -27,6 +27,6 @@ endif::[]
 * xref:end-user-guide:configuring-a-workspace-using-a-devfile.adoc[]
 * xref:end-user-guide:configuring-a-workspace-using-a-devfile.adoc#a-minimal-devfile_{context}[A minimal devfile]
 * xref:authenticating-users.adoc[]
-* link:https://github.com/eclipse/che-plugin-registry[Eclipse Che plugin registry - GitHub repository]
+* link:https://github.com/eclipse-che/che-plugin-registry[{prod-short} plugin registry repository]
 
 :context: {parent-context-of-calculating-che-resource-requirements}

--- a/modules/administration-guide/partials/con_che-editor-plug-in.adoc
+++ b/modules/administration-guide/partials/con_che-editor-plug-in.adoc
@@ -7,14 +7,14 @@
 
 A `Che Editor` plug-in is a {prod-short} workspace plug-in.
 It defines the web application that is used as an editor in a workspace.
-The default {prod-short} workspace editor is link:https://github.com/eclipse/che-theia[Che-Theia].
+The default {prod-short} workspace editor is link:https://github.com/eclipse-che/che-theia[Che-Theia].
 It is a web-based source-code editor similar to link:https://code.visualstudio.com/[Visual Studio Code] (VS Code).
 It has a plug-in system that supports VS Code extensions.
 
 [cols=2*]
 |===
 | Source code
-| link:https://github.com/eclipse/che-theia[Che-Theia]
+| link:https://github.com/eclipse-che/che-theia[Che-Theia]
 
 | Container image
 | `eclipse/che-theia`
@@ -26,7 +26,7 @@ It has a plug-in system that supports VS Code extensions.
 
 .Additional resources
 
-* link:https://github.com/eclipse/che-theia[Che-Theia]
+* link:https://github.com/eclipse-che/che-theia[Che-Theia]
 * link:https://github.com/theia-ide/theia[Eclipse Theia open-source project]
 * link:https://code.visualstudio.com/[Visual Studio Code]
 

--- a/modules/administration-guide/partials/con_che-server.adoc
+++ b/modules/administration-guide/partials/con_che-server.adoc
@@ -12,7 +12,7 @@ The {prod-short} server is the central service of the workspaces controller. It 
 |===
 ifeval::["{project-context}" == "che"]
 | Source code
-| link:https://github.com/eclipse/che[{prod} GitHub] 
+| link:https://github.com/eclipse-che/che-server[{prod} server repository] 
 endif::[]
 
 | Container image

--- a/modules/administration-guide/partials/con_che-user-dashboard.adoc
+++ b/modules/administration-guide/partials/con_che-user-dashboard.adoc
@@ -11,7 +11,7 @@ The user dashboard is the landing page of {prod}. It is an Angular front-end app
 |===
 ifeval::["{project-context}" == "che"]
 | Source code
-| link:https://github.com/eclipse/che-dashboard[{prod-short} Dashboard]
+| link:https://github.com/eclipse-che/che-dashboard[{prod-short} Dashboard]
 endif::[]
 
 | Container image

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -21,7 +21,10 @@ include::example$prometheus-config.adoc[]
 ====
 ifeval::["{project-context}" == "che"]
 +
-Latest version: link:https://github.com/eclipse-che/che-server/blob/main/deploy/openshift/templates/monitoring/prometheus-config.yaml[example `prometheus-config.yaml` on GitHub].
+Latest version: link:https://raw.githubusercontent.com/eclipse-che/che-server/{pro
+
+
+d-ver-patch}/deploy/openshift/templates/monitoring/prometheus-config.yaml[example `prometheus-config.yaml` on GitHub].
 endif::[]
 +
 <1> Rate, at which a target is scraped.

--- a/modules/administration-guide/partials/proc_workspaces-requirements.adoc
+++ b/modules/administration-guide/partials/proc_workspaces-requirements.adoc
@@ -89,7 +89,7 @@ include::example$snip_{project-context}-memory-requirement-note.adoc[]
 ====
 .How to find the `meta.yaml` file of `chePlugin`
 
-Community plug-ins are available in the link:https://github.com/eclipse-che/che-plugin-registry[{prod-short} plugin registry repository] in folder `v3/plugins/$\{organization}/$\{name}/$\{version}/`.
+Community plug-ins are available in the link:https://github.com/eclipse-che/che-plugin-registry[{prod-short} plug-ins registry repository] in folder `v3/plugins/$\{organization}/$\{name}/$\{version}/`.
 
 For non-community or customized plug-ins, the `meta.yaml` files are available on the local {platforms-name} cluster at `$\{pluginRegistryEndpoint}/v3/plugins/$\{organization}/$\{name}/$\{version}/meta.yaml`.
 

--- a/modules/administration-guide/partials/proc_workspaces-requirements.adoc
+++ b/modules/administration-guide/partials/proc_workspaces-requirements.adoc
@@ -89,7 +89,7 @@ include::example$snip_{project-context}-memory-requirement-note.adoc[]
 ====
 .How to find the `meta.yaml` file of `chePlugin`
 
-Community plug-ins are available in the link:https://github.com/eclipse/che-plugin-registry[che-plugin-registry GitHub repository] in folder `v3/plugins/$\{organization}/$\{name}/$\{version}/`.
+Community plug-ins are available in the link:https://github.com/eclipse-che/che-plugin-registry[{prod-short} plugin registry repository] in folder `v3/plugins/$\{organization}/$\{name}/$\{version}/`.
 
 For non-community or customized plug-ins, the `meta.yaml` files are available on the local {platforms-name} cluster at `$\{pluginRegistryEndpoint}/v3/plugins/$\{organization}/$\{name}/$\{version}/meta.yaml`.
 

--- a/modules/contributor-guide/partials/con_che-theia-plug-in-registries.adoc
+++ b/modules/contributor-guide/partials/con_che-theia-plug-in-registries.adoc
@@ -57,7 +57,7 @@ For more details about the `meta.yaml` structure, see xref:end-user-guide:what-i
 [id="custom-plug-in-registries_{context}"]
 == Custom plug-in registries
 
-For more information about setting up a custom registry, see the description of the link:https://github.com/eclipse/che-plugin-registry[official registry repository].
+For more information about setting up a custom registry, see the description of the link:https://github.com/eclipse-che/che-plugin-registry[official registry repository].
 
 To use plug-ins from a custom registry, follow one of the following methods:
 

--- a/modules/contributor-guide/partials/proc_adding-a-che-theia-plug-in-into-a-workspace.adoc
+++ b/modules/contributor-guide/partials/proc_adding-a-che-theia-plug-in-into-a-workspace.adoc
@@ -90,7 +90,7 @@ This approach brings an advantage of other users being able to contribute to the
 +
 .Factory URL pointing to a repository containing a devfile
 ====
-`pass:c,a,q[{prod-url}/#https://github.com/eclipse/che]`
+`pass:c,a,q[{prod-url}/#https://github.com/eclipse-che/che-server]`
 ====
 +
 .Factory URL pointing to a devfile

--- a/modules/contributor-guide/partials/proc_adding-a-che-theia-plug-in-to-the-che-plug-in-registry.adoc
+++ b/modules/contributor-guide/partials/proc_adding-a-che-theia-plug-in-to-the-che-plug-in-registry.adoc
@@ -29,4 +29,4 @@ After the new Che-Theia plug-ins are added and merged into the repository, the l
 
 .Additional resources
 
-* link:https://github.com/eclipse/che-plugin-registry/[che-plugin-registry GitHub repository]
+* link:https://github.com/eclipse-che/che-plugin-registry/[che-plugin-registry repository]

--- a/modules/contributor-guide/partials/proc_building-a-che-theia-container-image-with-custom-branding.adoc
+++ b/modules/contributor-guide/partials/proc_building-a-che-theia-container-image-with-custom-branding.adoc
@@ -15,7 +15,7 @@ This section describes how to build a Che-Theia container image with custom bran
 
 .Procedure
 
-. Download an example link:https://github.com/che-samples/che-theia-branding-example/blob/master/Dockerfile[`Dockerfile`].
+. Download an example link:https://raw.githubusercontent.com/che-samples/che-theia-branding-example/master/Dockerfile[`Dockerfile`].
 . In the `Dockerfile` directory, create a `branding/` sub-directory. Place the custom `product.json` file and logo images into the `branding/` directory.
 . Build the container image with Che-Theia and push the image to a container registry:
 +

--- a/modules/contributor-guide/partials/proc_defining-custom-branding-values-for-che-theia.adoc
+++ b/modules/contributor-guide/partials/proc_defining-custom-branding-values-for-che-theia.adoc
@@ -9,7 +9,7 @@ This section describes how to customize definitions of basic branding elements o
 
 .Procedure
 
-Create a `product.json` file with a new name of the product, logo, description, and list of hyperlinks on the *Welcome* page (an example of link:https://github.com/che-samples/che-theia-branding-example/blob/master/branding/product.json[`product.json`]:
+Create a `product.json` file with a new name of the product, logo, description, and list of hyperlinks on the *Welcome* page (an example of link:https://raw.githubusercontent.com/che-samples/che-theia-branding-example/master/branding/product.json[`product.json`]:
 
 [source,json,attrs="nowrap"]
 ----

--- a/modules/contributor-guide/partials/proc_testing-che-theia-with-custom-branding.adoc
+++ b/modules/contributor-guide/partials/proc_testing-che-theia-with-custom-branding.adoc
@@ -33,7 +33,7 @@ include::administration-guide:example$snip_{project-context}-build-a-custom-plug
 
 . Publish the `meta.yaml` file in this directory to a publicly accessible location where it can be used as an HTTP resource.
 
-. Create a workspace using the sample https://github.com/che-samples/che-theia-branding-example/blob/master/devfile.yaml[che-theia-branding-example devfile] to apply the changes.
+. Create a workspace using the sample https://raw.githubusercontent.com/che-samples/che-theia-branding-example/master/devfile.yaml[che-theia-branding-example devfile] to apply the changes.
 +
 Make sure the `reference` field points to your published `meta.yaml` file:
 +

--- a/modules/contributor-guide/partials/ref_che-theia-plug-in-api.adoc
+++ b/modules/contributor-guide/partials/ref_che-theia-plug-in-api.adoc
@@ -20,7 +20,7 @@ The Che-Theia plug-in API consists of two {namespace}s:
 [id="theia-{namespace}_{context}"]
 == `theia` {namespace}
 
-The available resources of the `theia` {namespace} are described in the link:https://github.com/theia-ide/theia/blob/master/packages/plugin/src/theia.d.ts[`theia.d.ts`] file in the link:https://github.com/theia-ide/theia[Theia repository]. The root of the {namespace} contains types declaration and the following API sections:
+The available resources of the `theia` {namespace} are described in the link:https://raw.githubusercontent.com/theia-ide/theia/master/packages/plugin/src/theia.d.ts[`theia.d.ts`] file in the link:https://github.com/theia-ide/theia[Theia repository]. The root of the {namespace} contains types declaration and the following API sections:
 
 |===
 | `commands` | API for adding new and executing existing Che-Theia commands
@@ -40,7 +40,7 @@ The available resources of the `theia` {namespace} are described in the link:htt
 
 NOTE: Many APIs in the {namespace} are experimental and can change in the future.
 
-Available resources of the `che` {orch-namespace} are described in the link:https://github.com/eclipse/che-theia/blob/master/extensions/eclipse-che-theia-plugin/src/che.d.ts[`che.d.ts`] file in the link:https://github.com/eclipse/che-theia[Che-Theia repository].
+Available resources of the `che` {orch-namespace} are described in the link:https://raw.githubusercontent.com/eclipse/che-theia/{prod-ver-patch}/extensions/eclipse-che-theia-plugin/src/che.d.ts[`che.d.ts`] file in the link:https://github.com/eclipse-che/che-theia[Che-Theia repository].
 
 This {namespace} contains APIs and types related to {prod-short}. Some sections are a bridge to {prod-short} API. The following is a list of the sections:
 

--- a/modules/end-user-guide/pages/adding-a-vs-code-extension-to-the-che-plugin-registry.adoc
+++ b/modules/end-user-guide/pages/adding-a-vs-code-extension-to-the-che-plugin-registry.adoc
@@ -1,6 +1,6 @@
 [id="adding-a-vs-code-extension-to-the-che-plugin-registry"]
-// = Adding a VS Code extension to the Che plugin registry
-:navtitle: Adding a VS Code extension to the Che plugin registry
+// = Adding a VS Code extension to the Che plug-ins registry
+:navtitle: Adding a VS Code extension to the Che plug-ins registry
 :keywords: end-user-guide, adding-a-vs-code-extension-to-the-che-plugin-registry
 :page-aliases: .:adding-a-vs-code-extension-to-the-che-plugin-registry
 

--- a/modules/end-user-guide/partials/con_a-minimal-devfile.adoc
+++ b/modules/end-user-guide/partials/con_a-minimal-devfile.adoc
@@ -17,7 +17,7 @@ metadata:
   name: {project-context}-in-{project-context}-out
 ----
 
-For a complete devfile example, see link:https://github.com/eclipse-che/che-server/blob/main/devfile.yaml[{prod} in {prod-short} devfile.yaml].
+For a complete devfile example, see link:https://raw.githubusercontent.com/eclipse-che/che-server/main/devfile.yaml[{prod} in {prod-short} devfile.yaml].
 
 [NOTE]
 ====

--- a/modules/end-user-guide/partials/con_che-theia-plug-in-concept-in-detail.adoc
+++ b/modules/end-user-guide/partials/con_che-theia-plug-in-concept-in-detail.adoc
@@ -44,27 +44,27 @@ Che-Theia plug-ins have the following capabilities:
 
 | *{prod-short} Extended Tasks*
 | Handles the {prod-short} commands and provides the ability to start those into a specific container of the workspace.
-|link:https://github.com/eclipse/che-theia/tree/master/plugins/task-plugin[Task plug-in]
+|link:https://github.com/eclipse-che/che-theia/tree/master/plugins/task-plugin[Task plug-in]
 
 | *{prod-short} Extended Terminal*
 | Allows to provide terminal for any of the containers of the workspace.
-|link:https://github.com/eclipse/che-theia/tree/master/extensions/eclipse-che-theia-terminal[Extended Terminal extension]
+|link:https://github.com/eclipse-che/che-theia/tree/master/extensions/eclipse-che-theia-terminal[Extended Terminal extension]
 
 | *{prod-short} Factory*
 | Handles the {prod} Factories
-|link:https://github.com/eclipse/che-theia/tree/master/plugins/workspace-plugin[Workspace plug-in]
+|link:https://github.com/eclipse-che/che-theia/tree/master/plugins/workspace-plugin[Workspace plug-in]
 
 | *{prod-short} Container*
 | Provides a container view that shows all the containers that are running in the workspace and allows to interact with them.
-| link:https://github.com/eclipse/che-theia/tree/master/plugins/containers-plugin[Containers plug-in]
+| link:https://github.com/eclipse-che/che-theia/tree/master/plugins/containers-plugin[Containers plug-in]
 
 | *Dashboard*
 | Integrates the IDE with the *Dashboard* and facilitate the navigation.
-|link:https://github.com/eclipse/che-theia/tree/master/extensions/eclipse-che-theia-dashboard[Che-Theia Dashbord extension]
+|link:https://github.com/eclipse-che/che-theia/tree/master/extensions/eclipse-che-theia-dashboard[Che-Theia Dashbord extension]
 
 | *{prod-short} APIs*
 | Extends the IDE APIs to allow interacting with {prod-short}-specific components (workspaces, preferences).
-|link:https://github.com/eclipse/che-theia/tree/master/extensions/eclipse-che-theia-plugin-ext[Che-Theia API extension]
+|link:https://github.com/eclipse-che/che-theia/tree/master/extensions/eclipse-che-theia-plugin-ext[Che-Theia API extension]
 |===
 
 

--- a/modules/end-user-guide/partials/con_che-theia-task-types.adoc
+++ b/modules/end-user-guide/partials/con_che-theia-task-types.adoc
@@ -71,5 +71,4 @@ pass:[<!-- vale Vale.Spelling = YES -->]
 pass:[<!-- vale Vale.Terms = YES -->]
 
 .Examples
-* link:https://github.com/eclipse/che-devfile-registry/blob/master/devfiles/quarkus-command-mode/devfile.yaml#L63-L71[An example of a theia task]
-* link:https://github.com/eclipse/che-devfile-registry/blob/master/devfiles/quarkus-command-mode/devfile.yaml#L84-L100[An example of a vscode-launch task] 
+* link:https://raw.githubusercontent.com/eclipse/che-devfile-registry/{prod-ver-patch}/devfiles/quarkus-command-mode/devfile.yaml[Quarkus command mode devfile, includings a `theia` task, and a `vscode-launch` task] 

--- a/modules/end-user-guide/partials/con_support-for-theia-based-ides.adoc
+++ b/modules/end-user-guide/partials/con_support-for-theia-based-ides.adoc
@@ -21,7 +21,7 @@ editors:
     displayName: theia-ide
     description: Eclipse Theia, get the latest release each day.
     icon: https://raw.githubusercontent.com/theia-ide/theia/master/logo/theia-logo-no-text-black.svg?sanitize=true
-    repository: https://github.com/eclipse/che-theia
+    repository: https://github.com/eclipse-che/che-theia
     firstPublicationDate: "2021-01-01"
     endpoints:
       - name: "theia"

--- a/modules/end-user-guide/partials/proc_adding-a-vs-code-extension-to-the-che-plugin-registry.adoc
+++ b/modules/end-user-guide/partials/proc_adding-a-vs-code-extension-to-the-che-plugin-registry.adoc
@@ -1,13 +1,13 @@
 [id="proc_adding-a-vs-code-extension-to-the-che-plugin-registry_{context}"]
-= Adding a VS Code extension to the Che plugin registry
+= Adding a VS Code extension to the Che plug-ins registry
 
-To use a VS Code extension in a {prod-short} workspace, {prod-short} need to consume metadata describing the extension. The {prod-short} plugin registry is a static website publishing metadata for common VS Code extensions. VS Code extension metadata for the {prod-short} plugin registry is generated from a central file named `che-theia-plugins.yaml`.
+To use a VS Code extension in a {prod-short} workspace, {prod-short} need to consume metadata describing the extension. The {prod-short} plug-ins registry is a static website publishing metadata for common VS Code extensions. VS Code extension metadata for the {prod-short} plug-ins registry is generated from a central file named `che-theia-plugins.yaml`.
 
-To add or modify an extension in the {prod-short} plugin registry, edit the `che-theia-plugins.yaml` file and add relevant metadata.
+To add or modify an extension in the {prod-short} plug-ins registry, edit the `che-theia-plugins.yaml` file and add relevant metadata.
 
 [NOTE]
 ====
-This article describes the steps needed to build the plugin registry with a custom plugin definition. If you are looking to create a custom `meta.yaml` file that can be directly referenced in a devfile, see xref:end-user-guide:publishing-metadata-for-a-vs-code-extension.adoc[].
+This article describes the steps needed to build the plug-ins registry with a custom plugin definition. If you are looking to create a custom `meta.yaml` file that can be directly referenced in a devfile, see xref:end-user-guide:publishing-metadata-for-a-vs-code-extension.adoc[].
 ====
 
 
@@ -81,4 +81,4 @@ This article describes the steps needed to build the plugin registry with a cust
 
 
 . Run the `build.sh` script with the options of your choosing. The build process will generate `meta.yaml` files automatically, based on the entries in the `che-theia-plugins.yaml` file.
-. Use the resulting plugin registry image in {prod-short}, or copy the `meta.yaml` file out of the registry container and reference it directly as an HTTP resource.
+. Use the resulting plug-ins registry image in {prod-short}, or copy the `meta.yaml` file out of the registry container and reference it directly as an HTTP resource.

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-by-importing-the-source-code-of-a-project.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-by-importing-the-source-code-of-a-project.adoc
@@ -52,7 +52,7 @@ projects:
   - name: che
     source:
       type: git
-      location: 'https://github.com/eclipse/che.git'
+      location: 'https://github.com/eclipse-che/che-server.git'
 ----
 See the xref:configuring-a-workspace-using-a-devfile.adoc#devfile-reference_{context}[Devfile reference].
 ====
@@ -79,7 +79,7 @@ projects:
   - name: che
     source:
       type: git
-      location: 'https://github.com/eclipse/che.git'
+      location: 'https://github.com/eclipse-che/che-server.git'
 ----
 See the xref:configuring-a-workspace-using-a-devfile.adoc#devfile-reference_{context}[Devfile reference].
 ====

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-from-the-default-branch-of-a-git-repository.adoc
@@ -27,16 +27,16 @@ pass:[<!-- vale CheDocs.TechnicalTerms = NO -->]
 `pass:c,a,q[{prod-url}/#__<GIT_REPOSITORY_URL>__]`:: This is the short format.
 `pass:c,a,q[{prod-url}/f?url=__<GIT_REPOSITORY_URL>__]`:: This long format supports additional configuration parameters.
 +
-.Create a workspace on Eclipse Che hosted by Red Hat from the default branch of the `https://github.com/eclipse/che` repository using the short factory URL format.
+.Create a workspace on Eclipse Che hosted by Red Hat from the default branch of the `https://github.com/eclipse-che/che-server` repository using the short factory URL format.
 [subs="+quotes"]
 ====
-link:https://workspaces.openshift.com/#https://github.com/eclipse/che[]
+link:https://workspaces.openshift.com/#https://github.com/eclipse-che/che-server[]
 ====
 +
-.Create a workspace on Eclipse Che hosted by Red Hat from the default branch of the `https://github.com/eclipse/che` repository using the long factory URL format.
+.Create a workspace on Eclipse Che hosted by Red Hat from the default branch of the `https://github.com/eclipse-che/che-server` repository using the long factory URL format.
 [subs="+quotes"]
 ====
-link:https://workspaces.openshift.com/f?url=https://github.com/eclipse/che[]
+link:https://workspaces.openshift.com/f?url=https://github.com/eclipse-che/che-server[]
 ====
 
 pass:[<!-- vale CheDocs.TechnicalTerms = YES -->]

--- a/modules/end-user-guide/partials/proc_creating-a-workspace-using-chectl-and-a-local-devfile.adoc
+++ b/modules/end-user-guide/partials/proc_creating-a-workspace-using-chectl-and-a-local-devfile.adoc
@@ -16,7 +16,7 @@ A {prod-short} workspace can be created by pointing the `{prod-cli}` tool to a l
 
 ifeval::["{project-context}" == "che"]
 .Example
-Download the `devfile.yaml` file from the link:https://github.com/eclipse-che/che-server/blob/main/devfile.yaml[GitHub repository]  to the current working directory.
+Download the `devfile.yaml` file from the link:https://raw.githubusercontent.com/eclipse-che/che-server/main/devfile.yaml[GitHub repository]  to the current working directory.
 endif::[]
 
 

--- a/modules/end-user-guide/partials/proc_publishing-metadata-for-a-vs-code-extension.adoc
+++ b/modules/end-user-guide/partials/proc_publishing-metadata-for-a-vs-code-extension.adoc
@@ -5,9 +5,9 @@
 [id="proc_publishing-metadata-for-a-vs-code-extension_{context}"]
 = Publishing metadata for a VS Code extension
 
-To use a VS Code extension in a {prod-short} workspace, {prod-short} needs to consume metadata describing the extension. The {prod-short} plugin registry is a static website publishing metadata for common VS Code extensions.
+To use a VS Code extension in a {prod-short} workspace, {prod-short} needs to consume metadata describing the extension. The {prod-short} plug-ins registry is a static website publishing metadata for common VS Code extensions.
 
-This article describes how to publish metadata for an additional extension, not available in the {prod-short} plugin registry, by using the extension configuration `meta.yaml` file.
+This article describes how to publish metadata for an additional extension, not available in the {prod-short} plug-ins registry, by using the extension configuration `meta.yaml` file.
 
 For details on adding a plugin to an existing plug-in registry, see xref:adding-a-vs-code-extension-to-the-che-plugin-registry.adoc[]
 

--- a/modules/end-user-guide/partials/proc_writing-a-devfile-for-your-project.adoc
+++ b/modules/end-user-guide/partials/proc_writing-a-devfile-for-your-project.adoc
@@ -98,5 +98,5 @@ For a detailed explanation of all devfile component assignments and possible val
 
 These sample devfiles are a good source of inspiration:
 
-* link:https://github.com/eclipse/che-devfile-registry/tree/master/devfiles[Sample devfiles for {prod} workspaces used by default in the user interface].
+* link:https://github.com/eclipse-che/che-devfile-registry/tree/master/devfiles[Sample devfiles for {prod} workspaces used by default in the user interface].
 * link:https://github.com/redhat-developer/devfile/tree/master/samples[Sample devfiles for {prod} workspaces from Red Hat Developer program].

--- a/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
+++ b/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
@@ -22,7 +22,7 @@ The Che-Theia plug-in metadata, for each specific plug-in, is defined in a `meta
 Here is an overview of all fields that can be available in plugin meta YAML files. This document represents the link:https://github.com/eclipse-che/che-plugin-registry#user-content-plugin-meta-yaml-structure[plugin meta YAML structure (version 3)].
 
 
-The link:https://github.com/eclipse-che/che-plugin-registry/[{prod-short} plugin registry repository] generates `meta.yaml` files at build time, from a link:https://raw.githubusercontent.com/eclipse/che-plugin-registry/{prod-ver-patch}/che-theia-plugins.yaml[che-theia-plugins.yaml file]. This file contains a list of all Che-Theia plug-ins in the registry.
+The link:https://github.com/eclipse-che/che-plugin-registry/[{prod-short} plug-ins registry repository] generates `meta.yaml` files at build time, from a link:https://raw.githubusercontent.com/eclipse/che-plugin-registry/{prod-ver-patch}/che-theia-plugins.yaml[che-theia-plugins.yaml file]. This file contains a list of all Che-Theia plug-ins in the registry.
 
 .`meta.yml`
 |===

--- a/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
+++ b/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
@@ -19,10 +19,10 @@ Che-Theia plug-in metadata is information about individual plug-ins for the plug
 
 The Che-Theia plug-in metadata, for each specific plug-in, is defined in a `meta.yaml` file. These files can be referenced in a devfile to include Che-Theia plug-ins in a workspace.
 
-Here is an overview of all fields that can be available in plugin meta YAML files. This document represents the link:https://github.com/eclipse/che-plugin-registry#user-content-plugin-meta-yaml-structure[plugin meta YAML structure (version 3)].
+Here is an overview of all fields that can be available in plugin meta YAML files. This document represents the link:https://github.com/eclipse-che/che-plugin-registry#user-content-plugin-meta-yaml-structure[plugin meta YAML structure (version 3)].
 
 
-The link:https://github.com/eclipse/che-plugin-registry/[che-plugin-registry repository] generates `meta.yaml` files at build time, from a link:https://github.com/eclipse/che-plugin-registry/blob/master/che-theia-plugins.yaml[che-theia-plugins.yaml file]. This file contains a list of all Che-Theia plug-ins in the registry.
+The link:https://github.com/eclipse-che/che-plugin-registry/[{prod-short} plugin registry repository] generates `meta.yaml` files at build time, from a link:https://raw.githubusercontent.com/eclipse/che-plugin-registry/{prod-ver-patch}/che-theia-plugins.yaml[che-theia-plugins.yaml file]. This file contains a list of all Che-Theia plug-ins in the registry.
 
 .`meta.yml`
 |===
@@ -145,7 +145,7 @@ The link:https://github.com/eclipse/che-plugin-registry/[che-plugin-registry rep
   description: {prod-short} Plug-in with che-machine-exec service to provide creation terminal
     or tasks for Eclipse CHE workspace containers.
   icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
-  repository: https://github.com/eclipse/che-machine-exec/
+  repository: https://github.com/eclipse-che/che-machine-exec/
   firstPublicationDate: "2020-03-18"
   category: Other
   spec:

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -90,7 +90,7 @@ Project source consists of two mandatory values: `type` and `location`.
 ----
 source:
     type: git
-    location: https://github.com/eclipse/che.git
+    location: https://github.com/eclipse-che/che-server.git
     startPoint: master           <1>
     tag: 7.2.0
     commitId: 36fe587
@@ -184,7 +184,7 @@ Describes plug-ins in a workspace by defining their `id`. It is allowed to have 
 
 Both types above use an ID, which is slash-separated publisher, name and version of plug-in from the {prod-short} Plug-in registry.
 
-List of available {prod-upstream} plug-ins and more information about registry can be found in the link:https://github.com/eclipse/che-plugin-registry[{prod-upstream} plug-in registry] GitHub repository.
+List of available {prod-upstream} plug-ins and more information about registry can be found in the link:https://github.com/eclipse-che/che-plugin-registry[{prod-upstream} plug-in registry] GitHub repository.
 
 === Specifying an alternative component registry
 

--- a/modules/glossary/partials/con_glossary.adoc
+++ b/modules/glossary/partials/con_glossary.adoc
@@ -22,7 +22,7 @@ Editor:: A web application that is used as an editor in a workspace.
 
 Plugin:: Plugins are services that extend {prod-short} workspace capabilities. {prod-short} plugins are packaged as containers. Plugins are extensions of an editor or a service running in the container. For example, the Che-Theia editor is compatible with Visual Studio Code extensions. 
 //TODO See for a diagram of {prod-short} extensibility architecture. 
-Both {prod-short} plugins and editors are distributed through the {prod-short} plugin registry. 
+Both {prod-short} plugins and editors are distributed through the {prod-short} plug-ins registry. 
  
 Workspace:: A container based development environment managed by {prod}. Every  {prod-short} workspace is defined by a devfile. A  {prod-short} workspace can be composed by an editor, some plugins and runtime containers. Workspace runtime containers can be defined as simple container images or as {platforms-name} resources. A {prod-short} Workspace can be associated with source code projects hosted on a remote CVS server. A {prod-short} Workspace can contain the definition of one or more commands such as `run`, `build`, or `debug`.
 

--- a/modules/hosted-che/partials/proc_contributing-to-github-projects-in-hosted-che.adoc
+++ b/modules/hosted-che/partials/proc_contributing-to-github-projects-in-hosted-che.adoc
@@ -11,10 +11,10 @@ This section describes how to contribute to GitHub projects from Eclipse Che hos
 
 * A workspace running in Eclipse Che hosted by Red Hat, including a project imported from GitHub.
 
-* The link:https://github.com/eclipse/che-theia/tree/master/plugins/ssh-plugin[SSH Plug-in] is available in the workspace.
+* The link:https://github.com/eclipse-che/che-theia/tree/master/plugins/ssh-plugin[SSH Plug-in] is available in the workspace.
 
 .Procedure
 
-. Generate an SSH key pair with the link:https://github.com/eclipse/che-theia/tree/master/plugins/ssh-plugin[SSH Plug-in].
+. Generate an SSH key pair with the link:https://github.com/eclipse-che/che-theia/tree/master/plugins/ssh-plugin[SSH Plug-in].
 
 . Upload the public key to the GitHub account. For details, see the link:https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account[Adding a new SSH key to your GitHub account] procedure.

--- a/modules/installation-guide/partials/assembly_using-the-chectl-management-tool.adoc
+++ b/modules/installation-guide/partials/assembly_using-the-chectl-management-tool.adoc
@@ -9,14 +9,17 @@
 
 `{prod-cli}` is the {prod} command-line management tool. It is used for operations on the {prod-short} server (start, stop, update, delete) and on workspaces (list, start, stop, inject) and to generate devfiles.
 
-ifeval::["{project-context}" == "che"]
-You can find additional information in the link:https://github.com/che-incubator/{prod-cli}/blob/master/README.md[`{prod-cli}` README].
-endif::[]
-
 include::partial$proc_installing-the-chectl-management-tool-on-windows.adoc[leveloffset=+1]
 
 include::partial$proc_installing-the-chectl-management-tool-on-linux-or-macos.adoc[leveloffset=+1]
 
 include::partial$proc_upgrading-the-chectl-management-tool.adoc[leveloffset=+1]
+
+
+ifeval::["{project-context}" == "che"]
+.Additional resources
+
+* See: link:https://github.com/che-incubator/{prod-cli}/[`{prod-cli}` reference documentation].
+endif::[]
 
 :context: {parent-context-of-using-the-chectl-management-tool}

--- a/modules/installation-guide/partials/proc_configuring-labels-and-domains-for-routes.adoc
+++ b/modules/installation-guide/partials/proc_configuring-labels-and-domains-for-routes.adoc
@@ -98,7 +98,7 @@ $ {orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} --type=json 
 ----
 $ {orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} --type=json -p \
 '[{"op": "replace", "path": "/spec/server/pluginRegistryRoute/labels", '\
-'"value": "__<labels for a plugin registry route>__"}]'
+'"value": "__<labels for a plug-ins registry route>__"}]'
 ----
 +
 [subs="+quotes,+attributes"]

--- a/modules/installation-guide/partials/proc_configuring-labels-for-ingresses.adoc
+++ b/modules/installation-guide/partials/proc_configuring-labels-for-ingresses.adoc
@@ -27,7 +27,7 @@ $ {orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} --type=json 
 
 $ {orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} --type=json -p \
 '[{"op": "replace", "path": "/spec/server/pluginRegistryIngress/labels", '\
-'"value": "__<labels for a plugin registry ingress>__"}]'
+'"value": "__<labels for a plug-ins registry ingress>__"}]'
 
 $ {orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} --type=json -p \
 '[{"op": "replace", "path": "/spec/server/devfileRegistryIngress/labels",'\

--- a/modules/installation-guide/partials/proc_configuring-storage-types.adoc
+++ b/modules/installation-guide/partials/proc_configuring-storage-types.adoc
@@ -67,7 +67,7 @@ Asynchronous storage is a combination of persistent and ephemeral modes. The ini
 
 Synchronization is performed by the link:https://rsync.samba.org/[rsync] tool using the link:https://www.openssh.com/[SSH] protocol. When a workspace is configured with asynchronous storage, the link:https://github.com/che-incubator/workspace-data-sync/[workspace-data-sync] plug-in is automatically added to the workspace configuration. The plug-in runs the `rsync` command on workspace start to restore changes. When a workspace is stopped, it sends changes to the permanent storage.
 
-For relatively small projects, the restore procedure is fast, and project source files are immediately available after Che-Theia is initialized. In case `rsync` takes longer, the synchronization process is shown in the Che-Theia status-bar area. (link:https://github.com/eclipse/che-theia/tree/master/extensions/eclipse-che-theia-file-sync-tracker[Extension in Che-Theia repository]).
+For relatively small projects, the restore procedure is fast, and project source files are immediately available after Che-Theia is initialized. In case `rsync` takes longer, the synchronization process is shown in the Che-Theia status-bar area. (link:https://github.com/eclipse-che/che-theia/tree/master/extensions/eclipse-che-theia-file-sync-tracker[Extension in Che-Theia repository]).
 
 image::troubleshooting/status-bar-file-sync.png[link="../_images/troubleshooting/status-bar-file-sync.png",Files synchronization progress]
 

--- a/modules/installation-guide/partials/proc_deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc
+++ b/modules/installation-guide/partials/proc_deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc
@@ -43,8 +43,8 @@ ifeval::["{project-context}" == "che"]
 =====
 .For {prod-short} deployed using a Helm Chart
 
-. Clone the https://github.com/eclipse/che[che] project
-. Go to `deploy/kubernetes/helm/che` directory
+. Clone the https://github.com/eclipse-che/che-server[{prod-short} server repository].
+. Go to `deploy/kubernetes/helm/che` directory.
 . Update the `global.useGitSelfSignedCerts` property. To do that, add the following option to the `helm upgrade` command:
 +
 [subs="+quotes,+attributes"]

--- a/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates-old.adoc
+++ b/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates-old.adoc
@@ -141,7 +141,7 @@ ifeval::["{project-context}" == "che"]
 ====
 For a {prod-short} link:https://helm.sh/[Helm Chart] deployment:
 
-. Clone the https://github.com/eclipse/che[che] project.
+. Clone the https://github.com/eclipse-che/che-server[{prod-short} server] project.
 . Go to the `deploy/kubernetes/helm/che` directory.
 . Update the name of the configMap {prod-short} will use, by editing the `global.tls.serverTrustStoreConfigMapName` Helm Chart property to match the created or updated ConfigMap:
 +

--- a/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates.adoc
+++ b/modules/installation-guide/partials/proc_importing-untrusted-tls-certificates.adoc
@@ -109,7 +109,7 @@ global:
 
 Upgrade {prod-short} Helm Chart:
 
-. Clone the https://github.com/eclipse/che[che] project.
+. Clone the https://github.com/eclipse-che/che-server[{prod-short} server] project.
 . Go to the `deploy/kubernetes/helm/che` directory.
 . Update the name of the configMap {prod-short} will use, by editing the `global.tls.serverTrustStoreConfigMapName` Helm Chart property to match the created or updated ConfigMap:
 +

--- a/modules/installation-guide/partials/proc_switching-between-external-and-internal-communication.adoc
+++ b/modules/installation-guide/partials/proc_switching-between-external-and-internal-communication.adoc
@@ -52,7 +52,7 @@ $ {orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} --type=json 
 ifeval::["{project-context}" == "che"]
 * For {prod-short} deployed using a Helm Chart
 
-. Clone the https://github.com/eclipse/che[che] project
+. Clone the https://github.com/eclipse-che/che-server[{prod-short} server] project
 . Go to `deploy/kubernetes/helm/che` directory
 . Update the `global.useInternalClusterSVCNames` property. To do that, add the following option to the `helm upgrade` command:
 - To use external {platforms-ingress} in inter-component communication:


### PR DESCRIPTION
### What does this PR do?

More robust links: 

* Align URLs after repositories relocation 
* Use raw.githubusercontent
* Use {prod-ver-patch} tag when available
* Lang fix: plug-ins registry

### What issues does this PR fix or reference?

Followup on https://github.com/eclipse/che/issues/19841

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
