### PR TITLE
chore: set minimal kubernetes version to 1.19

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -63,6 +63,7 @@ asciidoc:
     image-puller-namespace: k8s-image-puller
     image-puller-repository-name: kubernetes-image-puller
     kubernetes: Kubernetes
+    kube-ver-min: 1.19
     link-accessing-a-git-repository-via-https: xref:end-user-guide:version-control.adoc#accessing-a-git-repository-via-https_che[Accessing a Git repository using HTTPS]
     link-advanced-configuration-options-for-the-che-server: xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc[]
     link-advanced-configuration-options: xref:installation-guide:advanced-configuration-options-for-the-che-server-component.adoc[]

--- a/modules/installation-guide/examples/ref_che-supported-platforms-and-installation-methods.adoc
+++ b/modules/installation-guide/examples/ref_che-supported-platforms-and-installation-methods.adoc
@@ -6,7 +6,7 @@ The following section provides information about the availability of {prod-short
 
 {prod} can be installed on:
 
-* {kubernetes} infrastructures starting at version 1.9
+* {kubernetes} infrastructures starting at version 1.19
 * {ocp} versions 3.11, 4.3, and 4.4
 
 The following options are available:
@@ -39,7 +39,7 @@ a|* `minikube`
 |===
 |
 |{kubernetes} +
-1.9 or higher
+1.19 or higher
 |{ocp} +
 3.11
 |{ocp} +

--- a/modules/installation-guide/examples/ref_che-supported-platforms-and-installation-methods.adoc
+++ b/modules/installation-guide/examples/ref_che-supported-platforms-and-installation-methods.adoc
@@ -6,7 +6,7 @@ The following section provides information about the availability of {prod-short
 
 {prod} can be installed on:
 
-* {kubernetes} infrastructures starting at version 1.19
+* {kubernetes} infrastructures starting at version {kube-ver-min}
 * {ocp} versions 3.11, 4.3, and 4.4
 
 The following options are available:
@@ -39,7 +39,7 @@ a|* `minikube`
 |===
 |
 |{kubernetes} +
-1.19 or higher
+{kube-ver-min} or higher
 |{ocp} +
 3.11
 |{ocp} +

--- a/modules/installation-guide/partials/proc_installing-che-on-docker-desktop-using-helm.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-docker-desktop-using-helm.adoc
@@ -10,7 +10,7 @@ This section describes how to install {prod-short} on Docker Desktop using Helm.
 .Prerequisites
 
 * Running macOS or Windows.
-* An installation of Docker Desktop running {kubernetes} version `1.9` or higher. See link:https://www.docker.com/products/docker-desktop[Installing Docker Desktop].
+* An installation of Docker Desktop running {kubernetes} version `1.19` or higher. See link:https://www.docker.com/products/docker-desktop[Installing Docker Desktop].
 
 .Procedure
 

--- a/modules/installation-guide/partials/proc_installing-che-on-docker-desktop-using-helm.adoc
+++ b/modules/installation-guide/partials/proc_installing-che-on-docker-desktop-using-helm.adoc
@@ -10,7 +10,7 @@ This section describes how to install {prod-short} on Docker Desktop using Helm.
 .Prerequisites
 
 * Running macOS or Windows.
-* An installation of Docker Desktop running {kubernetes} version `1.19` or higher. See link:https://www.docker.com/products/docker-desktop[Installing Docker Desktop].
+* An installation of Docker Desktop running {kubernetes} version `{kube-ver-min}` or higher. See link:https://www.docker.com/products/docker-desktop[Installing Docker Desktop].
 
 .Procedure
 

--- a/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
+++ b/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
@@ -7,7 +7,7 @@ on Amazon Elastic Compute Cloud (Amazon EC2).
 
 .Prerequisites
 
-* A running instance of {kubernetes}, version 1.9 or higher, and Ingress.
+* A running instance of {kubernetes}, version 1.19 or higher, and Ingress.
 * The `{orch-cli}` tool installed.
 * The `{prod-cli}` tool installed.
 

--- a/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
+++ b/modules/installation-guide/partials/proc_preparing-the-aws-system-for-installing-che.adoc
@@ -7,7 +7,7 @@ on Amazon Elastic Compute Cloud (Amazon EC2).
 
 .Prerequisites
 
-* A running instance of {kubernetes}, version 1.19 or higher, and Ingress.
+* A running instance of {kubernetes}, version {kube-ver-min} or higher, and Ingress.
 * The `{orch-cli}` tool installed.
 * The `{prod-cli}` tool installed.
 

--- a/modules/installation-guide/partials/proc_using-minikube-to-set-up-kubernetes.adoc
+++ b/modules/installation-guide/partials/proc_using-minikube-to-set-up-kubernetes.adoc
@@ -10,7 +10,7 @@ This section describes how to use Minikube to prepare a local single-node {kuber
 .Prerequisites
 
 * An installation of `{orch-cli}`. See link:https://kubernetes.io/docs/tasks/tools/#kubectl/[Installing and Setting Up {orch-cli} ].
-* An installation of Minikube with {kubernetes} version `1.19` or higher. See link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Installing Minikube].
+* An installation of Minikube with {kubernetes} version `{kube-ver-min}` or higher. See link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Installing Minikube].
 
 .Procedure
 

--- a/modules/installation-guide/partials/proc_using-minikube-to-set-up-kubernetes.adoc
+++ b/modules/installation-guide/partials/proc_using-minikube-to-set-up-kubernetes.adoc
@@ -10,7 +10,7 @@ This section describes how to use Minikube to prepare a local single-node {kuber
 .Prerequisites
 
 * An installation of `{orch-cli}`. See link:https://kubernetes.io/docs/tasks/tools/#kubectl/[Installing and Setting Up {orch-cli} ].
-* An installation of Minikube with {kubernetes} version `1.9` or higher. See link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Installing Minikube].
+* An installation of Minikube with {kubernetes} version `1.19` or higher. See link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Installing Minikube].
 
 .Procedure
 


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

> Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR.

### What does this PR do?
Set minimal kubernetes version to 1.19

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20182

### Specify the version of the product this PR applies to.

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] `vale` has been run successfully against the PR branch
- [x] Link checker has been run successfully against the PR branch
- [x] Documentation describes a scenario that is already covered by QE tests, otherwise an issue has been created and acknowledged by Che QE team
- [ ] Changed article references are updated where they are used (or a redirect has been configured on the docs side):
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
