### PR TITLE
fix: Use double quotes for bumped versions during release

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -64,11 +64,11 @@ updateYaml() {
     echo "[WARN] Existing prod-ver ${OLDVERSION} is greater or equal than planned update to ${NEWVERSION}. Version should not go backwards, so nothing to do!"
     return 1
   else 
-    replaceFieldSed $playbookfile 'prod-ver' "${BASE1}.${BASE2}"
-    replaceFieldSed $playbookfile 'prod-ver-patch' $NEWVERSION
+    replaceFieldSed $playbookfile 'prod-ver' "\"${BASE1}.${BASE2}\""
+    replaceFieldSed $playbookfile 'prod-ver-patch' "\"$NEWVERSION\""
     # set prod-prev-ver = 7.y-1
     (( BASE2=BASE2-1 ))
-    replaceFieldSed $playbookfile 'prod-prev-ver' "${BASE1}.${BASE2}"
+    replaceFieldSed $playbookfile 'prod-prev-ver' "\"${BASE1}.${BASE2}\""
   fi
 }
 


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Add double quotes to all values that are bumped during release

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
