### PR TITLE
docs: set telemetry backend-base version to 0.0.32

### DIFF
--- a/modules/extensions/examples/telemetry/pom_snippet.xml
+++ b/modules/extensions/examples/telemetry/pom_snippet.xml
@@ -1,7 +1,7 @@
 <dependency>
     <groupId>org.eclipse.che.incubator.workspace-telemetry</groupId>
     <artifactId>backend-base</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.32</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
+++ b/modules/extensions/partials/proc_creating-a-telemetry-plugin.adoc
@@ -74,7 +74,7 @@ $ mvn io.quarkus:quarkus-maven-plugin:1.2.1.Final:create \
 
 pass:[<!-- vale RedHat.TermsErrors = YES -->]
 
-. Add a dependency to `org.eclipse.che.incubator.workspace-telemetry.back-end-base` in your `pom.xml`:
+. Add a dependency to `org.eclipse.che.incubator.workspace-telemetry:backend-base` in your `pom.xml`:
 +
 .`pom.xml`
 ====
@@ -86,7 +86,7 @@ include::example$telemetry/pom_snippet.xml[]
 
 . Add the Apache HTTP components library to send HTTP requests.
 
-. Consult the link:https://github.com/che-incubator/che-workspace-telemetry-client/packages[GitHub packages] for the latest version and Maven coordinates of `back-end-base`. link:https://help.github.com/en/packages/publishing-and-managing-packages/about-github-packages[GitHub packages] require a personal access token with `read:packages` permissions to download the {prod-short} telemetry libraries. Create a personal access token and copy the token value.
+. Create a GitHub personal access token with `read:packages` permissions and copy the token value. This token is used to access link:https://help.github.com/en/packages/publishing-and-managing-packages/about-github-packages[GitHub packages] to download the {prod-short} telemetry library.
 
 . Create a `settings.xml` file in the repository root and add the coordinates and token to the `che-incubator` packages:
 +


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change
This is a small PR that updates the version for the `org.eclipse.che.incubator.workspace-telemetry:backend-base` dependency.

## What issues does this pull request fix or reference
Related to https://github.com/eclipse/che/issues/20820, however, a larger PR will come soon.

## Specify the version of the product this pull request applies to
Any version that supports che-theia workspace telemetry.

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
