### PR TITLE
fix: The reference to che-theia-plugins.yaml is specific to upstream.

### DIFF
--- a/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
+++ b/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
@@ -21,8 +21,9 @@ The Che-Theia plug-in metadata, for each specific plug-in, is defined in a `meta
 
 Here is an overview of all fields that can be available in plugin meta YAML files. This document represents the link:https://github.com/eclipse-che/che-plugin-registry#user-content-plugin-meta-yaml-structure[plugin meta YAML structure (version 3)].
 
-
-The link:https://github.com/eclipse-che/che-plugin-registry/[{prod-short} plug-ins registry repository] generates `meta.yaml` files at build time, from a link:https://raw.githubusercontent.com/eclipse/che-plugin-registry/{prod-ver-patch}/che-theia-plugins.yaml[che-theia-plugins.yaml file]. This file contains a list of all Che-Theia plug-ins in the registry.
+ifeval::["{project-context}" == "che"]
+In the link:https://github.com/eclipse-che/che-plugin-registry/tree/{prod-ver-patch}[{prod-short} plug-ins registry repository], the `che-theia-plugins.yaml` contains a list of all Che-Theia plug-ins in the registry. Build the registry container image to generate the `meta.yaml` file.
+endif::[]
 
 .`meta.yml`
 |===


### PR DESCRIPTION
The reference to che-theia-plugins.yaml is specific to upstream.

Fixes broken links in CRW context.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
