### PR TITLE
fix: Add a step for explicit configuration of GitLab OAuth2 endpoints;

### DIFF
--- a/modules/administration-guide/partials/proc_configuring-gitlab-oauth2.adoc
+++ b/modules/administration-guide/partials/proc_configuring-gitlab-oauth2.adoc
@@ -15,7 +15,7 @@ OAuth2 for GitLab allows accepting factories from private GitLab repositories.
 .Procedure
 
 * Create a link:https://docs.gitlab.com/ee/integration/oauth_provider.html#authorized-applications[Authorized OAuth2 application in GitLab] using {prod-short} as the application `Name` and {identity-provider} GitLab endpoint URL as the value for `Redirect URI`. The callback URL default value is `++https://++keycloak-{prod-namespace}.__<DOMAIN>__/auth/realms/{prod-deployment}/broker/gitlab/endpoint`, where `__<DOMAIN>__` is {orch-name} cluster domain. Store the `Application ID` and `Secret` values. 
-  All three types of GitLab OAuth2 applications are supported: User owned, Group owned and Instance-wide.
+  All three types of GitLab OAuth 2 applications are supported: User owned, Group owned and Instance-wide.
 
 . Create a custom OIDC provider link on {identity-provider} pointing to GitLab server. Fill the following fields:
 
@@ -27,13 +27,20 @@ Scopes:: set of scopes which must contain (but not limited to) the following set
 Store Tokens:: needs to be enabled;
 Store Tokens Readable:: needs to be enabled
 
-
 + 
 [NOTE]
 ====
 * Substitute `_<GITLAB_DOMAIN>_` with the URL and port of the GitLab installation.
 ==== 
 
+
+* Register URL of the GitLab instance with enabled OAuth 2 in {prod-short}, using the `+CHE_INTEGRATION_GITLAB_OAUTH__ENDPOINT+` property.
+
++
+[NOTE]
+====
+* This address *must* be present in the list of configured GitLab integration endpoints (set by the `+CHE_INTEGRATION_GITLAB_SERVER__ENDPOINTS+` property).
+====
 
 .Additional resources 
 In case of having issues {prod-short} accessing GitLab related to TLS keys, consult with the following docs:

--- a/modules/administration-guide/partials/proc_configuring-gitlab-oauth2.adoc
+++ b/modules/administration-guide/partials/proc_configuring-gitlab-oauth2.adoc
@@ -18,7 +18,8 @@ OAuth2 for GitLab allows accepting factories from private GitLab repositories.
   All three types of GitLab OAuth 2 applications are supported: User owned, Group owned and Instance-wide.
 
 . Create a custom OIDC provider link on {identity-provider} pointing to GitLab server. Fill the following fields:
-
++
+====
 Client ID:: a value from the `Application ID` field provided by GitLab server in previous step;
 Client Secret:: a value from `Secret` field provided by GitLab server in previous step;
 Authorization URL:: a URL which have a `https://__<GITLAB_DOMAIN>__/oauth/authorize` format;
@@ -26,20 +27,18 @@ Token URL:: a URL which have a `https://__<GITLAB_DOMAIN>__/oauth/token` format;
 Scopes:: set of scopes which must contain (but not limited to) the following set: `api write_repository openid`;
 Store Tokens:: needs to be enabled;
 Store Tokens Readable:: needs to be enabled
-
+====
 + 
 [NOTE]
 ====
 * Substitute `_<GITLAB_DOMAIN>_` with the URL and port of the GitLab installation.
 ==== 
 
-
-* Register URL of the GitLab instance with enabled OAuth 2 in {prod-short}, using the `+CHE_INTEGRATION_GITLAB_OAUTH__ENDPOINT+` property.
-
+. Register the GitLab instance URL with the enabled OAuth 2 support in {prod-short} using the `+CHE_INTEGRATION_GITLAB_OAUTH__ENDPOINT+` property.
 +
-[NOTE]
+[WARNING]
 ====
-* This address *must* be present in the list of configured GitLab integration endpoints (set by the `+CHE_INTEGRATION_GITLAB_SERVER__ENDPOINTS+` property).
+* The GitLab instance URL must be present in the list of configured GitLab integration endpoints, set by the `+CHE_INTEGRATION_GITLAB_SERVER__ENDPOINTS+` property.
 ====
 
 .Additional resources 


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Adds a step for explicit configuration of GitLab OAuth2 endpoints which is added as required on Che server side.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19991  Complements PR https://github.com/eclipse-che/che-server/pull/38

### Specify the version of the product this PR applies to.
7.33.0

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
