### PR TITLE
fix: duplicate include

### DIFF
--- a/antora-playbook-for-development.yml
+++ b/antora-playbook-for-development.yml
@@ -10,7 +10,7 @@ content:
   sources:
     - url: ./
       branches: HEAD
-      edit_url: "https://github.com/eclipse/che-docs/edit/master/{path}"
+      edit_url: "https://github.com/eclipse-che/che-docs/edit/master/{path}"
 antora:
   extensions:
     - require: "@antora/lunr-extension"

--- a/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
+++ b/modules/administration-guide/partials/assembly_configuring-server-logging.adoc
@@ -7,7 +7,7 @@
 
 It is possible to fine-tune the log levels of individual loggers available in the {prod-short} server.
 
-The log level of the whole {prod-short} server is configured globally using the xref:installation-guide:configuring-the-che-installation.adoc#checluster-custom-resources-fields-reference_{context}[`cheLogLevel` configuration property] of the Operator.
+The log level of the whole {prod-short} server is configured globally using the `cheLogLevel` configuration property of the Operator. See xref:installation-guide:checluster-custom-resource-fields-reference.adoc[]. 
 To set the global log level in installations not managed by the Operator, specify the `CHE_LOG_LEVEL` environment variable in the `che`
 ConfigMap.
 

--- a/modules/installation-guide/nav.adoc
+++ b/modules/installation-guide/nav.adoc
@@ -4,10 +4,13 @@
 
 * xref:configuring-the-che-installation.adoc[]
 
+** xref:understanding-the-checluster-custom-resource.adoc[]
 ** xref:using-the-openshift-web-console-to-configure-the-checluster-custom-resource-during-installation.adoc[]
 ** xref:using-the-openshift-web-console-to-configure-the-checluster-custom-resource.adoc[]
 ** xref:using-chectl-to-configure-the-checluster-custom-resource-during-installation.adoc[]
 ** xref:using-cli-to-configure-the-checluster-custom-resource.adoc[]
+** xref:checluster-custom-resource-fields-reference.adoc[]
+
 
 * xref:installing-che.adoc[]
 

--- a/modules/installation-guide/pages/checluster-custom-resource-fields-reference.adoc
+++ b/modules/installation-guide/pages/checluster-custom-resource-fields-reference.adoc
@@ -1,0 +1,7 @@
+[id="checluster-custom-resource-fields-reference"]
+// = `CheCluster` Custom Resource fields reference
+:navtitle: `CheCluster` Custom Resource fields reference
+:keywords: installation-guide, configuring-the-che-installation, configuring-che
+// :page-aliases: 
+
+include::partial$ref_checluster-custom-resource-fields-reference.adoc[]

--- a/modules/installation-guide/pages/understanding-the-checluster-custom-resource.adoc
+++ b/modules/installation-guide/pages/understanding-the-checluster-custom-resource.adoc
@@ -1,0 +1,7 @@
+[id="understanding-the-checluster-custom-resource"]
+// = Understanding the `CheCluster` Custom Resource
+:navtitle: Understanding the `CheCluster` Custom Resource
+:keywords: installation-guide, configuring-the-che-installation, configuring-che
+// :page-aliases: 
+
+include::partial$con_understanding-the-checluster-custom-resource.adoc[]

--- a/modules/installation-guide/partials/assembly_configuring-the-che-installation.adoc
+++ b/modules/installation-guide/partials/assembly_configuring-the-che-installation.adoc
@@ -18,17 +18,16 @@ ifeval::["{project-context}" == "che"]
 
 endif::[]
 
-include::partial$con_understanding-the-checluster-custom-resource.adoc[leveloffset=+1]
 
-include::partial$proc_using-the-openshift-web-console-to-configure-the-checluster-custom-resource-during-installation.adoc[leveloffset=+1]
+.Additional resources
 
-include::partial$proc_using-the-openshift-web-console-to-configure-the-checluster-custom-resource.adoc[leveloffset=+1]
+* xref:understanding-the-checluster-custom-resource.adoc[]
+* xref:using-the-openshift-web-console-to-configure-the-checluster-custom-resource-during-installation.adoc[]
+* xref:using-the-openshift-web-console-to-configure-the-checluster-custom-resource.adoc[]
+* xref:using-chectl-to-configure-the-checluster-custom-resource-during-installation.adoc[]
+* xref:using-the-cli-to-configure-the-checluster-custom-resource.adoc[]
+* xref:checluster-custom-resource-fields-reference.adoc[]
 
-include::partial$proc_using-chectl-to-configure-the-checluster-custom-resource-during-installation.adoc[leveloffset=+1]
-
-include::partial$proc_using-the-cli-to-configure-the-checluster-custom-resource.adoc[leveloffset=+1]
-
-include::partial$ref_checluster-custom-resource-fields-reference.adoc[leveloffset=+1]
 
 :context: {parent-context-of-configuring-the-che-installation}
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change

Fix duplicate include. Downstream doesn't accept it.

## What issues does this pull request fix or reference


```
asciidoctor: WARNING: topics/crw/installation-guide/proc_using-the-openshift-web-console-to-configure-the-checluster-custom-resource-during-installation.adoc: line 3: id assigned to section already in use: using-the-openshift-web-console-to-configure-the-checluster-custom-resource-during-installation_crw
asciidoctor: WARNING: topics/crw/installation-guide/proc_using-the-openshift-web-console-to-configure-the-checluster-custom-resource.adoc: line 3: id assigned to section already in use: using-the-openshift-web-console-to-configure-the-checluster-custom-resource_crw
asciidoctor: WARNING: topics/crw/installation-guide/proc_using-chectl-to-configure-the-checluster-custom-resource-during-installation.adoc: line 3: id assigned to section already in use: using-crwctl-to-configure-the-checluster-custom-resource-during-installation_crw

```

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
