### PR TITLE
fix: fixing an inaccurate figure description

### DIFF
--- a/modules/administration-guide/partials/con_che-workspaces-architecture.adoc
+++ b/modules/administration-guide/partials/con_che-workspaces-architecture.adoc
@@ -19,7 +19,7 @@ The following diagram shows the detailed components of a {prod-short} workspace.
 .{prod-short} workspace components
 image::architecture/{project-context}-workspaces.png[]
 
-In the diagram, there are three running workspaces: two belonging to *User A* and one to *User C*. A fourth workspace is getting provisioned where the plug-in broker is verifying and completing the workspace configuration.
+In the diagram, there are four running workspaces: two belonging to *User A*, one to *User B* and one to *User C*.
 
 Use the devfile format to specify the tools and runtime applications of a {prod-short} workspace.
 


### PR DESCRIPTION
Signed-off-by: xbaran4 <pbaran@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Changes the description of **Figure 1. Che workspace components** (in Che workspaces architecture) to accurately describe the diagram.
As users A,B,C have their running workspaces and there is no new workspace being provisioned.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19265

### Specify the version of the product this PR applies to.
latest

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
