### PR TITLE
fix: missing prereq step for an OCP3 installation

### DIFF
--- a/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
@@ -34,7 +34,7 @@ This approach is only supported for use with {ocp} and {osd} version 3.11, but a
 
 * To apply settings that the main {prod-cli} command-line parameters cannot set, prepare a configuration file `operator-cr-patch.yaml` that will override the default values in the `CheCluster` Custom Resource used by the Operator. See xref:configuring-the-che-installation.adoc[].
 
-* The {prod-namespace} namespace represents the default installation project.
+* Use the {prod-namespace} namespace as the default installation project.
 
 * Configure OpenShift to pull images from `registry.redhat.com`. See link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].
 

--- a/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
@@ -36,7 +36,7 @@ This approach is only supported for use with {ocp} and {osd} version 3.11, but a
 
 * __<namespace>__ represents the project of the target installation.
 
-* Configure OpenShift to pull images from `registry.redhat.com`. See link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication]
+* Configure OpenShift to pull images from `registry.redhat.com`. See link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].
 
 .Procedure
 

--- a/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
@@ -55,22 +55,14 @@ $ oc version
 oc v3.11.0+0cbc58b
 ----
 
-. Run the following command to create the {prod-short} instance
-+
-** In the {prod-namespace} {orch-namespace}:
-+
-[subs="+quotes,+attributes",options="nowrap"]
-----
-$ {prod-cli} server:deploy -n {prod-namespace} -p openshift
-----
+. Run the following command to create the {prod-short} instance:
 
-** In the default {orch-namespace} called {prod-namespace}:
+* In the default {orch-namespace} called {prod-namespace}:
 +
 [subs="+quotes,+attributes",options="nowrap"]
 ----
 $ {prod-cli} server:deploy -p openshift
 ----
-
 
 .Verification steps
 

--- a/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
@@ -34,7 +34,7 @@ This approach is only supported for use with {ocp} and {osd} version 3.11, but a
 
 * To apply settings that the main {prod-cli} command-line parameters cannot set, prepare a configuration file `operator-cr-patch.yaml` that will override the default values in the `CheCluster` Custom Resource used by the Operator. See xref:configuring-the-che-installation.adoc[].
 
-* __<namespace>__ represents the project of the target installation.
+* The {prod-namespace} namespace represents the default installation project.
 
 * Configure OpenShift to pull images from `registry.redhat.com`. See link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].
 

--- a/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
@@ -36,6 +36,8 @@ This approach is only supported for use with {ocp} and {osd} version 3.11, but a
 
 * __<namespace>__ represents the project of the target installation.
 
+* Configure OpenShift to pull images from `registry.redhat.com`. See link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication]
+
 .Procedure
 
 . Log in to OpenShift. See link:https://docs.openshift.com/container-platform/3.11/cli_reference/get_started_cli.html#basic-setup-and-login[Basic Setup and Login].

--- a/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-openshift-3-using-the-operator.adoc
@@ -55,9 +55,7 @@ $ oc version
 oc v3.11.0+0cbc58b
 ----
 
-. Run the following command to create the {prod-short} instance:
-
-* In the default {orch-namespace} called {prod-namespace}:
+. Run the following command to create the {prod-short} instance in the default {orch-namespace} called {prod-namespace}:
 +
 [subs="+quotes,+attributes",options="nowrap"]
 ----


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?

Adding missing prerequisite that is needed during a special event on OCP 3.11

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/20004

### Specify the version of the product this PR applies to.
7.30.x and beyond

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
