### PR TITLE
fix: prometheus config explanation formatting, broken link

### DIFF
--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -7,7 +7,7 @@ This section describes how to use the Prometheus monitoring system to collect, s
 
 .Prerequisites
 
-* {prod-short} is exposing metrics on port `8087`. See xref:enabling-and-exposing-{prod-id-short}-metrics_{context}[Enabling and exposing che metrics].
+* {prod-short} is exposing metrics on port `8087`. See xref:enabling-and-exposing-{prod-id-short}-metrics_{context}[Enabling and exposing {prod-short} metrics].
 
 * Prometheus 2.9.1 or higher is running. The Prometheus console is running on port `9090` with a corresponding *service* and *route*. See link:https://prometheus.io/docs/introduction/first_steps/[First steps with Prometheus].
 
@@ -19,13 +19,6 @@ This section describes how to use the Prometheus monitoring system to collect, s
 ====
 include::example$prometheus-config.adoc[]
 ====
-ifeval::["{project-context}" == "che"]
-+
-Latest version: link:https://raw.githubusercontent.com/eclipse-che/che-server/{pro
-
-
-d-ver-patch}/deploy/openshift/templates/monitoring/prometheus-config.yaml[example `prometheus-config.yaml` on GitHub].
-endif::[]
 +
 <1> Rate, at which a target is scraped.
 <2> Rate, at which recording and alerting rules are re-checked (not used in the system at the moment).


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>


<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR fixes the Prometheus config explanation in the Che server monitoring doc: https://www.eclipse.org/che/docs/che-7/administration-guide/monitoring-che/#collecting-che-metrics-with-prometheus_che.

This PR also removes a broken link.

Before:
![image](https://user-images.githubusercontent.com/83611742/142692661-8d11d248-4319-4b37-942b-541a8c5c0608.png)

After:
![image](https://user-images.githubusercontent.com/83611742/142694441-116d1f04-6b6a-4b0a-89e0-943e0898e549.png)


## What issues does this pull request fix or reference?
AFAIK there are no GH issues related to this PR.

## Specify the version of the product this pull request applies to
All versions that support Che-server monitoring.

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
