### PR TITLE
fix: devworkspace operator metrics docs

### DIFF
--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -45,8 +45,8 @@ metadata:
   name: devworkspace-controller-metrics-binding
 subjects:
   - kind: ServiceAccount
-    name: __<ServiceAccount name>__           <1>
-    namespace: __<Prometheus {orch-namespace}>__     <2>
+    name: __<ServiceAccount_name>__ <1>
+    namespace: __<Prometheus_{orch-namespace}>__ <2>
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -6,7 +6,9 @@ This section describes how to use the Prometheus to collect, store, and query me
 
 .Prerequisites
 
-* The `devworkspace-controller-metrics` service and `devworkspace-webhookserver` service is exposing metrics on port `8443` and `9443` respecitvely. This is the default configuration.
+* The default configuration is set:
+** The `devworkspace-controller-metrics` service is exposing metrics on port `8443`.
+** The `devworkspace-webhookserver` service is exposing metrics on `9443`. 
 
 * Prometheus 2.26.0 or later is running. The Prometheus console is running on port `9090` with a corresponding *service* and *route*. See link:https://prometheus.io/docs/introduction/first_steps/[First steps with Prometheus].
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -91,7 +91,7 @@ data:
           tls_config:
             insecure_skip_verify: true
           static_configs:
-            - targets: ['__<devworkspace-webhookserver service host>__:9443']  <5>
+            - targets: ['__<devworkspace-webhookserver_service_host>__:9443']  <5>
 ----
 
 <1> Rate at which a target is scraped.

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -82,7 +82,7 @@ data:
           tls_config:
             insecure_skip_verify: true
           static_configs:
-            - targets: ['__<devworkspace-controller-metrics service host>__:8443']  <4>
+            - targets: ['__<devworkspace-controller-metrics_service_host>__:8443']  <4>
         - job_name: 'DevWorkspace webhooks'
           scheme: https
           authorization:

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -6,9 +6,7 @@ This section describes how to use the Prometheus to collect, store, and query me
 
 .Prerequisites
 
-* The link:https://github.com/devfile/devworkspace-operator/blob/v0.10.0/deploy/deployment/kubernetes/objects/devworkspace-controller-metrics.Service.yaml[`devworkspace-controller-metrics` service] is exposing metrics on port `8443`.
-
-* The `devworkspace-webhookserver` service is exposing metrics on port `9443`. By default, the service exposes metrics on port `9443`.
+* The `devworkspace-controller-metrics` service and `devworkspace-webhookserver` service is exposing metrics on port `8443` and `9443` respecitvely. This is the default configuration.
 
 * Prometheus 2.26.0 or later is running. The Prometheus console is running on port `9090` with a corresponding *service* and *route*. See link:https://prometheus.io/docs/introduction/first_steps/[First steps with Prometheus].
 
@@ -37,7 +35,7 @@ rules:
 +
 .ClusterRoleBinding example
 ====
-[source,yaml,subs="+attributes"]
+[source,yaml,subs="+quotes,+attributes,+macros"]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -45,20 +43,24 @@ metadata:
   name: devworkspace-controller-metrics-binding
 subjects:
   - kind: ServiceAccount
-    name: <ServiceAccount name associated with the Prometheus Pod>
-    namespace: <Prometheus namespace>
+    name: __<ServiceAccount name>__           <1>
+    namespace: __<Prometheus {orch-namespace}>__     <2>
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: devworkspace-controller-metrics-reader
 ----
+
+<1> Name of the ServiceAccount associated with the Prometheus Pod.
+<2> The {orch-namespace} in which Prometheus is running in.
+
 ====
 
 . Configure Prometheus to scrape metrics from the `8443` port exposed by the `devworkspace-controller-metrics` service, and `9443` port exposed by the `devworkspace-webhookserver` service.
 +
 .Prometheus configuration example
 ====
-[source,yaml,subs="+attributes"]
+[source,yaml,subs="+quotes,+attributes,+macros"]
 ----
 apiVersion: v1
 kind: ConfigMap
@@ -71,29 +73,32 @@ data:
         evaluation_interval: 5s             <2>
       scrape_configs:                       <3>
         - job_name: 'DevWorkspace'
+          scheme: https
           authorization:
             type: Bearer
             credentials_file: '/var/run/secrets/kubernetes.io/serviceaccount/token'
           tls_config:
             insecure_skip_verify: true
           static_configs:
-            - targets: ['devworkspace-controller-metrics:8443']  <4>
+            - targets: ['__<devworkspace-controller-metrics service host>__:8443']  <4>
         - job_name: 'DevWorkspace webhooks'
+          scheme: https
           authorization:
             type: Bearer
             credentials_file: '/var/run/secrets/kubernetes.io/serviceaccount/token'
           tls_config:
             insecure_skip_verify: true
           static_configs:
-            - targets: ['devworkspace-webhookserver:9443']  <5>
+            - targets: ['__<devworkspace-webhookserver service host>__:9443']  <5>
 ----
-====
 
 <1> Rate at which a target is scraped.
 <2> Rate at which recording and alerting rules are re-checked.
 <3> Resources that Prometheus monitors. In the default configuration, two jobs (`DevWorkspace` and `DevWorkspace webhooks`), scrape the time series data exposed by the `devworkspace-controller-metrics` and `devworkspace-webhookserver` services.
 <4> Scrape metrics from the `8443` port.
 <5> Scrape metrics from the `9443` port.
+
+====
 
 .Verification steps
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -54,7 +54,7 @@ roleRef:
 ----
 
 <1> Name of the `ServiceAccount` associated with the Prometheus Pod.
-<2> The {orch-namespace} in which Prometheus is running in.
+<2> The {orch-namespace} in which Prometheus is running.
 
 ====
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -53,7 +53,7 @@ roleRef:
   name: devworkspace-controller-metrics-reader
 ----
 
-<1> Name of the ServiceAccount associated with the Prometheus Pod.
+<1> Name of the `ServiceAccount` associated with the Prometheus Pod.
 <2> The {orch-namespace} in which Prometheus is running in.
 
 ====

--- a/modules/administration-guide/partials/proc_viewing-dev-workspace-operator-metrics-on-grafana-dashboards.adoc
+++ b/modules/administration-guide/partials/proc_viewing-dev-workspace-operator-metrics-on-grafana-dashboards.adoc
@@ -2,7 +2,7 @@
 = Viewing {devworkspace} operator metrics on Grafana dashboards
 
 This section describes how to view {devworkspace} operator metrics on Grafana with the example dashboard.
-Grafana version 7.x.x is required to support all panels in the example dashboard.
+Grafana version 7 or later is required to support all panels in the example dashboard.
 
 .Prerequisites
 

--- a/modules/administration-guide/partials/proc_viewing-dev-workspace-operator-metrics-on-grafana-dashboards.adoc
+++ b/modules/administration-guide/partials/proc_viewing-dev-workspace-operator-metrics-on-grafana-dashboards.adoc
@@ -2,7 +2,7 @@
 = Viewing {devworkspace} operator metrics on Grafana dashboards
 
 This section describes how to view {devworkspace} operator metrics on Grafana with the example dashboard.
-Grafana version 7.5.3 or later is required to support all panels in the example dashboard.
+Grafana version 7.x.x is required to support all panels in the example dashboard.
 
 .Prerequisites
 


### PR DESCRIPTION

<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Fixes the devworkspace-operator monitoring docs prometheus config files.

## What issues does this pull request fix or reference?
References https://github.com/eclipse/che/issues/21283

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
