### PR TITLE
fix: update image puller docs and csv link

### DIFF
--- a/modules/administration-guide/examples/snip_che-getting-the-list-of-relevant-images.adoc
+++ b/modules/administration-guide/examples/snip_che-getting-the-list-of-relevant-images.adoc
@@ -2,8 +2,9 @@
 ====
 [subs="+attributes,+quotes,+macros"]
 ----
-$ curl -sSLo- https://raw.githubusercontent.com/eclipse/che-operator/master/olm/eclipse-che-preview-kubernetes/deploy/olm-catalog/eclipse-che-preview-kubernetes/{prod-ver-patch}/eclipse-che-preview-kubernetes.v{prod-ver-patch}.clusterserviceversion.yaml | \
-  yq -r '.spec.relatedImages[]'
+$ curl -sSLo- https://raw.githubusercontent.com/eclipse-che/che-operator/{prod-ver}.x/deploy/olm-catalog/stable/eclipse-che-preview-kubernetes/manifests/che-operator.clusterserviceversion.yaml | \
+yq -r '.spec.install.spec.deployments[].spec.template.spec.containers[].env[] | select(.name | test("RELATED_IMAGE_.*"; "g")) | .value' | \
+sort -u 
 ----
 ====
 +

--- a/modules/administration-guide/examples/snip_che-list-of-images-for-faster-workspace-start.adoc
+++ b/modules/administration-guide/examples/snip_che-list-of-images-for-faster-workspace-start.adoc
@@ -1,0 +1,5 @@
+* `che-theia`
+* `che-theia-endpoint-runtime-binary`
+* `che-machine-exec`
+* `che-plugin-artifacts-broker`
+* `che-plugin-metadata-broker` 

--- a/modules/administration-guide/examples/snip_che-list-of-images-for-faster-workspace-start.adoc
+++ b/modules/administration-guide/examples/snip_che-list-of-images-for-faster-workspace-start.adoc
@@ -2,4 +2,4 @@
 * `che-theia-endpoint-runtime-binary`
 * `che-machine-exec`
 * `che-plugin-artifacts-broker`
-* `che-plugin-metadata-broker` 
+* `che-plugin-metadata-broker`

--- a/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
+++ b/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
@@ -2,9 +2,9 @@
 [id="caching-images-for-faster-workspace-start_{context}"]
 = Caching images for faster workspace start
 
-To improve the start time performance of {prod-short} workspaces, use the {image-puller-name-short}. 
-The {image-puller-name-short} is an additional {platforms-name} deployment.
-It creates a _DaemonSet_ downloading and running the relevant container images on each node. These images are already available when a {prod-short} workspace starts.
+To improve the start time performance of {prod-short} workspaces, use the {image-puller-name-short}, a {prod-short}-agnostic component that can be used to pre-pull images for {platforms-name} clusters. 
+The {image-puller-name-short} is an additional {platforms-name} deployment which creates a _DaemonSet_ that can be configured to pre-pull relevant {prod-short} workspace images on each node.
+These images would already be available when a {prod-short} workspace starts, therefore improving the workspace start time.
 
 The {image-puller-name-short} provides the following parameters for configuration.
 ifeval::["{project-context}" == "che"]

--- a/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
+++ b/modules/administration-guide/partials/con_caching-images-for-faster-workspace-start.adoc
@@ -2,9 +2,7 @@
 [id="caching-images-for-faster-workspace-start_{context}"]
 = Caching images for faster workspace start
 
-To improve the start time performance of {prod-short} workspaces, use the {image-puller-name-short}, a {prod-short}-agnostic component that can be used to pre-pull images for {platforms-name} clusters. 
-The {image-puller-name-short} is an additional {platforms-name} deployment which creates a _DaemonSet_ that can be configured to pre-pull relevant {prod-short} workspace images on each node.
-These images would already be available when a {prod-short} workspace starts, therefore improving the workspace start time.
+To improve the start time performance of {prod-short} workspaces, use the {image-puller-name-short}, a {prod-short}-agnostic component that can be used to pre-pull images for {platforms-name} clusters. The {image-puller-name-short} is an additional {platforms-name} deployment which creates a _DaemonSet_ that can be configured to pre-pull relevant {prod-short} workspace images on each node. These images would already be available when a {prod-short} workspace starts, therefore improving the workspace start time.
 
 The {image-puller-name-short} provides the following parameters for configuration.
 ifeval::["{project-context}" == "che"]

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -1,7 +1,7 @@
 [id="defining-the-list-of-images-to-pull_{context}"]
 = Defining the list of images to pull
 
-The {image-puller-name-short} can pre-pull most images, including scratch images. However, due to limited support, it is not recommended to pre-pull the container images that mount volumes in their Dockerfile.
+The {image-puller-name-short} can pre-pull most images, including scratch images (ex. che-machine-exec). However, images that mount volumes in the Dockerfile are not supported for pre-pulling on OpenShift.
 
 .Prerequisites
 
@@ -18,9 +18,10 @@ include::example$snip_{project-context}-getting-the-list-of-relevant-images.adoc
 
 . Determine images from the list for pre-pulling. 
 +
-For faster workspace startup times, considered pre-pulling the workspace-related images:
+For faster workspace startup times, consider pre-pulling the workspace-related images:
 +
 * che-theia
+* che-theia-endpoint-runtime-binary
 * che-machine-exec
 * che-plugin-artifacts-broker
 * che-plugin-metadata-broker 

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -1,7 +1,7 @@
 [id="defining-the-list-of-images-to-pull_{context}"]
 = Defining the list of images to pull
 
-The {image-puller-name-short} can pre-pull most images, including scratch images, which are the images with the included sleep command. However, due to limited support, it is not recommended to pre-pull the container images that mount volumes in their Dockerfile.
+The {image-puller-name-short} can pre-pull most images, including scratch images. However, due to limited support, it is not recommended to pre-pull the container images that mount volumes in their Dockerfile.
 
 .Prerequisites
 

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -1,9 +1,9 @@
 [id="defining-the-list-of-images-to-pull_{context}"]
 = Defining the list of images to pull
 
-The {image-puller-name-short} can pre-pull most images, including scratch images such as `che-machine-exec`. However, images that mount volumes in the Dockerfile, such as `traefik`, are not supported for pre-pulling on OpenShift and are not a good use case for speeding up the workspace start.
+The {image-puller-name-short} can pre-pull most images, including scratch images such as `che-machine-exec`. However, images that mount volumes in the Dockerfile, such as `traefik`, are not supported for pre-pulling on OpenShift.
 
-Pre-pulling images, which are involved during workspace startup, leads to speeding up the workspace start times. For example:
+Pre-pulling images involved in workspace startup will reduce workspace start times. For example:
 
 * Che-Theia
 * brokers

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -3,6 +3,12 @@
 
 The {image-puller-name-short} can pre-pull most images, including scratch images such as `che-machine-exec`. However, images that mount volumes in the Dockerfile, such as `traefik`, are not supported for pre-pulling on OpenShift and are not a good use case for speeding up the workspace start.
 
+Pre-pulling images, which are involved during workspace startup, leads to speeding up the workspace start times. For example:
+
+* Che-Theia
+* brokers
+* sidecars
+
 .Prerequisites
 
 * The `curl` tool is available. See link:https://curl.se/[curl homepage].

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -1,7 +1,7 @@
 [id="defining-the-list-of-images-to-pull_{context}"]
 = Defining the list of images to pull
 
-The {image-puller-name-short} can pre-pull most images, including scratch images (ex. che-machine-exec). However, images that mount volumes in the Dockerfile are not supported for pre-pulling on OpenShift.
+The {image-puller-name-short} can pre-pull most images, including scratch images such as `che-machine-exec`. However, images that mount volumes in the Dockerfile, such as `traefik`, are not supported for pre-pulling on OpenShift and are not a good use case for speeding up the workspace start.
 
 .Prerequisites
 

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -1,8 +1,7 @@
 [id="defining-the-list-of-images-to-pull_{context}"]
 = Defining the list of images to pull
 
-The {image-puller-name-short} is able to pre-pull most images, including scratch images. 
-However, container images that mount volumes in their Dockerfile should not be pre-pulled due to limited support.
+The {image-puller-name-short} can pre-pull most images, including scratch images, which are the images with the included sleep command. However, due to limited support, it is not recommended to pre-pull the container images that mount volumes in their Dockerfile.
 
 .Prerequisites
 

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -26,11 +26,7 @@ include::example$snip_{project-context}-getting-the-list-of-relevant-images.adoc
 +
 For faster workspace startup times, consider pre-pulling the workspace-related images:
 +
-* che-theia
-* che-theia-endpoint-runtime-binary
-* che-machine-exec
-* che-plugin-artifacts-broker
-* che-plugin-metadata-broker 
+include::example$snip_{project-context}-list-of-images-for-faster-workspace-start.adoc[]
 
 .Additional resources
 

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -7,7 +7,7 @@ Pre-pulling images involved in workspace startup will reduce workspace start tim
 
 * Che-Theia
 * broker images
-* plugin sidecar images
+* plug-in sidecar images
 
 .Prerequisites
 

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -1,6 +1,9 @@
 [id="defining-the-list-of-images-to-pull_{context}"]
 = Defining the list of images to pull
 
+The {image-puller-name-short} is able to pre-pull most images, including scratch images. 
+However, container images that mount volumes in their Dockerfile should not be pre-pulled due to limited support.
+
 .Prerequisites
 
 * The `curl` tool is available. See link:https://curl.se/[curl homepage].
@@ -9,14 +12,13 @@
 
 .Procedure
 
-. Get the list of relevant container images.
+. Gather a list of relevant container images depending on the platform.
 +
 include::example$snip_{project-context}-getting-the-list-of-relevant-images.adoc[]
 
 
-. Exclude from the list the container images mounting volumes in Dockerfile.
-
-
+. Determine images from the list for pre-pulling. For faster workspace startup times, workspace-related images such as
+che-theia, che-machine-exec, che-plugin-artifacts-broker, and che-plugin-metadata-broker should be considered for pre-pulling.
 
 .Additional resources
 

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -1,7 +1,7 @@
 [id="defining-the-list-of-images-to-pull_{context}"]
 = Defining the list of images to pull
 
-The {image-puller-name-short} can pre-pull most images, including scratch images, which are the images with the included sleep command. However, due to limited support, it is not recommended to pre-pull the container images that mount volumes in their Dockerfile.
+The {image-puller-name-short} can pre-pull most images, including scratch images. However, due to limited support, it is not recommended to pre-pull the container images that mount volumes in their Dockerfile.
 
 .Prerequisites
 
@@ -11,13 +11,19 @@ The {image-puller-name-short} can pre-pull most images, including scratch images
 
 .Procedure
 
-. Gather a list of relevant container images depending on the platform.
+. Gather a list of relevant container images for the {platforms-name} platform:
 +
 include::example$snip_{project-context}-getting-the-list-of-relevant-images.adoc[]
 
 
-. Determine images from the list for pre-pulling. For faster workspace startup times, workspace-related images such as
-che-theia, che-machine-exec, che-plugin-artifacts-broker, and che-plugin-metadata-broker should be considered for pre-pulling.
+. Determine images from the list for pre-pulling. 
++
+For faster workspace startup times, considered pre-pulling the workspace-related images:
++
+* che-theia
+* che-machine-exec
+* che-plugin-artifacts-broker
+* che-plugin-metadata-broker 
 
 .Additional resources
 

--- a/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/partials/proc_defining-the-list-of-images-to-pull.adoc
@@ -1,13 +1,13 @@
 [id="defining-the-list-of-images-to-pull_{context}"]
 = Defining the list of images to pull
 
-The {image-puller-name-short} can pre-pull most images, including scratch images such as `che-machine-exec`. However, images that mount volumes in the Dockerfile, such as `traefik`, are not supported for pre-pulling on OpenShift.
+The {image-puller-name-short} can pre-pull most images, including scratch images such as `che-machine-exec`. However, images that mount volumes in the Dockerfile, such as `traefik`, are not supported for pre-pulling on OpenShift 3.11.
 
 Pre-pulling images involved in workspace startup will reduce workspace start times. For example:
 
 * Che-Theia
-* brokers
-* sidecars
+* broker images
+* plugin sidecar images
 
 .Prerequisites
 


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
This PR updates the image puller docs by adding details to the "Caching images for faster workspace start
" and "Defining the list of images" pages:
https://www.eclipse.org/che/docs/che-7/administration-guide/caching-images-for-faster-workspace-start/
https://www.eclipse.org/che/docs/che-7/administration-guide/defining-the-list-of-images-to-pull/

In the "Procedure" section of the "Defining the list of images" page, the link to the CSV file was also updated (previous link resulted in a 404 error).

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
