### PR TITLE
fix: add missing . to docker build command

### DIFF
--- a/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
+++ b/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
@@ -47,7 +47,7 @@ Create a container image based on this code and expose it as a deployment in Ope
 ----
 $ git clone https://github.com/che-incubator/che-workspace-telemetry-example
 $ cd che-workspace-telemetry-example
-$ docker build -t registry/organization/che-workspace-telemetry-example:latest
+$ docker build -t registry/organization/che-workspace-telemetry-example:latest .
 $ docker push registry/organization/che-workspace-telemetry-example:latest
 ----
 


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>


<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
The PR adds a missing `.` to docker build command.

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
