### PR TITLE
chore: Adding Call publication builder workflow

### DIFF
--- a/.github/workflows/call-publication-builder.yaml
+++ b/.github/workflows/call-publication-builder.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: "Call publication builder"
+
+on:
+  push:
+    branches:
+      - "7.*.x"
+      - main
+      - master
+
+jobs:
+  call-publication-builder:
+    name: "Call publication builder"
+    uses: eclipse/che-docs/.github/workflows/publication-builder.yaml@publication-builder
+    secrets:
+      CHE_BOT_GITHUB_TOKEN: ${{ secrets.CHE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this pull request change?

Adding Call publication builder workflow in the `master` branch.

For the runs, see: https://github.com/eclipse/che-docs/actions/workflows/call-publication-builder.yaml

This workflow is already present in the `main` and `7.40.x` branches.

## What issues does this pull request fix or reference?

Scheduled workflows run on the latest commit on the default or base branch.
https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule

Therefore, the scheduled workflow on the publication-builder branch don't run.