### PR TITLE
fix: metadata on assembly_authoring-devfiles-version-2.adoc

### DIFF
--- a/modules/end-user-guide/nav.adoc
+++ b/modules/end-user-guide/nav.adoc
@@ -15,7 +15,6 @@
 ** xref:creating-a-workspace-from-local-devfile-using-chectl.adoc[]
 ** xref:creating-a-workspace-by-importing-the-source-code-of-a-project.adoc[]
 ** xref:configuring-a-workspace-with-dashboard.adoc[]
-** xref:configuring-a-workspace-using-a-devfile.adoc[]
 ** xref:running-a-workspace-with-dashboard.adoc[]
 ** xref:importing-kubernetes-applications-into-a-workspace.adoc[]
 ** xref:remotely-accessing-workspaces.adoc[]

--- a/modules/end-user-guide/partials/assembly_authoring-devfiles-version-2.adoc
+++ b/modules/end-user-guide/partials/assembly_authoring-devfiles-version-2.adoc
@@ -18,4 +18,4 @@ This section explains the concept of the devfile 2.0 specification and how to co
 
 * link:https://redhat-developer.github.io/devfile/devfile[Devfile 2.0 specification]
 
-:context: {parent-context-of-configuring-a-workspace-using-a-devfile}
+:context: {parent-context-of-authoring-devfiles-version-2}

--- a/modules/end-user-guide/partials/assembly_workspaces-overview.adoc
+++ b/modules/end-user-guide/partials/assembly_workspaces-overview.adoc
@@ -64,10 +64,9 @@ For additional information, see: xref:installation-guide:advanced-configuration-
 | Yes. Only requires a browser.
 |===
 
-To start a {prod-short} workspace, following options are available:
+To start a {prod-short} workspace:
 
 * xref:configuring-a-workspace-with-dashboard.adoc[]
-* xref:authoring-devfiles.adoc[]
 
 Use the Dashboard to discover {prod-short} {prod-ver}:
 
@@ -76,7 +75,7 @@ Use the Dashboard to discover {prod-short} {prod-ver}:
 
 Use a devfile as the preferred way to start a {prod-short} {prod-ver} workspace:
 
-* xref:configuring-a-workspace-using-a-devfile.adoc[]
+* xref:authoring-devfiles.adoc[]
 * xref:importing-kubernetes-applications-into-a-workspace.adoc[]
 
 Use the browser-based IDE as the preferred way to interact with a {prod-short} {prod-ver} workspace. For an alternative way to interact with a {prod-short} {prod-ver} workspace, see: xref:remotely-accessing-workspaces.adoc[].

--- a/modules/end-user-guide/partials/assembly_workspaces-overview.adoc
+++ b/modules/end-user-guide/partials/assembly_workspaces-overview.adoc
@@ -67,7 +67,7 @@ For additional information, see: xref:installation-guide:advanced-configuration-
 To start a {prod-short} workspace, following options are available:
 
 * xref:configuring-a-workspace-with-dashboard.adoc[]
-* xref:configuring-a-workspace-using-a-devfile.adoc[]
+* xref:authoring-devfiles.adoc[]
 
 Use the Dashboard to discover {prod-short} {prod-ver}:
 


### PR DESCRIPTION

### What does this PR do?

Fix metadata  on assembly_authoring-devfiles-version-2.adoc

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [x] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
