### PR TITLE
docs: procedure: Adding a topic about the factory workspace-creation policy

### DIFF
--- a/modules/end-user-guide/partials/assembly_creating-a-workspace-from-remote-devfile.adoc
+++ b/modules/end-user-guide/partials/assembly_creating-a-workspace-from-remote-devfile.adoc
@@ -19,6 +19,8 @@ include::partial$proc_overriding-devfile-values-using-factory-parameters.adoc[le
 
 include::partial$proc_allowing-users-to-define-workspace-deployment-labels-and-annotations.adoc[leveloffset=+1]
 
+include::partial$proc_allowing-users-to-define-workspace-creation-strategy.adoc[leveloffset=+1]
+
 .Additional resources
 
 * xref:authoring-devfiles-version-2.adoc[]

--- a/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
+++ b/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
@@ -10,9 +10,9 @@ As a developer, you can configure {prod-short} to create a new workspace each ti
 
 {prod-short} supports the following options: 
 
-* `perclick`:  Create a new workspace each time the same factory URL is accepted. The default value.
+* `perclick`:  The default strategy, which creates a new workspace each time a given factory URL is accepted.
 
-* `peruser`: `peruser` creation strategy will re-use an existing workspace for second and any other subsequent acceptance of the same factory URL.
+* `peruser`: Initially, a workspace is created using a factory URL. Other user's calls then re-use the particular workspace created by the factory URL (1 factory = 1 workspace).
 
 .Prerequisites
 

--- a/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
+++ b/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
@@ -8,7 +8,7 @@
 
 This section describes how to control the strategy of creating a {prod-short} workspace using a factory URL. {prod-short} currently supports the following options: 
 
-* `perclick`:  `perclick` is the default creation strategy, which creates a new workspace each time the same factory URL is accepted.
+* `perclick`:  Create a new workspace each time the same factory URL is accepted. The default value.
 
 * `peruser`: `peruser` creation strategy will re-use an existing workspace for second and any other subsequent acceptance of the same factory URL.
 

--- a/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
+++ b/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// creating-a-workspace-from-a-remote-devfile
+
+[id="allowing-users-to-define-workspace-creation-strategy_{context}"]
+= Allowing users to define workspace creation strategy
+
+
+This section describes how to control strategy of creation a {prod-short} workspace using a factory URL.
+Currently, two options for workspace creation strategy are supported: 
+
+* `perclick` (default) - means creation of new workspace each time same factory URL is accepted.
+
+* `peruser` - means re-use existing workspace for 2nd and any subsequent acceptance of the same factory URL.
+
+.Prerequisites
+
+* A running instance of {prod}. See xref:installation-guide:installing-che.adoc[].
+* The Git repository __<GIT_REPOSITORY_URL>__ is available over HTTPS.
+
+
+.Procedure
+
+pass:[<!-- vale CheDocs.TechnicalTerms = NO -->]
+
+* Run the workspace by opening the factory URL, with additional policy parameter specified:
++
+`pass:c,a,q[{prod-url}/f?url=__<GIT_REPOSITORY_URL>&policies.create=<value>__]`
++
+
+pass:[<!-- vale CheDocs.TechnicalTerms = YES -->]

--- a/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
+++ b/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
@@ -6,7 +6,9 @@
 = Allowing users to define workspace creation strategy
 
 
-As a developer, you can configure {prod-short} to create a new workspace each time it accepts a factory URL, or to reuse the existing workspace if a user already has one. {prod-short} currently supports the following options: 
+As a developer, you can configure {prod-short} to create a new workspace each time it accepts a factory URL, or to reuse the existing workspace if a user already has one.
+
+{prod-short} supports the following options: 
 
 * `perclick`:  Create a new workspace each time the same factory URL is accepted. The default value.
 

--- a/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
+++ b/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
@@ -24,7 +24,7 @@ As a developer, you can configure {prod-short} to create a new workspace each ti
 
 pass:[<!-- vale CheDocs.TechnicalTerms = NO -->]
 
-* Run the workspace by opening the factory URL and specify the additional policy parameter:
+* Run the workspace by opening the factory URL and specify the additional strategy parameter:
 +
 `pass:c,a,q[{prod-url}/f?url=__<GIT_REPOSITORY_URL>&policies.create=<value>__]`
 +

--- a/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
+++ b/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
@@ -6,7 +6,7 @@
 = Allowing users to define workspace creation strategy
 
 
-This section describes how to control the strategy of creating a {prod-short} workspace using a factory URL. {prod-short} currently supports the following options: 
+As a developer, you can configure {prod-short} to create a new workspace each time it accepts a factory URL, or to reuse the existing workspace if a user already has one. {prod-short} currently supports the following options: 
 
 * `perclick`:  Create a new workspace each time the same factory URL is accepted. The default value.
 

--- a/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
+++ b/modules/end-user-guide/partials/proc_allowing-users-to-define-workspace-creation-strategy.adoc
@@ -6,16 +6,15 @@
 = Allowing users to define workspace creation strategy
 
 
-This section describes how to control strategy of creation a {prod-short} workspace using a factory URL.
-Currently, two options for workspace creation strategy are supported: 
+This section describes how to control the strategy of creating a {prod-short} workspace using a factory URL. {prod-short} currently supports the following options: 
 
-* `perclick` (default) - means creation of new workspace each time same factory URL is accepted.
+* `perclick`:  `perclick` is the default creation strategy, which creates a new workspace each time the same factory URL is accepted.
 
-* `peruser` - means re-use existing workspace for 2nd and any subsequent acceptance of the same factory URL.
+* `peruser`: `peruser` creation strategy will re-use an existing workspace for second and any other subsequent acceptance of the same factory URL.
 
 .Prerequisites
 
-* A running instance of {prod}. See xref:installation-guide:installing-che.adoc[].
+* A running instance of {prod-short}. See xref:installation-guide:installing-che.adoc[].
 * The Git repository __<GIT_REPOSITORY_URL>__ is available over HTTPS.
 
 
@@ -23,7 +22,7 @@ Currently, two options for workspace creation strategy are supported:
 
 pass:[<!-- vale CheDocs.TechnicalTerms = NO -->]
 
-* Run the workspace by opening the factory URL, with additional policy parameter specified:
+* Run the workspace by opening the factory URL and specify the additional policy parameter:
 +
 `pass:c,a,q[{prod-url}/f?url=__<GIT_REPOSITORY_URL>&policies.create=<value>__]`
 +


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Adds missing documentation for creating a workspace with factory link and creating policy

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19416

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
