### PR TITLE
feat: update doc accordingly to che-operator changes

### DIFF
--- a/modules/installation-guide/partials/proc_switching-between-external-and-internal-communication.adoc
+++ b/modules/installation-guide/partials/proc_switching-between-external-and-internal-communication.adoc
@@ -38,7 +38,7 @@ endif::[]
 [subs="+quotes,+attributes"]
 ----
 $ {orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} --type=json -p \
-'[{"op": "replace", "path": "/spec/server/useInternalClusterSVCNames", "value": false}]'
+'[{"op": "replace", "path": "/spec/server/disableInternalClusterSVCNames", "value": true}]'
 ----
 
 . To use internal {orch-name} DNS names in the inter-component communication:
@@ -46,7 +46,7 @@ $ {orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} --type=json 
 [subs="+quotes,+attributes"]
 ----
 $ {orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} --type=json -p \
-'[{"op": "replace", "path": "/spec/server/useInternalClusterSVCNames", "value": true}]'
+'[{"op": "replace", "path": "/spec/server/disableInternalClusterSVCNames", "value": false}]'
 ----
 
 ifeval::["{project-context}" == "che"]


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Update doc due to https://github.com/eclipse-che/che-operator/pull/919

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19726

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [x] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [x] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
