### PR TITLE
chore: run publication daily

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,6 +134,11 @@ spec:
                 '''
             }
         }
+      post {
+        always {
+          archiveArtifacts artifacts: 'che-docs/build/**', fingerprint: true
+      }
+  }
         milestone 22
       }
     }
@@ -178,12 +183,4 @@ spec:
 
   }
 
-  post {
-    always {
-      archiveArtifacts artifacts: 'che-docs/build/**', fingerprint: true
-    }
-  }
-
 }
-
-


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

The Jenkins Pipeline builds Eclipse Che documentation for the publication to Eclipse website https://www.eclipse.org/che/docs/.

It is: 
* Executing the build from the *Execution branch*.
* Using the content from the *Publication branches*.
* Pushing the build artifacts to the `che` repository on Eclipse Git server.

Eclipse infrastructure then publishes to Eclipse website: https://www.eclipse.org/che/docs/.

Execution branch::

The build runs on a branch containing at least the `Jenkinsfile` and `antora-playbook.yml` files.
It does not need to run at all on other branches.
By convention: restrict the build to the `main`, `master` and `publication` branches.

Publication branch(es)::

The build is using the content from the publication branch(es) defined in the `antora-playbook.yml` file.

Triggers::

Ideally, run the build when a change in the publication branch happened. 
But it impossible to implement in current context with the available `pollSCM` or `upstream` triggers https://www.jenkins.io/doc/book/pipeline/syntax/#triggers
It would be possible to implement using the `upstream` trigger with a dedicated Jenkins job for the Publication branch, and a dedicated Jenkins job for the Execution branch.
Pragmatic solution: run daily with the `cron` trigger.


## What issues does this pull request fix or reference?

Currently:

* Change to the current publication branch doesn't trigger a publication.
* We build all branches on Eclipse Jenkins, but it is not necessary.
* We build the master branch when a change on the master branch occurs.

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [x] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [x] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
