### PR TITLE
docs: Installation guide supported platforms

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -42,7 +42,7 @@ asciidoc:
     image-puller-operator-name: Kubernetes Image Puller Operator
     image-puller-operator-repository-name: kubernetes-image-puller-operator
     image-puller-repository-name: kubernetes-image-puller
-    kube-ver-min: "1.19"
+    kube-ver-min: "1.21"
     kubernetes: Kubernetes
     link-oauth2-proxy: link:https://github.com/oauth2-proxy/oauth2-proxy[OAuth2 Proxy]
     link-kube-rbac-proxy: link:https://github.com/brancz/kube-rbac-proxy[kube-rbac-proxy]

--- a/modules/administration-guide/examples/ref_che-supported-platforms-and-installation-methods.adoc
+++ b/modules/administration-guide/examples/ref_che-supported-platforms-and-installation-methods.adoc
@@ -2,63 +2,27 @@
 //
 // supported_platforms
 
-The following section provides information about the availability of {prod-short} {prod-ver} on {platforms-name} infrastructures, and about their supported installation methods.
+The following section provides information about the availability of {prod-short} {prod-ver} on {platforms-name} infrastructures.
 
 {prod} can be installed on:
 
 * {kubernetes} infrastructures starting at version {kube-ver-min}
-* {ocp} versions 3.11, 4.3, and 4.4
+* {ocp} starting at version 4.8
 
-The following options are available:
+{prod} can be installed on all major Public Clouds such as:
 
-.Local installation on {kubernetes}
-[options="header",cols="2*.^"]
-|===
-|{kubernetes}
-|Installation method
-
-a|* `minikube`
-* `microk8s`
-* `docker-desktop`
-* `kind`
-|`{prod-cli}` using the Operator
-|===
-
-.Local installation on OpenShift
-[options="header",cols="2,2"]
-|===
-|{ocp}
-|Installation method
-
-|CodeReady Containers
-|OperatorHub
-|===
-
-.Public cloud installation on {platforms-name}
-[options="header",cols="25,25,25,25"]
-|===
-|
-|{kubernetes} +
-{kube-ver-min} or higher
-|{ocp} +
-3.11
-|{ocp} +
-4.3 and 4.4
-
-a|* Microsoft Azure
 * Amazon Web Services
 * Google Cloud
 * IBM Cloud
-.^|`{prod-cli}` using the Operator
-.^|`{prod-cli}` using the Operator
-.^|OperatorHub
-|===
+* Microsoft Azure
+* Rancher
 
-It is possible to use the `{prod-cli}` utility for deploying {prod-short} on {ocp} version 4.3 and 4.4. This method is considered unofficial and serves as a backup installation method for situations where installation using OperatorHub is not available.
+WARNING: Setting up link:https://kubernetes.io/docs/reference/access-authn-authz/authentication/[Users' Authentication] is required for deploying {prod-short} on {kubernetes} infrastructures. For {ocp} no additional setup is needed.
 
-////
-Starting with the {prod-short} version 7.14, the `{prod-cli}` acts as secondary supported and official installation method that serves also as an backup installation method for situations where the installation method using OperatorHub is not available.
-////
+The following options are available for the local installation:
+
+* link:https://minikube.sigs.k8s.io/docs/[minikube]
+* link:https://developers.redhat.com/products/codeready-containers/overview[CodeReady Containers]
 
 .Additional resources
 


### PR DESCRIPTION
## What does this pull request change

- bump minimal kube version to 1.21 (used in OpenShift 4.8)
- remove the installation methods from the supported platforms
- add a warning about Users' Authentication setup req for vanilla k8s
- list cloud providers alphabetically

 Installation guide supported platforms

![image](https://user-images.githubusercontent.com/1461122/163220362-c75d0a28-e133-40c3-a1e0-7dd9bc4c9fae.png)


## What issues does this pull request fix or reference

part of https://github.com/eclipse/che/issues/21284

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
