### PR TITLE
fix: Use new URL for downloading and parsing CRD

### DIFF
--- a/tools/checluster_docs_gen.sh
+++ b/tools/checluster_docs_gen.sh
@@ -41,9 +41,9 @@ fetch_conf_files_content() {
   echo "Fetching property files content from GitHub..." >&2
 
   if [[ $PRODUCT == "che" ]]; then
-    CHECLUSTER_PROPERTIES_URL="https://raw.githubusercontent.com/eclipse/che-operator/$CURRENT_VERSION/deploy/crds/org_v1_che_crd.yaml"
+    CHECLUSTER_PROPERTIES_URL=https://raw.githubusercontent.com/eclipse-che/che-operator/$CURRENT_VERSION/config/crd/bases/org_v1_che_crd.yaml"
   else
-    CHECLUSTER_PROPERTIES_URL="https://raw.githubusercontent.com/redhat-developer/codeready-workspaces-operator/crw-$CURRENT_VERSION-rhel-8/deploy/crds/org_v1_che_crd.yaml"
+    CHECLUSTER_PROPERTIES_URL="https://raw.githubusercontent.com/redhat-developer/codeready-workspaces-operator/$CURRENT_VERSION/config/crd/bases/org_v1_che_crd.yaml"
   fi
 
   RAW_CONTENT=$(curl -sf "$CHECLUSTER_PROPERTIES_URL")

--- a/tools/checluster_docs_gen.sh
+++ b/tools/checluster_docs_gen.sh
@@ -41,7 +41,7 @@ fetch_conf_files_content() {
   echo "Fetching property files content from GitHub..." >&2
 
   if [[ $PRODUCT == "che" ]]; then
-    CHECLUSTER_PROPERTIES_URL=https://raw.githubusercontent.com/eclipse-che/che-operator/$CURRENT_VERSION/config/crd/bases/org_v1_che_crd.yaml"
+    CHECLUSTER_PROPERTIES_URL="https://raw.githubusercontent.com/eclipse-che/che-operator/$CURRENT_VERSION/config/crd/bases/org_v1_che_crd.yaml"
   else
     CHECLUSTER_PROPERTIES_URL="https://raw.githubusercontent.com/redhat-developer/codeready-workspaces-operator/$CURRENT_VERSION/config/crd/bases/org_v1_che_crd.yaml"
   fi


### PR DESCRIPTION
> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Update URL to retrieve CRD from new locations since Che 7.34.0/x release

### What issues does this PR fix or reference?


### Specify the version of the product this PR applies to.


### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
