### PR TITLE
chore: enable container update

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ const { parallel, series, src, watch } = require('gulp')
 const yaml = require('js-yaml')
 
 const playbookFilename = 'antora-playbook-for-development.yml'
-const playbook = yaml.safeLoad(fs.readFileSync(playbookFilename, 'utf8'))
+const playbook = yaml.load(fs.readFileSync(playbookFilename, 'utf8'))
 const outputDir = (playbook.output || {}).dir || './build/site'
 const serverConfig = { name: 'Preview Site', livereload, host: '0.0.0.0', port: 4000, root: outputDir }
 const antoraArgs = ['--playbook', playbookFilename]


### PR DESCRIPTION
Fix following error, to enable che-docs container update:

```
Error: Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.
```