### PR TITLE
feat(docs): better describe custom plugin scenarios

### DIFF
--- a/modules/contributor-guide/partials/proc_overriding-ram-of-a-che-theia-plug-in.adoc
+++ b/modules/contributor-guide/partials/proc_overriding-ram-of-a-che-theia-plug-in.adoc
@@ -24,7 +24,7 @@ For the YAML language server plug-in, sets the RAM limit to 768 mebibytes (10737
 [source,yaml]
 ----
 components:
-  - id: redhat/vscode-yaml
+  - id: redhat/vscode-yaml/latest
     type: chePlugin
     memoryLimit: 768mi
     memoryRequest: 500M
@@ -39,7 +39,7 @@ For the YAML language server plug-in, sets the CPU limit to 1.5 cores and CPU re
 [source,yaml]
 ----
 components:
-  - id: redhat/vscode-yaml
+  - id: redhat/vscode-yaml/latest
     type: chePlugin
     cpuLimit: 1.5
     cpuRequest: 500m

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -2,6 +2,8 @@ pass:[<!-- vale IBM.Slash = NO -->]
 
 pass:[<!-- vale IBM.Terms = NO -->]
 
+pass:[<!-- vale Vale.Avoid = NO -->]
+
 // Module included in the following assemblies:
 //
 // configuring-a-workspace-using-a-devfile
@@ -1133,3 +1135,6 @@ attributes:
 pass:[<!-- vale IBM.Slash = YES -->]
 
 pass:[<!-- vale IBM.Terms = YES -->]
+
+pass:[<!-- vale Vale.Avoid = YES -->]
+

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -186,7 +186,7 @@ Describes plug-ins in a workspace by defining their `id`. A devfile is allowed t
 
 Both types above use an ID, which is slash-separated publisher, name and version of plug-in from the {prod-short} Plug-in registry. Note that the {prod-short} Plug-in registry uses the `latest` version by default for all plug-ins.
 
-In order to refer to a custom plug-in by ID, please build and deploy a custom plug-in registry. See xref:administration-guide:building-custom-registry-images.adoc[].
+To reference a custom plug-in by ID, build and deploy a custom plug-in registry. See xref:administration-guide:building-custom-registry-images.adoc[].
 
 === Specifying an alternative component registry
 
@@ -214,7 +214,7 @@ Rather than using the editor or plug-in `id` to specify `cheEditor` or `chePlugi
      reference: https://raw.githubusercontent.com.../plugin/1.0.1/meta.yaml
 ----
 
-The URL in the `reference` field must be publicly accessible and should directly point to a fetchable `meta.yaml` file. URLs that redirect or do not directly point to a `meta.yaml` file will cause the workspace startup to fail. To learn more about publishing `meta.yaml` files, please see xref:publishing-metadata-for-a-vs-code-extension.adoc[].
+The URL in the `reference` field must be publicly accessible and should directly point to a fetchable `meta.yaml` file. URLs that redirect or do not directly point to a `meta.yaml` file will cause the workspace startup to fail. To learn more about publishing `meta.yaml` files, see xref:publishing-metadata-for-a-vs-code-extension.adoc[].
 
 NOTE: It is impossible to mix the `id` and `reference` fields in a single component definition; they are mutually exclusive.
 

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -172,19 +172,19 @@ To specify that a workspace requires no editor, use the xref:attribute-editorfre
 
 === Component type: chePlugin
 
-Describes plug-ins in a workspace by defining their `id`. It is allowed to have several `chePlugin` components.
+Describes plug-ins in a workspace by defining their `id`. A devfile is allowed to have multiple `chePlugin` components.
 
 [source,yaml]
 ----
   components:
    - alias: exec-plugin
      type: chePlugin
-     id: eclipse/che-machine-exec-plugin/0.0.1
+     id: eclipse/che-machine-exec-plugin/latest
 ----
 
-Both types above use an ID, which is slash-separated publisher, name and version of plug-in from the {prod-short} Plug-in registry.
+Both types above use an ID, which is slash-separated publisher, name and version of plug-in from the {prod-short} Plug-in registry. Note that the {prod-short} Plug-in registry uses the `latest` version by default for all plug-ins.
 
-List of available {prod-upstream} plug-ins and more information about registry can be found in the link:https://github.com/eclipse-che/che-plugin-registry[{prod-upstream} plug-in registry] GitHub repository.
+In order to refer to a custom plug-in by ID, please build and deploy a custom plug-in registry. See xref:administration-guide:building-custom-registry-images.adoc[].
 
 === Specifying an alternative component registry
 
@@ -196,7 +196,7 @@ To specify an alternative registry for the `cheEditor` and `chePlugin` component
    - alias: exec-plugin
      type: chePlugin
      registryUrl: https://my-customregistry.com
-     id: eclipse/che-machine-exec-plugin/0.0.1
+     id: eclipse/che-machine-exec-plugin/latest
 ----
 
 === Specifying a component by linking to its descriptor
@@ -212,6 +212,8 @@ Rather than using the editor or plug-in `id` to specify `cheEditor` or `chePlugi
      reference: https://raw.githubusercontent.com.../plugin/1.0.1/meta.yaml
 ----
 
+The URL in the `reference` field must be publicly accessible and should directly point to a fetchable `meta.yaml` file. URLs that redirect or do not directly point to a `meta.yaml` file will cause the workspace startup to fail. To learn more about publishing `meta.yaml` files, please see xref:publishing-metadata-for-a-vs-code-extension.adoc[].
+
 NOTE: It is impossible to mix the `id` and `reference` fields in a single component definition; they are mutually exclusive.
 
 === Tuning chePlugin component configuration
@@ -220,7 +222,7 @@ A chePlugin component may need to be precisely tuned, and in such case, componen
 
 [source,yaml]
 ----
-  id: redhat/java/0.38.0
+  id: redhat/java/latest
   type: chePlugin
   preferences:
      java.jdt.ls.vmargs: '-noverify -Xmx1G -XX:+UseG1GC -XX:+UseStringDeduplication'
@@ -230,7 +232,7 @@ Preferences may also be specified as an array:
 
 [source,yaml]
 ----
-  id: redhat/java/0.38.0
+  id: redhat/java/latest
   type: chePlugin
   preferences:
      go.lintFlags: ["--enable-all", "--new"]
@@ -486,7 +488,7 @@ To specify a container(s) memory limit for `dockerimage`, `chePlugin` or `cheEdi
   components:
    - alias: exec-plugin
      type: chePlugin
-     id: eclipse/che-machine-exec-plugin/0.0.1
+     id: eclipse/che-machine-exec-plugin/latest
      memoryLimit: 1Gi
    - alias: maven
      type: dockerimage
@@ -510,7 +512,7 @@ To specify a container(s) memory request for `dockerimage`, `chePlugin` or `cheE
   components:
    - alias: exec-plugin
      type: chePlugin
-     id: eclipse/che-machine-exec-plugin/0.0.1
+     id: eclipse/che-machine-exec-plugin/latest
      memoryLimit: 1Gi
      memoryRequest: 512M
    - alias: maven
@@ -536,7 +538,7 @@ To specify a container(s) CPU limit for `chePlugin`, `cheEditor` or `dockerimage
   components:
    - alias: exec-plugin
      type: chePlugin
-     id: eclipse/che-machine-exec-plugin/0.0.1
+     id: eclipse/che-machine-exec-plugin/latest
      cpuLimit: 1.5
    - alias: maven
      type: dockerimage
@@ -560,7 +562,7 @@ To specify a container(s) CPU request for `chePlugin`, `cheEditor` or `dockerima
   components:
    - alias: exec-plugin
      type: chePlugin
-     id: eclipse/che-machine-exec-plugin/0.0.1
+     id: eclipse/che-machine-exec-plugin/latest
      cpuLimit: 1.5
      cpuRequest: 0.225
    - alias: maven


### PR DESCRIPTION
Signed-off-by: Eric Williams <ericwill@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Do a better job explaining how custom plugins relate to authoring devfiles. Also removed versioning from plugin `id` fields and replaced them with `latest`.

### What issues does this PR fix or reference?
Fixes RHDEVDOCS-2853

### Specify the version of the product this PR applies to.
All Che 7.x and CRW 2.x

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [x] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
