### PR TITLE
fix: language fix

### DIFF
--- a/modules/contributor-guide/partials/con_che-extension-points.adoc
+++ b/modules/contributor-guide/partials/con_che-extension-points.adoc
@@ -335,7 +335,7 @@ webViewPanel.webview.html ='<html><body><h1>Hello from web view</h1></body></htm
 
 [NOTE]
 ====
-Web view content is destroyed when hidden. To restore its state, register a serializer, or set the `retainContextWhenHidden` option for the web view. Even with this option set, hiding a web view pauses all scripts, and the web view will not process messages from the plug-in.
+Web view content is removed when hidden. To restore its state, register a serializer, or set the `retainContextWhenHidden` option for the web view. Even with this option set, hiding a web view pauses all scripts, and the web view will not process messages from the plug-in.
 
 The current state of a web view can be read from the web view panel object.
 


### PR DESCRIPTION
…on_che-extension-points.adoc

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Replaces a single instance of `destroy` with `remove`.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-1725

### Specify the version of the product this PR applies to.
Che 7.30.x

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
