### PR TITLE
fix: Fixup of Configuring GitLab OAuth2 procedure.

### DIFF
--- a/modules/administration-guide/partials/proc_configuring-gitlab-oauth2.adoc
+++ b/modules/administration-guide/partials/proc_configuring-gitlab-oauth2.adoc
@@ -21,9 +21,12 @@ OAuth2 for GitLab allows accepting factories from private GitLab repositories.
 
 Client ID:: a value from the `Application ID` field provided by GitLab server in previous step;
 Client Secret:: a value from `Secret` field provided by GitLab server in previous step;
-Authorization URL:: a URL which have a `++https://__<GITLAB_DOMAIN>__/oauth/oauth/authorize` format;
-Token URL:: a URL which have a `++https://__<GITLAB_DOMAIN>__/oauth/oauth/token` format;
-Scopes:: set of scopes which must contain (but not limited to) the following set: `api write_repository openid`
+Authorization URL:: a URL which have a `https://__<GITLAB_DOMAIN>__/oauth/authorize` format;
+Token URL:: a URL which have a `https://__<GITLAB_DOMAIN>__/oauth/token` format;
+Scopes:: set of scopes which must contain (but not limited to) the following set: `api write_repository openid`;
+Store Tokens:: needs to be enabled;
+Store Tokens Readable:: needs to be enabled
+
 
 + 
 [NOTE]


### PR DESCRIPTION
Signed-off-by: rhopp <rhopp@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Fixes https://issues.redhat.com/browse/RHDEVDOCS-3073

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
