### PR TITLE
fix: pvcClaimSize-update

### DIFF
--- a/modules/installation-guide/examples/checluster-properties.adoc
+++ b/modules/installation-guide/examples/checluster-properties.adoc
@@ -123,7 +123,7 @@ updateAdminPassword: Forces the default `admin` Che user to update password on f
  Property: Description 
 postgresPVCStorageClassName: Storage class for the Persistent Volume Claim dedicated to the PostgreSQL database. When omitted or left blank, a default storage class is used.
 preCreateSubPaths: Instructs the Che server to start a special Pod to pre-create a sub-path in the Persistent Volumes. Defaults to `false`, however it will need to enable it according to the configuration of your Kubernetes cluster.
-pvcClaimSize: Size of the persistent volume claim for workspaces. Defaults to `1Gi`.
+pvcClaimSize: Size of the persistent volume claim for workspaces. Defaults to `10Gi`.
 pvcJobsImage: Overrides the container image used to create sub-paths in the Persistent Volumes. This includes the image tag. Omit it or leave it empty to use the default container image provided by the Operator. See also the `preCreateSubPaths` field.
 pvcStrategy: Persistent volume claim strategy for the Che server. This Can be\:`common` (all workspaces PVCs in one volume), `per-workspace` (one PVC per workspace for all declared volumes) and `unique` (one PVC per declared volume). Defaults to `common`.
 workspacePVCStorageClassName: Storage class for the Persistent Volume Claims dedicated to the Che workspaces. When omitted or left blank, a default storage class is used.


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Updating default value of pvcClaimSize field according to @rhopp 's notification

### What issues does this PR fix or reference?
Changing default value for pvcClaimSize from 1GB to 10GB.

### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
