### PR TITLE
docs: Add note about common PVC deletion

### DIFF
--- a/modules/installation-guide/partials/con_persistent-volume-configuration.adoc
+++ b/modules/installation-guide/partials/con_persistent-volume-configuration.adoc
@@ -9,7 +9,7 @@ Workspace Pods use Persistent Volume Claims (PVCs), which are bound to the physi
 
 include::example${project-context}-pvc-strategies.adoc[]
 
-{prod} uses the `common` PVC strategy in combination with the "one {orch-namespace} per user" {orch-namespace} strategy when all {prod-short} workspaces operate in the user's {orch-namespace}, sharing one PVC.
+{prod-short} uses the `common` PVC strategy in combination with the "one {orch-namespace} per user" {orch-namespace} strategy when all {prod-short} workspaces operate in the user's {orch-namespace}, sharing one PVC.
 
 [id="the-common-pvc-strategy_{context}"]
 == The `common` PVC strategy
@@ -20,7 +20,7 @@ All workspaces inside a {platforms-namespace} use the same Persistent Volume Cla
 * workspace logs
 * additional Volumes defined by a use
 
-When the `common` PVC strategy is in use, user-defined PVCs are ignored and volumes that relate to these user-defined PVCs are replaced with a volume that refers to the common PVC.
+When the `common` PVC strategy is in use, user-defined PVCs are ignored, and volumes related to these user-defined PVCs are replaced with a volume that refers to the common PVC.
 In this strategy, all {prod-short} workspaces use the same PVC. When the user runs one workspace, it only binds to one node in the cluster at a time.
 
 The corresponding containers volume mounts link to a common volume, and sub-paths are prefixed with `_<workspace-ID>_` or `__<original-PVC-name>__`. For more details, see xref:how-subpaths-are-used-in-pvcs_{context}[].
@@ -30,11 +30,11 @@ PVC has, they will use the same shared folder in the common PVC.
 
 When a workspace is deleted, a corresponding subdirectory (`$\{ws-id}`) is deleted in the PV directory.
 
-NOTE: The common PVC will be removed when a user's workspaces are all deleted. The PVC will be re-created when a non-ephemeral workspace is started.
+NOTE: Workspace deletion also removes the related common PVC. The start of a non-ephemeral workspace recreates the deleted PVC.
 
 .Restrictions on using the `common` PVC strategy
 
-When the `common` strategy is used and a workspace PVC access mode is ReadWriteOnce (RWO), only one node can simultaneously use the PVC.
+When the `common` strategy is used, and a workspace PVC access mode is ReadWriteOnce (RWO), only one node can simultaneously use the PVC.
 
 If there are several nodes, you can use the `common` strategy, but:
 
@@ -55,21 +55,21 @@ The `per-workspace` strategy is similar to the `common` PVC strategy. The only d
 
 With this strategy, {prod-short} keeps its workspace data in assigned PVs that are allocated by a single PVC.
 
-The `per-workspace` PVC strategy is the most universal strategy out of the PVC strategies available and acts as a proper option for large multi-node clusters with a higher amount of users. Using the `per-workspace` PVC strategy, users can run multiple workspaces simultaneously, results in more PVCs being created.
+The `per-workspace` PVC strategy is the universal strategy out of the PVC strategies available and acts as a proper option for large multi-node clusters with a higher amount of users. Using the `per-workspace` PVC strategy, users can run multiple workspaces simultaneously, which results in more PVCs being created.
 
 [id="the-unique-pvc-strategy_{context}"]
 == The `unique` PVC strategy
 
-When using the `unique `PVC strategy, every {prod-short} Volume of a workspace has its own PVC. This means that workspace PVCs are:
+Using the `unique `PVC strategy, every {prod-short} Volume of a workspace has its own PVC. The workspace PVCs are then:
 
-Created when a workspace starts for the first time.
-Deleted when a corresponding workspace is deleted.
+* Created when a workspace starts for the first time.
+* Deleted when a corresponding workspace is deleted.
 
 User-defined PVCs are created with the following specifics:
 
 * They are provisioned with generated names to prevent naming conflicts with other PVCs in a {orch-namespace}.
 
-*  Subpaths of the mounted Physical persistent volumes that reference user-defined PVCs are prefixed with `_<workspace-ID>_` or `__<PVC-name>__`. This ensures that the same PV data structure is configure with different PVC strategies. For details, see xref:how-subpaths-are-used-in-pvcs_{context}[].
+* Subpaths of the mounted Physical persistent volumes that reference user-defined PVCs are prefixed with `_<workspace-ID>_` or `__<PVC-name>__`. This ensures that the same PV data structure is configured with different PVC strategies. For details, see xref:how-subpaths-are-used-in-pvcs_{context}[].
 
 The `unique` PVC strategy is suitable for larger multi-node clusters with a lesser amount of users. Since this strategy operates with separate PVCs for each volume in a workspace, vastly more PVCs are created.
 

--- a/modules/installation-guide/partials/con_persistent-volume-configuration.adoc
+++ b/modules/installation-guide/partials/con_persistent-volume-configuration.adoc
@@ -30,6 +30,8 @@ PVC has, they will use the same shared folder in the common PVC.
 
 When a workspace is deleted, a corresponding subdirectory (`$\{ws-id}`) is deleted in the PV directory.
 
+NOTE: The common PVC will be removed when a user's workspaces are all deleted. The PVC will be re-created when a non-ephemeral workspace is started.
+
 .Restrictions on using the `common` PVC strategy
 
 When the `common` strategy is used and a workspace PVC access mode is ReadWriteOnce (RWO), only one node can simultaneously use the PVC.


### PR DESCRIPTION
Please do not merge before eclipse-che/che-server#16

Signed-off-by: David Kwon <dakwon@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Creates a new note for this feature: https://github.com/eclipse-che/che-server/pull/16
![image](https://user-images.githubusercontent.com/83611742/120503363-3dd55f00-c391-11eb-9840-53a95244d64c.png)


### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/pull/18713
Relevant PR: https://github.com/eclipse-che/che-server/pull/16

### Specify the version of the product this PR applies to.
7.32

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
