### PR TITLE
docs: Update docs on collecting logs using chectl

### DIFF
--- a/modules/administration-guide/pages/collecting-logs-using-chectl.adoc
+++ b/modules/administration-guide/pages/collecting-logs-using-chectl.adoc
@@ -5,11 +5,38 @@
 [id="collecting-logs-using-{prod-cli}_{context}"]
 = Collecting logs using {prod-cli}
 
+An installation of {prod} consists of several containers running in the {orch-name} cluster. While it is possible to manually collect logs from each running container, `{prod-cli}` provides commands which automate the process.
+
 Following commands are available to collect {prod} logs from the {orch-name} cluster using the `{prod-cli}` tool:
 
-`{prod-cli} server:deploy`:: 
-Automatically starts collecting logs during {prod-short} installation.
-
 `{prod-cli} server:logs`:: 
-Collects existing {prod} server logs.
+Collects existing {prod} server logs and stores them in a directory on the local machine. By default, logs are downloaded to a temporary directory on the machine. However, this can be overwritten by specifying the `-d` parameter. For example, to download Che logs to the `/home/user/che-logs/` directory, use the command
++
+[source,shell,subs="+attributes"]
+----
+{prod-cli} server:logs -d /home/user/che-logs/
+----
++
+When run, `{prod-cli} server:logs` prints a message in the console specifying the directory that will store the log files:
++
+[subs="+attributes"]
+----
+{prod} logs will be available in '/tmp/chectl-logs/1648575098344'
+----
++
+If {prod} is installed in a non-default {orch-namespace}, `{prod-cli} server:logs` requires the `-n <NAMESPACE>` paremeter, where `<NAMESPACE>` is the {platforms-namespace} in which {prod} was installed. For example, to get logs from {prod-short} in the `my-namespace` {orch-namespace}, use the command
++
+[source,shell,subs="+attributes"]
+----
+{prod-cli} server:logs -n my-namespace
+----
 
+`{prod-cli} server:deploy`:: 
+Logs are automatically collected during the {prod-short} installation when installed using `{prod-cli}`. As with `{prod-cli} server:logs`, the directory logs are stored in can be specified using the `-d` parameter.
+
+
+ifeval::["{project-context}" == "che"]
+.Additional resources
+
+* See: link:https://github.com/che-incubator/{prod-cli}/#chectl-serverlogs[`{prod-cli}` reference documentation].
+endif::[]


### PR DESCRIPTION
Redo of https://github.com/eclipse-che/che-docs/pull/2260 since I accidentally pushed zero commits into the branch.

<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change
Updates/extends instructions on retrieving Che logs using `chectl server:logs`

## What issues does this pull request fix or reference
Part of https://github.com/eclipse/che/issues/21283

## Specify the version of the product this pull request applies to
Applicable to all supported versions, fine for 7.45/next

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
