### PR TITLE
chore: URLs changes

### DIFF
--- a/modules/end-user-guide/partials/proc_verifying-the-vs-code-extension-api-compatibility-level.adoc
+++ b/modules/end-user-guide/partials/proc_verifying-the-vs-code-extension-api-compatibility-level.adoc
@@ -5,7 +5,7 @@
 [id="verifying-the-vs-code-extension-api-compatibility-level_{context}"]
 = Verifying the VS Code extension API compatibility level
 
-Che-Theia does not fully support the VS Code extensions API. The link:https://github.com/che-incubator/vscode-theia-comparator/[vscode-theia-comparator] is used to analyze the compatibility between the Che-Theia plug-in API and the VS Code extension API. This tool runs nightly, and the results are published on the link:https://che-incubator.github.io/vscode-theia-comparator/status.html[vscode-theia-comparator] GitHub page.
+Che-Theia does not fully support the VS Code extensions API. The link:https://github.com/che-incubator/vscode-theia-comparator/[vscode-theia-comparator] is used to analyze the compatibility between the Che-Theia plug-in API and the VS Code extension API. This tool runs nightly, and the results are published on the link:https://eclipse-theia.github.io/vscode-theia-comparator/status.html[vscode-theia-comparator] GitHub page.
 
 .Prerequisites
 

--- a/modules/overview/partials/assembly_introduction-to-eclipse-che.adoc
+++ b/modules/overview/partials/assembly_introduction-to-eclipse-che.adoc
@@ -48,7 +48,7 @@ Visit StackOverflow to help other users of {prod}: link:https://stackoverflow.co
 
 Community blog::
 
-Learn about the latest of {prod} and submit your blog posts to the link:https://che.eclipse.org[{prod} blog].
+Learn about the latest of {prod} and submit your blog posts to the link:https://che.eclipseprojects.io[{prod} blog].
 
 Weekly meetings::
 

--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -18,7 +18,7 @@
           <div class="gcse-searchbox" enableAutoComplete="true"></div>
         </div>
         <a class="navbar-item" href="https://www.eclipse.org/che/">Home</a>
-        <a class="navbar-item" href="https://che.eclipse.org/">Blog</a>
+        <a class="navbar-item" href="https://che.eclipseprojects.io/">Blog</a>
         <a class="navbar-item" href="https://github.com/eclipse/che">Source Code</a>
       </div>
     </div>


### PR DESCRIPTION
## What does this pull request change?

Eclipse Che Blog URL is now https://che.eclipseprojects.io/

## What issues does this pull request fix or reference?

https://www.eclipse.org/lists/eclipse.org-committers/msg01336.html

