### PR TITLE
docs: changing prod-url value in antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -90,7 +90,7 @@ asciidoc:
     prod-operator: che-operator
     prod-short: Che
     prod-upstream: Eclipse{nbsp}Che
-    prod-url: https://__<che_fqdn>__
+    prod-url: "https://__&lt;che_fqdn&gt;__"
     prod-workspace: che-ws
     prod: Eclipse&#160;Che
     prod2: Eclipse&#160;Che

--- a/antora.yml
+++ b/antora.yml
@@ -90,7 +90,7 @@ asciidoc:
     prod-operator: che-operator
     prod-short: Che
     prod-upstream: Eclipse{nbsp}Che
-    prod-url: "https://__&lt;che_fqdn&gt;__"
+    prod-url: https://<i><</i><i>che_fqdn</i><i>></i>
     prod-workspace: che-ws
     prod: Eclipse&#160;Che
     prod2: Eclipse&#160;Che

--- a/antora.yml
+++ b/antora.yml
@@ -104,7 +104,7 @@ asciidoc:
     prod-operator: che-operator
     prod-short: Che
     prod-upstream: Eclipse{nbsp}Che
-    prod-url: https://che-host:che-port
+    prod-url: https://__<che_fqdn>__
     prod-workspace: che-ws
     prod: Eclipse&#160;Che
     prod2: Eclipse&#160;Che


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change
Based on today's discussion with Fabrice and Ilya, changing the upstream value for the `prod-url` variable from `https://che-host:che-port` to `https://__<che_fqdn>__`.

## What issues does this pull request fix or reference

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
