### PR TITLE
Allow devs to choose between docker and podman when running preview script

### DIFF
--- a/tools/runnerpreview.sh
+++ b/tools/runnerpreview.sh
@@ -9,18 +9,20 @@
 #
 
 # Detect available runner
-if command -v podman > /dev/null
-  then RUNNER=podman
-elif command -v docker > /dev/null
-  then RUNNER=docker
-else echo "No installation of podman or docker found in the PATH" ; exit 1
+if [ -z ${RUNNER+x} ]; then 
+  if command -v podman > /dev/null 
+    then RUNNER=podman
+  elif command -v docker > /dev/null
+    then RUNNER=docker
+  else echo "No installation of podman or docker found in the PATH" ; exit 1
+  fi
 fi
 
 # Fail on errors
 set -e
 
 # Pull the image unless using a container defined in environment variable
-[ -z ${CHE_DOCS_IMAGE} ] && ${RUNNER} pull quay.io/eclipse/che-docs
+[ -z "${CHE_DOCS_IMAGE}" ] && ${RUNNER} pull quay.io/eclipse/che-docs
 
 # Display commands
 set -x


### PR DESCRIPTION
## What does this pull request change

It allow a developer to specify the RUNNER of the preview script like this:

```bash
RUNNER=docker ./tools/runnerpreview.sh
```

## What issues does this pull request fix or reference

If both `docker` and `podman` are installed there is no way to specify which one I want to use (except patching the script).

## Specify the version of the product this pull request applies to

N/A

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [x] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [x] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [x] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
