### PR TITLE
fix: Kubernetes Image Puller namespace

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -60,6 +60,7 @@ asciidoc:
     image-puller-deployment-id: kubernetes-image-puller-operator
     image-puller-name: Kubernetes Image Puller
     image-puller-name-short: Image Puller
+    image-puller-namespace: k8s-image-puller
     image-puller-repository-name: kubernetes-image-puller
     kubernetes: Kubernetes
     link-accessing-a-git-repository-via-https: xref:end-user-guide:version-control.adoc#accessing-a-git-repository-via-https_che[Accessing a Git repository using HTTPS]

--- a/modules/administration-guide/partials/proc_installing-image-puller-using-helm.adoc
+++ b/modules/administration-guide/partials/proc_installing-image-puller-using-helm.adoc
@@ -32,7 +32,7 @@ $ cd {image-puller-repository-name}
 +
 [subs="+quotes,+attributes"]
 ----
-$ {orch-cli} create namespace k8s-image-puller
+$ {orch-cli} create namespace {image-puller-namespace}
 ----
 
 . To configure the installation, edit the `deploy/helm/values.yaml` file using following parameters:
@@ -62,7 +62,7 @@ $ {orch-cli} create namespace k8s-image-puller
 |The name of the ConfigMap to create 
 |`k8s-image-puller`
 
-|configMap.images
+|`configMap.images`
 |The value of IMAGES in the ConfigMap
 |none
 
@@ -76,7 +76,7 @@ $ {orch-cli} create namespace k8s-image-puller
 
 |`configMap.cachingMemoryLimit` 
 |The value of `CACHING_MEMORY_LIMIT` in the ConfigMap 
-|`"20Mi"``
+|`"20Mi"`
 
 |`configMap.cachingCpuRequest` 
 |The value of `CACHING_CPU_REQUEST` in the ConfigMap 
@@ -95,7 +95,7 @@ $ {orch-cli} create namespace k8s-image-puller
 +
 [subs="+attributes"]
 ----
-$ helm install {image-puller-deployment-name} --namespace k8s-image-puller deploy/helm
+$ helm install {image-puller-deployment-name} --namespace {image-puller-namespace} deploy/helm
 ----
 +
 [NOTE]
@@ -109,7 +109,7 @@ Use the `--set property.name=__<value>__` parameter to override the values set i
 +
 [source%nowrap,dummy,subs="+quotes,+attributes"]
 ----
-$ {orch-cli} get deployment,daemonset,pod --namespace k8s-image-puller
+$ {orch-cli} get deployment,daemonset,pod --namespace {image-puller-namespace}
 NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/{image-puller-deployment-name}   1/1     1            1           4m21s
 
@@ -136,15 +136,15 @@ data:
   DAEMONSET_NAME: {image-puller-deployment-name}
   IMAGES: java11-maven=quay.io/eclipse/che-java11-maven:nightly; che-theia=eclipse/che-theia:next;
     java-plugin-runner=eclipse/che-remote-plugin-runner-java8:latest;
-  NAMESPACE: k8s-image-puller
+  NAMESPACE: {image-puller-namespace}
   NODE_SELECTOR: '{}'
 kind: ConfigMap
 metadata:
   creationTimestamp: "2020-02-17T22:15:22Z"
   name: k8s-image-puller
-  namespace: k8s-image-puller
+  namespace: {image-puller-namespace}
   resourceVersion: "3078"
-  selfLink: /api/v1/namespaces/k8s-image-puller/configmaps/k8s-image-puller
+  selfLink: /api/v1/namespaces/{image-puller-namespace}/configmaps/k8s-image-puller
   uid: 71bc5ce4-d095-468e-ab7b-23c1e0a36638
 ----
 

--- a/modules/administration-guide/partials/proc_installing-image-puller-using-openshift-templates.adoc
+++ b/modules/administration-guide/partials/proc_installing-image-puller-using-openshift-templates.adoc
@@ -63,7 +63,7 @@ include::example$snip_{project-context}-cloning-image-puller-project.adoc[]
 
 |`CACHING_MEMORY_LIMIT` 
 |The value of `CACHING_MEMORY_LIMIT` in the ConfigMap 
-|`"20Mi"``
+|`"20Mi"`
 
 |`CACHING_MEMORY_REQUEST` 
 |The value of `CACHING_MEMORY_REQUEST` in the ConfigMap 
@@ -80,6 +80,10 @@ include::example$snip_{project-context}-cloning-image-puller-project.adoc[]
 |`IMAGES` 
 |The value of `IMAGES` in the ConfigMap  
 |`{image-puller-images}`
+
+|`NAMESPACE` 
+|The value of `NAMESPACE` in the ConfigMap  
+|`{image-puller-namespace}`
 
 |`NODE_SELECTOR` 
 |The value of `NODE_SELECTOR` in the ConfigMap 
@@ -103,7 +107,7 @@ include::example$snip_{project-context}-cloning-image-puller-project.adoc[]
 +
 [subs="+attributes,+quotes"]
 ----
-$ oc new-project __<{image-puller-deployment-name}>__
+$ oc new-project __<{image-puller-namespace}>__
 ----
 
 . Process and apply the templates to install the puller:
@@ -122,7 +126,7 @@ $ oc process -f app.yaml | oc apply -f -
 +
 [source%nowrap,dummy,subs="+quotes,+attributes"]
 ----
-$ oc get deployment,daemonset,pod --namespace __<{image-puller-deployment-name}>__
+$ oc get deployment,daemonset,pod --namespace __<{image-puller-namespace}>__
 ----
 
 . Verify the values of the __<{image-puller-deployment-name}>__ `ConfigMap`.


### PR DESCRIPTION
Related PR: https://github.com/che-incubator/kubernetes-image-puller/pull/51

Signed-off-by: David Kwon <dakwon@redhat.com>

### What does this PR do?
Changes outdated Kubernetes Image Puller namespace (from `kubernetes-image-puller` to `k8s-image-puller`).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19969

### Specify the version of the product this PR applies to.
Current version

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
