### PR TITLE
fix: deploying Eclipse Che on GCP

### DIFF
--- a/modules/installation-guide/partials/proc_installing-che-on-kubernetes_using_chectl_and_helm.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-kubernetes_using_chectl_and_helm.adoc
@@ -15,7 +15,7 @@
 
 .Procedure
 ifeval::["{k8s-platform}" == "Google Cloud Platform"]
-* Prepare the helmchart template `patch.yaml` file for the proper Dashboard ingress path exposure:
+. Prepare the helmchart template `patch.yaml` file for the proper Dashboard ingress path exposure:
 +
 ----
 $ cat >patch.yaml<<EOF
@@ -24,7 +24,7 @@ $ cat >patch.yaml<<EOF
 > EOF
 ----
 endif::[]
-* To install {prod-short} on {k8s-platform}, run the following `{prod-cli}` command:
+. Run the following `{prod-cli}` command to install {prod-short} on {k8s-platform}:
 +
 [subs="+attributes"]
 ----

--- a/modules/installation-guide/partials/proc_installing-che-on-kubernetes_using_chectl_and_helm.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-kubernetes_using_chectl_and_helm.adoc
@@ -14,13 +14,27 @@
 * The `helm` tool is available, with version 2.15 or higher. See link:https://helm.sh/[Helm].
 
 .Procedure
-
+ifeval::["{k8s-platform}" == "Google Cloud Platform"]
+* Prepare the helmchart template `patch.yaml` file for the proper Dashboard ingress path exposure:
++
+----
+$ cat >patch.yaml<<EOF
+> dashboard:
+>   ingressPath: /dashboard/*
+> EOF
+----
+endif::[]
 * To install {prod-short} on {k8s-platform}, run the following `{prod-cli}` command:
 +
 [subs="+attributes"]
 ----
+ifeval::["{k8s-platform}" == "Google Cloud Platform"]
+$ {prod-cli} server:deploy --installer=helm --platform=k8s --domain={domain} --multiuser --helm-patch-yaml patch.yaml
+endif::[]
+ifeval::["{k8s-platform}" != "Google Cloud Platform"]
 $ {prod-cli} server:deploy --installer=helm --platform=k8s --domain={domain} --multiuser
-› Current {kubernetes} context: 'minikube'
+endif::[]
+› Current {kubernetes} context: 'current-context'
   ✔ Verify {kubernetes} API...OK
   ✔ 👀  Looking for an already existing {prod} instance
     ✔ Verify if {prod} is deployed into namespace "{prod-namespace}"...it is not


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Improve dploying Eclipse Che on GCP

![screenshot-0 0 0 0_4000-2021 06 04-11_18_27](https://user-images.githubusercontent.com/1640675/120770796-30ea7400-c527-11eb-8325-203a31139900.png)

### What issues does this PR fix or reference?
https://github.com/eclipse-che/che-server/pull/20

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [x] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
