### PR TITLE
fix: docs.github.com new URLs, mitigation for 403

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -18,6 +18,7 @@ CacheExpires: "12h" # Default is 2 weeks.
 ExternalTimeout: 60 # (seconds) default is 15.
 IgnoreURLs:
   - https://cse.google.com/cse.js
+  - https://docs.github.com/en/*
   - https://marketplace.visualstudio.com
   - https://github.com/eclipse-che/che-docs/edit/master/
   - https://www.eclipse.org/che/docs/che-7/

--- a/modules/administration-guide/pages/creating-a-telemetry-plugin.adoc
+++ b/modules/administration-guide/pages/creating-a-telemetry-plugin.adoc
@@ -92,7 +92,7 @@ include::example$creating-a-telemetry-plug-in/pom_snippet.xml[]
 ----
 ====
 
-. Create a personal access token with `read:packages` permissions to download the `org.eclipse.che.incubator.workspace-telemetry:backend-base` dependency from link:https://help.github.com/en/packages/publishing-and-managing-packages/about-github-packages[GitHub packages].
+. Create a personal access token with `read:packages` permissions to download the `org.eclipse.che.incubator.workspace-telemetry:backend-base` dependency from link:https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages[GitHub packages].
 
 . Add your GitHub username, personal access token and `che-incubator` repository details in your `~/.m2/settings.xml` file:
 +

--- a/modules/hosted-che/partials/proc_adding-the-action-to-a-github-repository-workflow.adoc
+++ b/modules/hosted-che/partials/proc_adding-the-action-to-a-github-repository-workflow.adoc
@@ -20,7 +20,7 @@ This section describes how to integrate the Try in Web IDE GitHub action to a Gi
 +
 include::example$snip_github-action-yaml-example.adoc[]
 This code snippet creates a workflow named `Try in Web IDE example`, with a job that runs the `v1` version of the `redhat-actions/try-in-web-ide` community action.
-The workflow is triggered on the link:https://docs.github.com/en/actions/reference/events-that-trigger-workflows[`pull_request_target` event],
+The workflow is triggered on the link:https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows[`pull_request_target` event],
  on the `opened` activity type.
 
 . Optionally configure the activity types from the `on.pull_request_target.types` field to customize when workflow trigger. Activity types such as `reopened` and `synchronize` can be useful.

--- a/modules/hosted-che/partials/proc_contributing-to-github-projects-in-hosted-che.adoc
+++ b/modules/hosted-che/partials/proc_contributing-to-github-projects-in-hosted-che.adoc
@@ -17,4 +17,4 @@ This section describes how to contribute to GitHub projects from Eclipse Che hos
 
 . Generate an SSH key pair with the link:https://github.com/eclipse-che/che-theia/tree/master/plugins/ssh-plugin[SSH Plug-in].
 
-. Upload the public key to the GitHub account. For details, see the link:https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account[Adding a new SSH key to your GitHub account] procedure.
+. Upload the public key to the GitHub account. For details, see the link:https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account[Adding a new SSH key to your GitHub account] procedure.


### PR DESCRIPTION


## What does this pull request change

* New URLs for docs.github.com links.
* `htmltest` skips docs.github.com returning 403 errors.

## What issues does this pull request fix or reference

* docs.github.com is returning 403 errors to CLI tools such as `curl` and `htmltest` 


## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
