### PR TITLE
chore: flag master as a prerelease

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -3,6 +3,7 @@ name: docs
 title: Documentation
 version: next
 display_version: next
+prerelease: true
 start_page: overview:introduction-to-eclipse-che.adoc
 nav:
   - modules/overview/nav.adoc


### PR DESCRIPTION
Flag master branch as a prerelease to request robots to skip indexation (with a robots noindex meta tag).


All pages published from the master branch will have this meta tag:

```
<meta name="robots" content="noindex">
```

Crawlers should stop indexing them.

See also: https://github.com/eclipse/che-docs/commit/003343c47780d6cf10e2fd9e5f939fab8e42965e