### PR TITLE
fix: Fixing badly commented-out include

### DIFF
--- a/modules/administration-guide/partials/assembly_viewing-che-server-logs.adoc
+++ b/modules/administration-guide/partials/assembly_viewing-che-server-logs.adoc
@@ -10,9 +10,8 @@
 
 This section describes how to view the {prod-short} server logs using the command line.
 
-////
 // include::partial$proc_viewing-che-server-logs-in-the-web-console.adoc[leveloffset=+1]
-////
+
 include::partial$proc_viewing-che-server-logs-on-the-cli.adoc[leveloffset=+1]
 
 :context: {parent-context-of-viewing-che-server-logs}

--- a/modules/administration-guide/partials/assembly_viewing-che-server-logs.adoc
+++ b/modules/administration-guide/partials/assembly_viewing-che-server-logs.adoc
@@ -11,7 +11,7 @@
 This section describes how to view the {prod-short} server logs using the command line.
 
 ////
-include::partial$proc_viewing-che-server-logs-in-the-web-console.adoc[leveloffset=+1]
+// include::partial$proc_viewing-che-server-logs-in-the-web-console.adoc[leveloffset=+1]
 ////
 include::partial$proc_viewing-che-server-logs-on-the-cli.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Signed-off-by: Michal Maléř <mmaler@redhat.com>

Fixing badly commented-out include
The include points to a file that doesn't exist. The writer who deleted the file badly commented out this include from the asciidoc code, causing the down-streaming script to break.

Replacing 
////
XXXX
////

for the comment block demarcation
with:

//

Asking for a second approval so I could merge and test if this is a bug or no.


<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
