### PR TITLE
chore: location for eclipse-che/che-docs-vale-style

### DIFF
--- a/tools/get_vale_styles.sh
+++ b/tools/get_vale_styles.sh
@@ -15,4 +15,4 @@ set -e
 cd .vale/styles || exit
 rm -rf RedHat CheDocs 
 wget -qO- https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/RedHat.zip | unzip -q -
-wget -qO- https://github.com/redhat-documentation/CheDocs/releases/latest/download/CheDocs.zip | unzip -q -
+wget -qO- https://github.com/eclipse-che/che-docs-vale-style/releases/latest/download/CheDocs.zip | unzip -q -


### PR DESCRIPTION
New location: https://github.com/eclipse-che/che-docs-vale-style