### PR TITLE
fix: typo

### DIFF
--- a/modules/end-user-guide/partials/proc_configuring_gitlab_authentication.adoc
+++ b/modules/end-user-guide/partials/proc_configuring_gitlab_authentication.adoc
@@ -13,7 +13,7 @@ See the link:https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html
 
 To allow GitLab authentication on {prod-short} side, personal tokens must be stored in the user's {orch-namespace} in the form of
 a secret. The secret must look as follows:
-+
+
 .GitLab personal access token secret
 ====
 include::example$snip_gitlab-personal-access-token-secret.adoc[]


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
removing a redundant `+` symbol

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
