### PR TITLE
Fix vale warnings in End-user Guide

### DIFF
--- a/modules/end-user-guide/partials/assembly_che-theia-troubleshooting.adoc
+++ b/modules/end-user-guide/partials/assembly_che-theia-troubleshooting.adoc
@@ -7,7 +7,7 @@
 
 :context: che-theia-troubleshooting
 
-This section describes some of the most frequent issues with the Che-Theia IDE.
+This section describes the most frequent issues with the Che-Theia IDE.
 
 Che-Theia shows a notification with the following message: `Plugin runtime crashed unexpectedly, all plugins are not working, please reload the page. Probably there is not enough memory for the plugins.`::
 

--- a/modules/end-user-guide/partials/assembly_using-artifact-repositories-in-a-restricted-environment.adoc
+++ b/modules/end-user-guide/partials/assembly_using-artifact-repositories-in-a-restricted-environment.adoc
@@ -7,7 +7,7 @@
 
 :context: using-artifact-repositories-in-a-restricted-environment
 
-This section describes how to manually configure various technology stacks to work with artifacts from in-house repositories using self-signed certificates.
+By configuring technology stacks, you can work with artifacts from in-house repositories using self-signed certificates.
 
 * xref:using-maven-artifact-repositories.adoc[]
 * xref:using-gradle-artifact-repositories.adoc[]

--- a/modules/end-user-guide/partials/assembly_using-gradle-artifact-repositories.adoc
+++ b/modules/end-user-guide/partials/assembly_using-gradle-artifact-repositories.adoc
@@ -8,6 +8,8 @@
 
 :context: using-gradle-artifact-repositories
 
+This section describes how to download and configure Gradle.
+
 include::partial$proc_downloading-different-versions-of-gradle.adoc[leveloffset=+1]
 
 include::partial$proc_configuring-global-gradle-repositories.adoc[leveloffset=+1]

--- a/modules/end-user-guide/partials/con_che-theia-plug-in-concept-in-detail.adoc
+++ b/modules/end-user-guide/partials/con_che-theia-plug-in-concept-in-detail.adoc
@@ -26,7 +26,7 @@ The same Che-Theia plug-in API is exposed to plug-ins running on the client side
 [id="che-theia-plug-in-apis_{context}"]
 == Che-Theia plug-in APIs
 
-For the purpose of providing tool isolation and easy extensibility in {prod}, the Che-Theia IDE has a set of plug-in APIs. The APIs are compatible with Visual Studio Code extension APIs. Usually, Che-Theia can run VS Code extensions as its own plug-ins.
+To provide tool isolation and easy extensibility in {prod}, the Che-Theia IDE has a set of plug-in APIs. The APIs are compatible with Visual Studio Code extension APIs. Usually, Che-Theia can run VS Code extensions as its own plug-ins.
 
 When developing a plug-in that depends on or interacts with components of {prod-short} workspaces (containers, preferences, factories), use the {prod-short} APIs embedded in Che-Theia.
 

--- a/modules/end-user-guide/partials/con_che-theia-plug-in-concept-in-detail.adoc
+++ b/modules/end-user-guide/partials/con_che-theia-plug-in-concept-in-detail.adoc
@@ -15,7 +15,7 @@ You can extend the IDE provided with {prod} by building a *Che-Theia plug-in*. C
 
 The Che-Theia editor plug-ins let you add languages, debuggers, and tools to your installation to support your development workflow. Plug-ins run when the editor completes loading. If a Che-Theia plug-in fails, the main Che-Theia editor continues to work.
 
-Che-Theia plug-presentins run either on the client side or on the server side. This is a scheme of the client and server-side plug-in concept:
+Che-Theia plug-ins run either on the client side or on the server side. This is a scheme of the client and server-side plug-in concept:
 
 .Client and server-side Che-Theia plug-ins
 image::extensibility/client-server-side-plug-ins.svg[]

--- a/modules/end-user-guide/partials/con_che-theia-plug-in-concept-in-detail.adoc
+++ b/modules/end-user-guide/partials/con_che-theia-plug-in-concept-in-detail.adoc
@@ -15,7 +15,7 @@ You can extend the IDE provided with {prod} by building a *Che-Theia plug-in*. C
 
 The Che-Theia editor plug-ins let you add languages, debuggers, and tools to your installation to support your development workflow. Plug-ins run when the editor completes loading. If a Che-Theia plug-in fails, the main Che-Theia editor continues to work.
 
-Che-Theia plug-ins run either on the client side or on the server side. This is a scheme of the client and server-side plug-in concept:
+Che-Theia plug-presentins run either on the client side or on the server side. This is a scheme of the client and server-side plug-in concept:
 
 .Client and server-side Che-Theia plug-ins
 image::extensibility/client-server-side-plug-ins.svg[]
@@ -26,7 +26,7 @@ The same Che-Theia plug-in API is exposed to plug-ins running on the client side
 [id="che-theia-plug-in-apis_{context}"]
 == Che-Theia plug-in APIs
 
-For the purpose of providing tool isolation and easy extensibility in {prod}, the Che-Theia IDE has a set of plug-in APIs. The APIs are compatible with Visual Studio Code extension APIs. In most cases, Che-Theia can run VS Code extensions as its own plug-ins.
+For the purpose of providing tool isolation and easy extensibility in {prod}, the Che-Theia IDE has a set of plug-in APIs. The APIs are compatible with Visual Studio Code extension APIs. Usually, Che-Theia can run VS Code extensions as its own plug-ins.
 
 When developing a plug-in that depends on or interacts with components of {prod-short} workspaces (containers, preferences, factories), use the {prod-short} APIs embedded in Che-Theia.
 

--- a/modules/end-user-guide/partials/proc_accessing-a-git-repository-via-ssh.adoc
+++ b/modules/end-user-guide/partials/proc_accessing-a-git-repository-via-ssh.adoc
@@ -18,7 +18,7 @@ The following section describes a generation of an SSH key using the {prod-short
 
 .Procedure
 
-A common SSH key pair that works with all the Git providers is present by default. To start using it, add the public key to the Git provider.
+A common SSH key pair that works with all the Git providers is available by default. To start using it, add the public key to the Git provider.
 
 . Generate an SSH key pair that only works with a particular Git provider:
 

--- a/modules/end-user-guide/partials/proc_accessing-a-git-repository-via-ssh.adoc
+++ b/modules/end-user-guide/partials/proc_accessing-a-git-repository-via-ssh.adoc
@@ -7,7 +7,9 @@
 
 == Generating an SSH key using the {prod-short} command palette
 
-The following section describes a generation of an SSH key using the {prod-short} command palette and its further use in Git provider communication. This SSH key restricts permissions for the specific Git provider, therefore, the user has to create a unique SSH key for each Git provider in use.
+You can generate an SSH key by using the {prod-short} command palette. You have to create a unique SSH key for each Git provider in use because each SSH key restricts permissions for one specific Git provider.
+
+A common SSH key pair that works with all the Git providers is available by default. To start using it, add the public key to the Git provider.
 
 .Prerequisites
 * A running instance of {prod-short}. To install an instance of {prod}, see xref:installation-guide:installing-che.adoc[].
@@ -17,8 +19,6 @@ The following section describes a generation of an SSH key using the {prod-short
 * Personal link:https://help.github.com/en/articles/types-of-github-accounts[GitHub account] or other Git provider account created.
 
 .Procedure
-
-A common SSH key pair that works with all the Git providers is available by default. To start using it, add the public key to the Git provider.
 
 . Generate an SSH key pair that only works with a particular Git provider:
 

--- a/modules/end-user-guide/partials/proc_adding-a-vs-code-extension-to-the-che-plugin-registry.adoc
+++ b/modules/end-user-guide/partials/proc_adding-a-vs-code-extension-to-the-che-plugin-registry.adoc
@@ -92,7 +92,7 @@ This article describes the steps needed to build the plug-ins registry with a cu
 <18> The path of the mount
 <19> (OPTIONAL) Any endpoint information for the sidecar container
 <20> Endpoint name
-<21> Whether the endpoint is exposed publicly
+<21> A Boolean value determining whether the endpoint is exposed publicly
 <22> The port number
 <23> Attributes relating to the endpoint
 <24> Direct link(s) to the `vsix` files included with this plugin. The `vsix` built by the repository specified, such as the main extension, must be listed first

--- a/modules/end-user-guide/partials/proc_adding-a-vs-code-extension-to-the-che-plugin-registry.adoc
+++ b/modules/end-user-guide/partials/proc_adding-a-vs-code-extension-to-the-che-plugin-registry.adoc
@@ -92,7 +92,7 @@ This article describes the steps needed to build the plug-ins registry with a cu
 <18> The path of the mount
 <19> (OPTIONAL) Any endpoint information for the sidecar container
 <20> Endpoint name
-<21> Whether or not the endpoint is exposed publicly or not
+<21> Whether the endpoint is exposed publicly
 <22> The port number
 <23> Attributes relating to the endpoint
 <24> Direct link(s) to the `vsix` files included with this plugin. The `vsix` built by the repository specified, such as the main extension, must be listed first

--- a/modules/end-user-guide/partials/proc_defining-maven-repositories-in-the-settings-xml-file.adoc
+++ b/modules/end-user-guide/partials/proc_defining-maven-repositories-in-the-settings-xml-file.adoc
@@ -6,7 +6,7 @@
 = Defining repositories in `settings.xml`
 
 To specify your own artifact repositories at `example.server.org`, use the `settings.xml` file.
-To do that, ensure, that `settings.xml` is in all the containers that use Maven tools, in particular the Maven container and the Java plug-in container.
+Ensure that `settings.xml` is in all the containers that use Maven tools. In particular, ensure that it is in the Maven container and the Java plug-in container.
 
 By default, `settings.xml` is located at the `__<home dir>__/.m2` directory which is already on persistent volume in Maven and Java plug-in containers and you don't need to re-create the file each time you restart the workspace if it isn't in ephemeral mode.
 

--- a/modules/end-user-guide/partials/proc_defining-maven-repositories-in-the-settings-xml-file.adoc
+++ b/modules/end-user-guide/partials/proc_defining-maven-repositories-in-the-settings-xml-file.adoc
@@ -6,7 +6,7 @@
 = Defining repositories in `settings.xml`
 
 To specify your own artifact repositories at `example.server.org`, use the `settings.xml` file.
-To do that, ensure, that `settings.xml` is present in all the containers that use Maven tools, in particular the Maven container and the Java plug-in container.
+To do that, ensure, that `settings.xml` is in all the containers that use Maven tools, in particular the Maven container and the Java plug-in container.
 
 By default, `settings.xml` is located at the `__<home dir>__/.m2` directory which is already on persistent volume in Maven and Java plug-in containers and you don't need to re-create the file each time you restart the workspace if it isn't in ephemeral mode.
 

--- a/modules/end-user-guide/partials/proc_downloading-different-versions-of-gradle.adoc
+++ b/modules/end-user-guide/partials/proc_downloading-different-versions-of-gradle.adoc
@@ -5,7 +5,7 @@ The recommended way to download any version of Gradle is by using the Gradle Wra
 
 .Prerequisites
 
-* The Gradle Wrapper is present in your project.
+* The Gradle Wrapper is available in your project.
 
 .Procedure
 

--- a/modules/end-user-guide/partials/proc_managing-git-configuration-identity.adoc
+++ b/modules/end-user-guide/partials/proc_managing-git-configuration-identity.adoc
@@ -20,7 +20,7 @@ image::git/git-config-identity.png[Configuring Git identity,link="../_images/git
 
 * To configure Git identity using the command line, open the terminal of the Che-Theia container.
 +
-. Navigate to the *My Workspace* view, and open *Plugins > theia-ide... > New terminal*:
+. Navigate to the *My Workspace* view, and open *Plugins > theia-ide > New terminal*:
 +
 image::git/terminal-git-command.png[]
 +

--- a/modules/end-user-guide/partials/proc_overriding-devfile-values-using-factory-parameters.adoc
+++ b/modules/end-user-guide/partials/proc_overriding-devfile-values-using-factory-parameters.adoc
@@ -5,17 +5,19 @@
 [id="overriding-devfile-values-using-factory-parameters_{context}"]
 = Overriding devfile values using factory parameters
 
-Values in the following sections of a remote devfile can be overridden using specially constructed additional factory parameters:
+You can override values in the following sections of a remote devfile:
 
 * `apiVersion`
 * `metadata`
 * `projects`
 * `attributes`
 
+You can override the values by using additional factory parameters.
+
 .Prerequisites
 
-* A running instance of {prod}. To install an instance of {prod}, see xref:installation-guide:installing-che.adoc[].
-* A publicly accessible standalone `devfile.yaml` file. See xref:authoring-devfiles-version-2.adoc[] for detailed information about creating and using devfiles.
+* A running instance of {prod}. See xref:installation-guide:installing-che.adoc[].
+* A publicly accessible stand-alone `devfile.yaml` file. See xref:authoring-devfiles-version-2.adoc[] for information about creating and using devfiles.
 
 .Procedure
 
@@ -72,7 +74,7 @@ projects:
 ...
 ----
 
-To add or override source `branch` value, use the following factory URL:
+To add or override the source `branch` value, use the following factory URL:
 
 [subs="+quotes"]
 ----
@@ -113,7 +115,7 @@ projects:
 ...
 ----
 
-To add or override `persistVolumes` attribute value, use the following factory URL:
+To add or override the `persistVolumes` attribute value, use the following factory URL:
 
 [subs="+quotes"]
 ----
@@ -135,7 +137,7 @@ projects:
 ...
 ----
 
-When overriding attributes, everything that follows the `attributes` keyword is interpreted as an attribute name, so a user can use dot-separated names:
+When overriding attributes, everything that follows the `attributes` keyword is interpreted as an attribute name. The user can use dot-separated names:
 
 [subs="+quotes"]
 ----
@@ -158,4 +160,4 @@ projects:
 
 .Verification steps
 
-. Using {prod-short} Dashboard, move to the *Devfile* tab of the newly created workspace and check its content.
+. In {prod-short} Dashboard, navigate to the *Devfile* tab of the newly created workspace and inspect the content.

--- a/modules/end-user-guide/partials/proc_overriding-devfile-values-using-factory-parameters.adoc
+++ b/modules/end-user-guide/partials/proc_overriding-devfile-values-using-factory-parameters.adoc
@@ -137,7 +137,7 @@ projects:
 ...
 ----
 
-When overriding attributes, everything that follows the `attributes` keyword is interpreted as an attribute name. The user can use dot-separated names:
+When overriding attributes, everything that follows the `attributes` keyword is interpreted as an attribute name. You can use dot-separated names:
 
 [subs="+quotes"]
 ----

--- a/modules/end-user-guide/partials/proc_troubleshooting-slow-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_troubleshooting-slow-workspaces.adoc
@@ -34,7 +34,7 @@ Installing offline::
 +
 _Role: Administrator_
 +
-Components of {prod-short} are OCI images. Setup {prod} in offline mode (air-gap scenario) to allow for reducing any extra download at runtime as everything needs to be present from the beginning. See xref:installation-guide:installing-che-in-a-restricted-environment.adoc[].
+Components of {prod-short} are OCI images. Setup {prod} in offline mode (air-gap scenario) to reduce any extra download at runtime as everything needs to be available from the beginning. See xref:installation-guide:installing-che-in-a-restricted-environment.adoc[].
 
 Optimizing workspace plug-ins::
 +

--- a/modules/end-user-guide/partials/proc_troubleshooting-slow-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_troubleshooting-slow-workspaces.adoc
@@ -34,7 +34,7 @@ Installing offline::
 +
 _Role: Administrator_
 +
-Components of {prod-short} are OCI images. Setup {prod} in offline mode (air-gap scenario) to reduce any extra download at runtime as everything needs to be available from the beginning. See xref:installation-guide:installing-che-in-a-restricted-environment.adoc[].
+Components of {prod-short} are OCI images. Set up {prod} in offline mode (air-gap scenario) to reduce any extra download at runtime because everything needs to be available from the beginning. See xref:installation-guide:installing-che-in-a-restricted-environment.adoc[].
 
 Optimizing workspace plug-ins::
 +

--- a/modules/end-user-guide/partials/proc_using-npm-artifact-repositories.adoc
+++ b/modules/end-user-guide/partials/proc_using-npm-artifact-repositories.adoc
@@ -9,7 +9,7 @@
 
 The npm (Node Package Manager) package manager for the JavaScript programming language is configured using the `npm config` command, by writing values to the `.npmrc` files. However, configuration values can also be set using the environment variables beginning with `NPM_CONFIG_`.
 
-The Javascript/Typescript plug-in used in {prod} does not download any artifacts. It is enough to configure npm in the dev-machine component. 
+The Typescript plug-in used in {prod} does not download any artifacts. It is enough to configure npm in the dev-machine component. 
 
 Use the following environment variables for configuration:
 

--- a/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
+++ b/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
@@ -19,7 +19,7 @@ Che-Theia plug-in metadata is information about individual plug-ins for the plug
 
 The Che-Theia plug-in metadata, for each specific plug-in, is defined in a `meta.yaml` file. These files can be referenced in a devfile to include Che-Theia plug-ins in a workspace.
 
-Here is an overview of all fields that can be available in plugin meta YAML files. This document represents the link:https://github.com/eclipse-che/che-plugin-registry#user-content-plugin-meta-yaml-structure[plugin meta YAML structure (version 3)].
+Here is an overview of all fields that can be available in plug-in meta YAML files. This document represents the link:https://github.com/eclipse-che/che-plugin-registry#user-content-plugin-meta-yaml-structure[plugin meta YAML structure (version 3)].
 
 ifeval::["{project-context}" == "che"]
 In the link:https://github.com/eclipse-che/che-plugin-registry/tree/{prod-ver-patch}[{prod-short} plug-ins registry repository], the `che-theia-plugins.yaml` contains a list of all Che-Theia plug-ins in the registry. Build the registry container image to generate the `meta.yaml` file.
@@ -29,20 +29,20 @@ endif::[]
 |===
 |`apiVersion`| Version 2 and higher where version is 1 supported for backwards compatibility 
 |`category`| Available: Category must be set to one of the followings: `Editor`, `Debugger`, `Formatter`, `Language`, `Linter`, `Snippet`, `Theme`, `Other`
-|`description`| Short description of plugin's purpose
+|`description`| Short description of the plug-in purpose
 |`displayName`| Name shown in user dashboard
-|`deprecate` | Optional; section for deprecating plugins in favor of others
+|`deprecate` | Optional; section for deprecating plug-ins in favor of others
 
             * autoMigrate - boolean 
             
             * migrateTo - new `org/plugin-id/version`, for example `redhat/vscode-apache-camel/latest`
-|`firstPublicationDate`| Not required to be in YAML; if it is not included, the Plugin Registry dockerimage build generates it
-|`latestUpdateDate`| Not required to be in YAML; if it is not included, the Plugin Registry dockerimage build generates it
+|`firstPublicationDate`| Not required to be in YAML; if it is not included, the plug-in registry dockerimage build generates it
+|`latestUpdateDate`| Not required to be in YAML; if it is not included, the plug-in registry dockerimage build generates it
 |`icon`| URL of an SVG or PNG icon
 |`name`| Name (no spaces allowed), must match [-a-z0-9]
 |`publisher`| Name of the publisher, must match [-a-z0-9]
-|`repository`| URL for plugin repository, for example, GitHub
-|`title`|  Plugin title (long)
+|`repository`| URL for plug-in repository, for example, GitHub
+|`title`|  Plug-in title (long)
 |`type`| `Che Plugin`, `VS Code extension`
 |`version`| Version information, for example: 7.5.1, [-.a-z0-9]
 |`spec`| Specifications (see below)
@@ -50,8 +50,8 @@ endif::[]
 
 .`spec` attributes
 |===
-|`endpoints` | Optional; plugin endpoint.
-|`containers`| Optional; sidecar containers for the plug-in. Che Plugin and VS Code extension supports only one container
+|`endpoints` | Optional; plug-in endpoint
+|`containers`| Optional; sidecar containers for the plug-in. Che Plug-in and VS Code extension supports only one container
 |`initContainers`| Optional; sidecar init containers for the plug-in
 |`workspaceEnv`| Optional; environment variables for the workspace
 |`extensions`| Optional; Attribute that is required for VS Code and Che-Theia plug-ins in a form list of URLs to plug-in artefacts, such as .vsix or .theia files
@@ -72,7 +72,7 @@ endif::[]
 |`ports` | Ports exposed by the plug-in (on the container)
 |`commands` | Development commands available to the plug-in container
 |`mountSources` | Boolean flag to bound volume with source code `/projects` to the plug-in container
-|`initContainers` | Optional; init containers for sidecar plugin
+|`initContainers` | Optional; init containers for sidecar plug-in
 |`Lifecycle` | Container lifecycle hooks. See link:https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/[`lifecycle` description]
 |===
 

--- a/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
+++ b/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
@@ -36,8 +36,8 @@ endif::[]
             * autoMigrate - boolean 
             
             * migrateTo - new `org/plugin-id/version`, for example `redhat/vscode-apache-camel/latest`
-|`firstPublicationDate`| Not required to be in YAML; if it is not included, it will be generated during Plugin Registry dockerimage build
-|`latestUpdateDate`| Not required to be in YAML; if it is not included, it will be generated during Plugin Registry dockerimage build
+|`firstPublicationDate`| Not required to be in YAML; if it is not included, the Plugin Registry dockerimage build generates it
+|`latestUpdateDate`| Not required to be in YAML; if it is not included, the Plugin Registry dockerimage build generates it
 |`icon`| URL of an SVG or PNG icon
 |`name`| Name (no spaces allowed), must match [-a-z0-9]
 |`publisher`| Name of the publisher, must match [-a-z0-9]

--- a/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
+++ b/modules/end-user-guide/partials/ref_che-theia-plug-in-metadata.adoc
@@ -36,8 +36,8 @@ endif::[]
             * autoMigrate - boolean 
             
             * migrateTo - new `org/plugin-id/version`, for example `redhat/vscode-apache-camel/latest`
-|`firstPublicationDate`| Not required to be present in YAML, as if not present, it will be generated during Plugin Registry dockerimage build
-|`latestUpdateDate`| Not required to be present in YAML, as if not present, it will be generated during Plugin Registry dockerimage build
+|`firstPublicationDate`| Not required to be in YAML; if it is not included, it will be generated during Plugin Registry dockerimage build
+|`latestUpdateDate`| Not required to be in YAML; if it is not included, it will be generated during Plugin Registry dockerimage build
 |`icon`| URL of an SVG or PNG icon
 |`name`| Name (no spaces allowed), must match [-a-z0-9]
 |`publisher`| Name of the publisher, must match [-a-z0-9]

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -420,7 +420,7 @@ components:
 
 The sources is mounted on a location stored in the `CHE_PROJECTS_ROOT` environment variable that is made available in the running container of the image. This location defaults to `/projects`.
 
-=== Container Entrypoint
+=== Container entrypoint
 
 The `command` attribute of the `dockerimage` along with other arguments, is used to modify the `entrypoint` command of the container created from the image. In {prod} the container is needed to run indefinitely so that you can connect to it and execute arbitrary commands in it at any time. Because the availability of the `sleep` command and the support for the `infinity` argument for it is different and depends on the base image used in the particular images, {prod-short} cannot insert this behavior automatically on its own. However, you can take advantage of this feature to, for example, start necessary servers with modified configurations, and so on.
 

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -639,7 +639,7 @@ the {platforms-namespace} to which the workspace is deployed.
 * `CHE_MACHINE_AUTH_SIGNATURE__ALGORITHM`: The encryption algorithm used in the secured communication with the {prod-short} server.
 
 
-A devfiles may only need the `CHE_PROJECTS_ROOT` environment variable to locate the cloned projects in the component's container. More advanced devfiles might use the `CHE_WORKSPACE_LOGS_ROOT__DIR` environment variable to read the logs (for example as part of a devfile command). The environment variables used to securely access the {prod-short} server are out of scope for devfiles and are available only for advanced use cases, which are handled by the {prod-short} plug-ins.
+A devfile might need the `CHE_PROJECTS_ROOT` environment variable to locate the cloned projects in the component's container. More advanced devfiles might use the `CHE_WORKSPACE_LOGS_ROOT__DIR` environment variable to read the logs. The environment variables for securely accessing the {prod-short} server are out of scope for devfiles. These variables are available only to {prod-short} plug-ins, which use them for advanced use cases.
 
 [id="endpoints_{context}"]
 === Endpoints
@@ -901,7 +901,7 @@ components:
       app: postgres
 ----
 
-Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers in the resource list. 
+Additionally, you can modify the entrypoints (command and arguments) of the containers in the resource list. 
 
 //For details of the advanced use case, see xref:configuring-a-workspace-with-dashboard.adoc#defining-specific-container-images_configuring-a-workspace-with-dashboard[Defining specific container images].
 

--- a/modules/end-user-guide/partials/ref_devfile-reference.adoc
+++ b/modules/end-user-guide/partials/ref_devfile-reference.adoc
@@ -639,7 +639,7 @@ the {platforms-namespace} to which the workspace is deployed.
 * `CHE_MACHINE_AUTH_SIGNATURE__ALGORITHM`: The encryption algorithm used in the secured communication with the {prod-short} server.
 
 
-A devfiles may only need the `CHE_PROJECTS_ROOT` environment variable to locate the cloned projects in the component's container. More advanced devfiles might use the `CHE_WORKSPACE_LOGS_ROOT__DIR` environment variable to read the logs (for example as part of a devfile command). The environment variables used to securely access the {prod-short} server are out of scope for devfiles and are present only for advanced use cases, which are handled by the {prod-short} plug-ins.
+A devfiles may only need the `CHE_PROJECTS_ROOT` environment variable to locate the cloned projects in the component's container. More advanced devfiles might use the `CHE_WORKSPACE_LOGS_ROOT__DIR` environment variable to read the logs (for example as part of a devfile command). The environment variables used to securely access the {prod-short} server are out of scope for devfiles and are available only for advanced use cases, which are handled by the {prod-short} plug-ins.
 
 [id="endpoints_{context}"]
 === Endpoints
@@ -901,7 +901,7 @@ components:
       app: postgres
 ----
 
-Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers present in the resource list. 
+Additionally, it is also possible to modify the entrypoints (command and arguments) of the containers in the resource list. 
 
 //For details of the advanced use case, see xref:configuring-a-workspace-with-dashboard.adoc#defining-specific-container-images_configuring-a-workspace-with-dashboard[Defining specific container images].
 
@@ -979,7 +979,7 @@ commands:
 
 === Editor-specific commands
 
-If the editor in the workspace supports it, the devfile can specify additional configuration in the editor-specific format. This is dependent on the integration code present in the workspace editor itself and so is not a generic mechanism. However, the default Che-Theia editor within {prod} is equipped to understand the `tasks.json` and `launch.json` files provided in the devfile.
+If the editor in the workspace supports it, the devfile can specify additional configuration in the editor-specific format. This is dependent on the integration code in the workspace editor itself and so is not a generic mechanism. However, the default Che-Theia editor within {prod} is equipped to understand the `tasks.json` and `launch.json` files provided in the devfile.
 
 [source,yaml]
 ----

--- a/modules/hosted-che/partials/ref_about-hosted-che.adoc
+++ b/modules/hosted-che/partials/ref_about-hosted-che.adoc
@@ -7,7 +7,7 @@
 = About Eclipse Che hosted by Red Hat
 
 Eclipse Che hosted by Red Hat is an open-source product based on link:https://www.eclipse.org/che/[Eclipse {prod-short}] that is running on link:https://www.openshift.com/products/dedicated/[OpenShift Dedicated].
-The new service is part of the link:https://developers.redhat.com/developer-sandbox[Developer Sandbox for Red Hat OpenShift] offering, and is using link:https://developers.redhat.com/products/codeready-workspaces[CodeReady Workspaces], which is built upon Eclipse Che and is optimized for Red Hat OpenShift and Red Hat Linux.
+The new service is part of the link:https://developers.redhat.com/developer-sandbox[Developer Sandbox for Red Hat OpenShift] offering, and is using link:https://developers.redhat.com/products/codeready-workspaces/overview[CodeReady Workspaces], which is built upon Eclipse Che and is optimized for Red Hat OpenShift and Red Hat Linux.
 
 == Differences between Eclipse Che and CodeReady Workspaces
 


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Fixes vale warnings in End-user Guide.

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
