### PR TITLE
docs: split the User Guide into two parts

### DIFF
--- a/modules/user-guide/nav.adoc
+++ b/modules/user-guide/nav.adoc
@@ -1,13 +1,13 @@
 .User Guide
 
-//Part I
+//Part I for standard flows
 * xref:user-onboarding.adoc[]
 ** xref:starting-a-workspace.adoc[]
 *** xref:starting-a-workspace-using-the-dashboard.adoc[]
 *** xref:starting-a-workspace-using-an-url.adoc[]
 ** xref:defining-a-workspaces.adoc[]
 
-//Part II
+//Part II for alternative or advanced features
 * xref:advanced-usage.adoc
 //** xref:etc.adoc[]
 //** xref:etc.adoc[]

--- a/modules/user-guide/nav.adoc
+++ b/modules/user-guide/nav.adoc
@@ -1,7 +1,13 @@
 .User Guide
 
-* xref:starting-a-workspace.adoc[]
-** xref:starting-a-workspace-using-the-dashboard.adoc[]
-** xref:starting-a-workspace-using-an-url.adoc[]
-* xref:defining-a-workspaces.adoc[]
+//Part I
+* xref:user-onboarding.adoc[]
+** xref:starting-a-workspace.adoc[]
+*** xref:starting-a-workspace-using-the-dashboard.adoc[]
+*** xref:starting-a-workspace-using-an-url.adoc[]
+** xref:defining-a-workspaces.adoc[]
 
+//Part II
+* xref:advanced-usage.adoc
+//** xref:etc.adoc[]
+//** xref:etc.adoc[]

--- a/modules/user-guide/nav.adoc
+++ b/modules/user-guide/nav.adoc
@@ -1,13 +1,13 @@
 .User Guide
 
-//Part I for standard flows
+//Part I for UX-optimized standard flows
 * xref:user-onboarding.adoc[]
 ** xref:starting-a-workspace.adoc[]
 *** xref:starting-a-workspace-using-the-dashboard.adoc[]
 *** xref:starting-a-workspace-using-an-url.adoc[]
 ** xref:defining-a-workspaces.adoc[]
 
-//Part II for alternative or advanced features
+//Part II for advanced or alternative features not documented in Part I
 * xref:advanced-usage.adoc
 //** xref:etc.adoc[]
 //** xref:etc.adoc[]

--- a/modules/user-guide/nav.adoc
+++ b/modules/user-guide/nav.adoc
@@ -1,13 +1,13 @@
 .User Guide
 
-//Part I for UX-optimized standard flows
+//Part I for UX-optimized flows
 * xref:user-onboarding.adoc[]
 ** xref:starting-a-workspace.adoc[]
 *** xref:starting-a-workspace-using-the-dashboard.adoc[]
 *** xref:starting-a-workspace-using-an-url.adoc[]
 ** xref:defining-a-workspaces.adoc[]
 
-//Part II for advanced or alternative features not documented in Part I
+//Part II for advanced features and alternative settings not documented in Part I
 * xref:advanced-usage.adoc
 //** xref:etc.adoc[]
 //** xref:etc.adoc[]

--- a/modules/user-guide/pages/advanced-usage.adoc
+++ b/modules/user-guide/pages/advanced-usage.adoc
@@ -1,0 +1,8 @@
+:_content-type: assembly
+:description: Advanced Usage
+:keywords: advanced-use, advanced-user, advanced-users, user-guide
+:navtitle: Advanced Usage
+// :page-aliases:
+
+[id="advanced-usage_{context}"]
+= Advanced Usage

--- a/modules/user-guide/pages/user-onboarding.adoc
+++ b/modules/user-guide/pages/user-onboarding.adoc
@@ -1,0 +1,8 @@
+:_content-type: assembly
+:description: User Onboarding
+:keywords: getting-started, user-onboarding, new-user,new-users, user-guide
+:navtitle: User Onboarding
+// :page-aliases:
+
+[id="user-onboarding_{context}"]
+= User Onboarding


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Splitting the User Guide into two parts to improve user experience for docs readers:
[Part I] **User Onboarding** (for UX-optimized flows)
[Part II] **Advanced Usage** (for advanced features and alternative settings not documented in Part I)

Advantages of splitting the new _User Guide_ into the _User Onboarding_ part and the _Advanced Usage_ part:

1. Because Che is an administrator-managed solution for engineering teams, the _User Onboarding_ heading can make it clear to both the new users and their onboarding leads/buddies that this part of the _User Guide_ is explicitly expected to be used when onboarding new users.
2. The _Administration Guide_ can instruct onboarding leads/buddies to share the link to the _User Onboarding_ part of the _User Guide_ when onboarding new users.
3. Having a separate _User Onboarding_ part in the _User Guide_ will allow the link to it to be used in the UI (e.g., Dashboard) of Che.
4. For large organizations, having a separate _User Onboarding_ part in the _User Guide_ introduces the potential to fork the `che-docs` repository and customize the _User Onboarding_ part in the _User Guide_ with their organization-specific information (by customizing our procedures and/or by adding new sections). For some large organizations that have a large number of engineers, it may be worthwhile investing in maintaining their own fork of the _User Onboarding_ part of the _User Guide_. It's not entirely clear how this could work, but this is something worth keeping in mind for the future. It's a win-win scenario that can benefit both Eclipse Che and its adopters. We can mention it in the _Administration Guide_ that Che-adopting organizations are welcome to fork `che-docs` repo for this purpose (@themr0c, _Antora for Modular Documentation_?).
5. For smaller organizations, we can advise them to create a README on their sourcode repo on the specifics of their Che setup and provide the link to the _User Onboarding_ part in the _User Guide_ in the https://www.eclipse.org/che/docs/ page. This can serve as a trend to recommend to Che adopters, simplify their adoption and improve their user experience, and standardize their setup in terms of what we offer them among best practices.
6. To make the _User Guide_ easier to follow for readers, we move all the advanced features with narrower and less frequent use cases into the _Advanced Usage_ part of the _User Guide_. Who needs them will know where to look. Who wants more out of their Che will know where to look.
7. Having a separate User Onboarding part in the User Guide can facilitate customer feedback on our docs: if some admin believes the onboarding part of the user guide is missing something or something is incorrect (because it impacts their onboarding user experience), they may be more likely to open a bug or provide some sort of feedback because they will have clearer expectations for the content of the explicit user onboarding part and be more aware of their needs regarding that part of the user guide. The increased likelihood of customer feedback can give the docs team more information about customer needs and enable the docs team to respond and improve the docs in the direction of user onboarding thanks to the provided customer feedback.

## What issues does this pull request fix or reference?
RHDEVDOCS-3501
RHDEVDOCS-3505

## Specify the version of the product this pull request applies to
N/A

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
