### PR TITLE
fix: Updating Hosted Che 'Troubleshooting' section. Adding a warning about currently disabled upstream devfile registry

### DIFF
--- a/modules/hosted-che/partials/ref_about-hosted-che.adoc
+++ b/modules/hosted-che/partials/ref_about-hosted-che.adoc
@@ -17,9 +17,15 @@ NOTE: link:https://workspaces.openshift.com/[Eclipse Che hosted by Red Hat] prov
 
 image::hosted-che/get-started-product-and-community-devfiles.png[]
 
-WARNING: Community-supported devfile registry has been temporarily disabled on the link:https://workspaces.openshift.com/[Eclipse Che hosted by Red Hat] due to a defect in the product. It is going to be re-enabled with the new release in September 2021.
+[WARNING]
+====
+The community-supported devfile registry has been temporarily disabled on the link:https://workspaces.openshift.com/[Eclipse Che hosted by Red Hat] due to a defect in the product. This devfile registry will be re-enabled for Hosted Che with the upcoming release in September 2021.
+====
 
-IMPORTANT: Eclipse Che and Red Hat CodeReady Workspaces share all of the features - all the product's functionality is available in the project and vice versa. However, not all the upstream plugins are available in the CodeReady Workspaces. To use an unsupported plugin inside the CodeReady Workspaces, one needs to explicitly point to the raw `meta.yaml` of the plugin from the devfile. The procedure is described in the xref:end-user-guide:adding-a-vs-code-extension-to-a-workspace.adoc#adding-the-vs-code-extension-using-the-workspace-configuration_che[Adding a VS Code extension using the workspace configuration] section.
+[IMPORTANT]
+====
+Eclipse Che and Red Hat CodeReady Workspaces share all of the features - all the product's functionality is available in the project and vice versa. However, not all the upstream plugins are available in the CodeReady Workspaces. To use an unsupported plugin inside the CodeReady Workspaces, one must explicitly point to the raw `meta.yaml` of the plugin from the devfile. The procedure is described in the xref:end-user-guide:adding-a-vs-code-extension-to-a-workspace.adoc#adding-the-vs-code-extension-using-the-workspace-configuration_che[Adding a VS Code extension using the workspace configuration] section.
+====
 
 [id="terms-of-service_{context}"]
 == Terms of service

--- a/modules/hosted-che/partials/ref_about-hosted-che.adoc
+++ b/modules/hosted-che/partials/ref_about-hosted-che.adoc
@@ -17,6 +17,8 @@ NOTE: link:https://workspaces.openshift.com/[Eclipse Che hosted by Red Hat] prov
 
 image::hosted-che/get-started-product-and-community-devfiles.png[]
 
+WARNING: Community-supported devfile registry has been temporarily disabled on the link:https://workspaces.openshift.com/[Eclipse Che hosted by Red Hat] due to a defect in the product. It is going to be re-enabled with the new release in September 2021.
+
 IMPORTANT: Eclipse Che and Red Hat CodeReady Workspaces share all of the features - all the product's functionality is available in the project and vice versa. However, not all the upstream plugins are available in the CodeReady Workspaces. To use an unsupported plugin inside the CodeReady Workspaces, one needs to explicitly point to the raw `meta.yaml` of the plugin from the devfile. The procedure is described in the xref:end-user-guide:adding-a-vs-code-extension-to-a-workspace.adoc#adding-the-vs-code-extension-using-the-workspace-configuration_che[Adding a VS Code extension using the workspace configuration] section.
 
 [id="terms-of-service_{context}"]

--- a/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
+++ b/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
@@ -13,6 +13,8 @@ The common FAQs are available on the link:https://developers.redhat.com/develope
 
 == Troubleshooting
 
+.Authentication
+
 To authenticate to link:https://workspaces.openshift.com[Red Hat Developer Sandbox], allow cookies from the `static.developers.redhat.com` page.  This authentication will fail in a scenario where these cookies are blocked by a browser extension such as link:https://www.eff.org/privacybadger[Privacy Badger].
 
 .Telemetry

--- a/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
+++ b/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
@@ -13,13 +13,7 @@ The common FAQs are available on the link:https://developers.redhat.com/develope
 
 == Troubleshooting
 
-.Unexpected error during login
-
-If an unexpected error during login happens the workaround is refreshing the page:
-
-----
-We are sorry... Unexpected error when authenticating with identity provider
-----
+.Authentication
 
 To authenticate to https://workspaces.openshift.com, one needs to allow cookies from the `static.developers.redhat.com`.
 In case these cookies are blocked (by a browser extension like https://www.eff.org/privacybadger[Privacy Badger]),

--- a/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
+++ b/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
@@ -13,11 +13,7 @@ The common FAQs are available on the link:https://developers.redhat.com/develope
 
 == Troubleshooting
 
-.Authentication
-
-To authenticate to https://workspaces.openshift.com, one needs to allow cookies from the `static.developers.redhat.com`.
-In case these cookies are blocked (by a browser extension like https://www.eff.org/privacybadger[Privacy Badger]),
-authentication will fail.
+To authenticate to link:https://workspaces.openshift.com[Red Hat Developer Sandbox], allow cookies from the `static.developers.redhat.com` page.  This authentication will fail in a scenario where these cookies are blocked by a browser extension such as link:https://www.eff.org/privacybadger[Privacy Badger].
 
 .Telemetry
 

--- a/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
+++ b/modules/hosted-che/partials/ref_hosted-che-faq-and-troubleshooting.adoc
@@ -15,7 +15,7 @@ The common FAQs are available on the link:https://developers.redhat.com/develope
 
 .Authentication
 
-To authenticate to link:https://workspaces.openshift.com[Red Hat Developer Sandbox], allow cookies from the `static.developers.redhat.com` page.  This authentication will fail in a scenario where these cookies are blocked by a browser extension such as link:https://www.eff.org/privacybadger[Privacy Badger].
+To authenticate to link:https://workspaces.openshift.com[Red Hat Developer Sandbox], allow cookies from the `static.developers.redhat.com` page. This authentication will fail in a scenario where these cookies are blocked by a browser extension such as link:https://www.eff.org/privacybadger[Privacy Badger].
 
 .Telemetry
 


### PR DESCRIPTION
### What does this PR do?
Updating Hosted Che 'Troubleshooting' section. Adding a warning about currently disabled upstream devfile registry

### What issues does this PR fix or reference?
Related to https://issues.redhat.com/browse/CRW-1426

### Specify the version of the product this PR applies to.
the current version of Eclipse Che hosted by Red Hat workspaces.openshift.com CRW 2.10.1

[![Contribute](https://raw.githubusercontent.com/redhat-developer-demos/quarkus-reactjs-postit-app/master/factory-contribute.svg)](https://workspaces.openshift.com#https://github.com/ibuziuk/che-docs/tree/CRW-1426)

![image](https://user-images.githubusercontent.com/1461122/128349768-d802e23f-5db8-47ca-949a-304a35f88a8e.png)

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] `vale` has been run successfully against the PR branch
- [ ] Link checker has been run successfully against the PR branch
- [ ] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
