### PR TITLE
feat: Add Github PAT-based auth configuration example

### DIFF
--- a/modules/end-user-guide/examples/snip_github-personal-access-token-secret.adoc
+++ b/modules/end-user-guide/examples/snip_github-personal-access-token-secret.adoc
@@ -1,0 +1,18 @@
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-personal-access-token-secret
+  labels:
+    app.kubernetes.io/part-of: che.eclipse.org
+    app.kubernetes.io/component: scm-personal-access-token
+  annotations:
+    che.eclipse.org/expired-after: '-1'
+    che.eclipse.org/che-userid: '355d1ce5-990e-401e-9a8c-094bca10b5b3'
+    che.eclipse.org/scm-userid: '1651062'
+    che.eclipse.org/scm-username: 'user-foo'
+    che.eclipse.org/scm-url: 'https://github.com'
+data:
+  token: Yzh5cEt6cURxUWVCa3FKazhtaHg=
+----

--- a/modules/end-user-guide/partials/assembly_authenticating-on-scm-server-with-a-personal-access-token.adoc
+++ b/modules/end-user-guide/partials/assembly_authenticating-on-scm-server-with-a-personal-access-token.adoc
@@ -12,11 +12,15 @@ The following section describes how to configure user authentications for SCM se
 
 * xref:configuring_bitbucket_authentication_{context}[]
 
+* xref:configuring_github_authentication_{context}[]
+
 
 
 include::partial$proc_configuring_bitbucket_authentication.adoc[leveloffset=+1]
 
 include::partial$proc_configuring_gitlab_authentication.adoc[leveloffset=+1]
+
+include::partial$proc_configuring_github_authentication.adoc[leveloffset=+1]
 
 
 :context: {parent-context-of-authenticating-on-scm-server-with-a-personal-access-token}

--- a/modules/end-user-guide/partials/assembly_authenticating-on-scm-server-with-a-personal-access-token.adoc
+++ b/modules/end-user-guide/partials/assembly_authenticating-on-scm-server-with-a-personal-access-token.adoc
@@ -8,9 +8,9 @@
 
 The following section describes how to configure user authentications for SCM servers.
 
-* xref:configuring_gitlab_authentication_{context}[]
-
 * xref:configuring_bitbucket_authentication_{context}[]
+
+* xref:configuring_gitlab_authentication_{context}[]
 
 * xref:configuring_github_authentication_{context}[]
 

--- a/modules/end-user-guide/partials/proc_configuring_github_authentication.adoc
+++ b/modules/end-user-guide/partials/proc_configuring_github_authentication.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// authenticating-on-scm-server-with-a-personal-access-token
+
+[id="configuring_github_authentication_{context}"]
+= Authenticating on GitHub servers
+
+Configuring authentication on the GitHub system is similar to GitLab.
+
+GitHub authentication can be based on using personal access tokens. Each GitHub user is able to request several personal access tokens with different names, permissions, expiration times, and so on. Those tokens can be used to sign GitHub REST API calls and perform Git repository operations.
+
+To allow GitHub authentication on {prod-short} side, personal tokens must be stored in the user's {orch-namespace} in the form of
+a secret. The secret must look as follows:
+
+.GitHub personal access token secret
+====
+include::example$snip_github-personal-access-token-secret.adoc[]
+====
+
+The main parts of the secret are:
+
+[cols=3*]
+|===
+| Label
+| `app.kubernetes.io/component`
+| Indicates it is a SCM personal token secret. 
+
+| Annotation
+| `che.eclipse.org/che-userid`
+| {prod} id of the user token belongs to
+
+| Annotation
+| `che.eclipse.org/scm-userid`
+| GitHub user id to which token belongs
+
+| Annotation
+| `che.eclipse.org/scm-username`
+| GitHub user name to which token belongs
+
+| Annotation
+| `che.eclipse.org/scm-url`
+| GitHub server URL to which this token belong. Typically, it is `https://github.com`
+
+| Annotation
+| `che.eclipse.org/expired-after`
+| Personal access token expiration time
+
+| Data entry
+| `token`
+| Base-64 encoded value of the personal access token
+
+|===
+
+NOTE: Encoding a string into the base64 format using the `base64` tool on Linux machines leads to adding the newline character to the end of the source string and causing a value to be unusable as the authentication header value after decoding. Avoid this by using `base64 -w0`, which removes newly added lines, or strip newlines explicitly using`tr -d \\n`.
+
+. To obtain a user ID from a secret,  make a call to a REST API URL:
++
+[subs="+quotes,macros"]
+----
+++https++://api.github.com/user
+----
+
+* For {prod-short}
++
+[subs="+macros,attributes"]
+----
+{prod-url}/api/user
+----
+
+* With the token credentials obtained from a secret, another secret is automatically created, allowing authorization to Git operations. This secret is mounted into a workspace container as a Git credentials file, and any additional configurations are not required to work with private Git repositories.
+
+* When a remote Git repository uses a self-signed certificate, add an additional server configuration. See:
+xref:installation-guide:deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc[].

--- a/modules/end-user-guide/partials/proc_configuring_github_authentication.adoc
+++ b/modules/end-user-guide/partials/proc_configuring_github_authentication.adoc
@@ -23,7 +23,7 @@ The main parts of the secret are:
 |===
 | Label
 | `app.kubernetes.io/component`
-| Indicates it is a SCM personal token secret. 
+| Indicates it is an SCM personal token secret. 
 
 | Annotation
 | `che.eclipse.org/che-userid`
@@ -35,11 +35,11 @@ The main parts of the secret are:
 
 | Annotation
 | `che.eclipse.org/scm-username`
-| GitHub user name to which token belongs
+| GitHub username to which token belongs
 
 | Annotation
 | `che.eclipse.org/scm-url`
-| GitHub server URL to which this token belong. Typically, it is `https://github.com`
+| GitHub server URL to which this token belongs. Typically, it is `https://github.com`
 
 | Annotation
 | `che.eclipse.org/expired-after`


### PR DESCRIPTION
### What does this PR do?
Adds example about Github PAT-based auth configuration

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20031

### Specify the version of the product this PR applies to.
7.33

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
