### PR TITLE
Removig the warning about missing upstream devfile registry on the hosted che instance

### DIFF
--- a/modules/hosted-che/partials/ref_about-hosted-che.adoc
+++ b/modules/hosted-che/partials/ref_about-hosted-che.adoc
@@ -17,11 +17,6 @@ NOTE: link:https://workspaces.openshift.com/[Eclipse Che hosted by Red Hat] prov
 
 image::hosted-che/get-started-product-and-community-devfiles.png[]
 
-[WARNING]
-====
-The community-supported devfile registry has been temporarily disabled on the link:https://workspaces.openshift.com/[Eclipse Che hosted by Red Hat] due to a defect in the product. This devfile registry will be re-enabled for Hosted Che with an upcoming release.
-====
-
 [IMPORTANT]
 ====
 Eclipse Che and Red Hat CodeReady Workspaces share all of the features - all the product's functionality is available in the project and vice versa. However, not all the upstream plugins are available in the CodeReady Workspaces. To use an unsupported plugin inside the CodeReady Workspaces, one must explicitly point to the raw `meta.yaml` of the plugin from the devfile. The procedure is described in the xref:end-user-guide:adding-a-vs-code-extension-to-a-workspace.adoc#adding-the-vs-code-extension-using-the-workspace-configuration_che[Adding a VS Code extension using the workspace configuration] section.


### PR DESCRIPTION
## What does this pull request change?
Removig the warning about missing upstream devfile registry on the hosted che instance

## What issues does this pull request fix or reference?

https://github.com/eclipse/che/issues/20437

## Specify the version of the product this pull request applies to
Hosted Che / CRW 2.12.1

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
