### PR TITLE
docs: changing prod-url value in antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -95,7 +95,7 @@ asciidoc:
     prod-prev-ver: "previous minor version"
     prod-short: Che
     prod-upstream: Eclipse{nbsp}Che
-    prod-url: https://che-host:che-port
+    prod-url: "https://__&lt;che_fqdn&gt;__"
     prod-ver-major: "7"
     prod-ver-patch: main
     prod-ver: main

--- a/modules/end-user-guide/partials/proc_using-a-badge-with-a-link-to-enable-a-first-time-contributor-to-start-a-workspace.adoc
+++ b/modules/end-user-guide/partials/proc_using-a-badge-with-a-link-to-enable-a-first-time-contributor-to-start-a-workspace.adoc
@@ -8,11 +8,11 @@ image::https://www.eclipse.org/che/contribute.svg[Factory badge]
 
 .Procedure
 
-. Substitute your URL and repository, and add the link to your repository in the project `README.md` file.
+. Substitute your {prod-short} URL (`pass:c,a,q[{prod-url}]`) and repository URL (`__<your-repository-url>__`), and add the link to your repository in the project `README.md` file.
 +
-[subs="+attributes"]
+[subs="+attributes,+macros,+quotes"]
 ----
-[![Contribute](https://www.eclipse.org/che/contribute.svg)]({prod-url}/#https://__<your-repository-url>__)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](pass:c,a,q[{prod-url}]/#https://__<your-repository-url>__)
 ----
 
 . The `README.md` file in your Git provider web interface displays the image:https://www.eclipse.org/che/contribute.svg[Factory badge] factory badge. Click the badge to open a workspace with your project in your {prod-short} instance.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change

docs: changing prod-url value in antora.yml

## What issues does this pull request fix or reference

https://github.com/eclipse-che/che-docs/pull/2224 for master branch

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
