### PR TITLE
procedure: removing an unnecesary procedure step for the Image Puller

### DIFF
--- a/modules/administration-guide/examples/snip_che-images-incompatibles-with-image-puller.adoc
+++ b/modules/administration-guide/examples/snip_che-images-incompatibles-with-image-puller.adoc
@@ -1,5 +1,0 @@
-.Images incompatibles with {image-puller-name-short}, missing the `sleep` command
-====
-* `FROM scratch` images.
-* `che-machine-exec`
-====

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -14,11 +14,6 @@
 include::example$snip_{project-context}-getting-the-list-of-relevant-images.adoc[]
 
 
-. Exclude from the list the container images not containing the `sleep` command.
-+
-include::example$snip_{project-context}-images-incompatibles-with-image-puller.adoc[]
-
-
 . Exclude from the list the container images mounting volumes in Dockerfile.
 
 


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?

Removing unnecessary step for Che ImagePuller section
This PR is for Che starting at 7.30.x, but applies for **CRW 2.9 (NOT 2.8)**

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20021
In Che, the che-machine-exec image ALSO contains a sleep binary now (as of 7.30.x) thus we can remove the warning entirely from the upstream docs.

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
