### PR TITLE
fix: 3-subscribe.sh script

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -68,6 +68,7 @@ asciidoc:
     prod-checluster: eclipse-che
     prod-cli: chectl
     prod-deployment: che
+    prod-subscription: eclipse-che
     prod-docs-url: https://www.eclipse.org/che/docs
     prod-docs-url-backup-recovery: link:https://www.eclipse.org/che/docs/che-7/administration-guide/backup-and-recovery/[Backup and recovery]
     prod-docs-url-enable-oauth: link:https://www.eclipse.org/che/docs/che-7/administration-guide/configuring-openshift-oauth/[Configuring OpenShift OAuth]

--- a/modules/administration-guide/attachments/migration/3-subscribe.sh
+++ b/modules/administration-guide/attachments/migration/3-subscribe.sh
@@ -5,6 +5,7 @@ set -o pipefail
 
 K8S_CLI=${K8S_CLI:-oc}                                                           # {orch-cli}
 PRODUCT_ID=${PRODUCT_ID:-eclipse-che}                                            # {prod-id}
+PRODUCT_SUBSCRIPTION_NAME=${PRODUCT_SUBSCRIPTION_NAME:-eclipse-che}              # {prod-subscription}
 INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-eclipse-che}                    # {prod-namespace}
 CHE_CLUSTER_CR_NAME=${CHE_CLUSTER_CR_NAME:-eclipse-che}                          # {prod-checluster}
 
@@ -16,20 +17,20 @@ PRODUCT_OPERATOR_NAME=${PRODUCT_OPERATOR_NAME:-che-operator}                    
 IDENTITY_PROVIDER_DEPLOYMENT_NAME=${IDENTITY_PROVIDER_DEPLOYMENT_NAME:-keycloak} # {identity-provider-id}
 
 deleteOperatorCSV() {
-    if "${K8S_CLI}" get subscription "${PRODUCT_ID}" -n "${INSTALLATION_NAMESPACE}" > /dev/null 2>&1 ; then
+    if "${K8S_CLI}" get subscription "${PRODUCT_SUBSCRIPTION_NAME}" -n "${INSTALLATION_NAMESPACE}" > /dev/null 2>&1 ; then
         echo "[INFO] Deleting operator cluster service version."
-        "${K8S_CLI}" delete csv "$("${K8S_CLI}" get subscription "${PRODUCT_ID}" -n "${INSTALLATION_NAMESPACE}" -o jsonpath="{.status.currentCSV}")" -n "${INSTALLATION_NAMESPACE}"
+        "${K8S_CLI}" delete csv "$("${K8S_CLI}" get subscription "${PRODUCT_SUBSCRIPTION_NAME}" -n "${INSTALLATION_NAMESPACE}" -o jsonpath="{.status.currentCSV}")" -n "${INSTALLATION_NAMESPACE}"
     else
-        echo "[INFO] Skipping CSV deletion. No ${PRODUCT_ID} operator subscription found."
+        echo "[INFO] Skipping CSV deletion. No ${PRODUCT_SUBSCRIPTION_NAME} operator subscription found."
     fi
 }
 
 deleteOperatorSubscription() {
-    if "${K8S_CLI}" get subscription "${PRODUCT_ID}" -n "${INSTALLATION_NAMESPACE}" > /dev/null 2>&1 ; then
-        echo "[INFO] Deleting ${PRODUCT_ID} operator subscription."
-        "${K8S_CLI}" delete subscription "${PRODUCT_ID}" -n "${INSTALLATION_NAMESPACE}"
+    if "${K8S_CLI}" get subscription "${PRODUCT_SUBSCRIPTION_NAME}" -n "${INSTALLATION_NAMESPACE}" > /dev/null 2>&1 ; then
+        echo "[INFO] Deleting ${PRODUCT_SUBSCRIPTION_NAME} operator subscription."
+        "${K8S_CLI}" delete subscription "${PRODUCT_SUBSCRIPTION_NAME}" -n "${INSTALLATION_NAMESPACE}"
     else
-        echo "[INFO] Skipping subscription deletion as no ${PRODUCT_ID} operator subscription was found."
+        echo "[INFO] Skipping subscription deletion as no ${PRODUCT_SUBSCRIPTION_NAME} operator subscription was found."
         echo "[INFO] Deleting the ${PRODUCT_ID} operator deployment instead."
         "${K8S_CLI}" delete deployment "${PRODUCT_OPERATOR_NAME}" -n "${INSTALLATION_NAMESPACE}"
     fi

--- a/modules/administration-guide/pages/upgrading-che-7-41-on-openshift.adoc
+++ b/modules/administration-guide/pages/upgrading-che-7-41-on-openshift.adoc
@@ -22,15 +22,16 @@ The workspace engine and authentication system used until version {prod-last-ver
 +
 [source,bash,subs="+attributes"]
 ----
-INSTALLATION_NAMESPACE={prod-namespace} #<1>
-PRODUCT_DEPLOYMENT_NAME={prod-deployment}
-PRODUCT_OPERATOR_NAME={prod-operator}
-PRODUCT_ID={prod-id}
-CHE_CLUSTER_CR_NAME={prod-checluster}
-IDENTITY_PROVIDER_DEPLOYMENT_NAME={identity-provider-id}
-OLM_STABLE_CHANNEL={prod-stable-channel}
-OLM_CATALOG_SOURCE={prod-stable-channel-catalog-source}
-OLM_PACKAGE={prod-stable-channel-package}
+export INSTALLATION_NAMESPACE={prod-namespace} #<1>
+export PRODUCT_DEPLOYMENT_NAME={prod-deployment}
+export PRODUCT_SUBSCRIPTION_NAME={prod-subscription}
+export PRODUCT_OPERATOR_NAME={prod-operator}
+export PRODUCT_ID={prod-id}
+export CHE_CLUSTER_CR_NAME={prod-checluster}
+export IDENTITY_PROVIDER_DEPLOYMENT_NAME={identity-provider-id}
+export OLM_STABLE_CHANNEL={prod-stable-channel}
+export OLM_CATALOG_SOURCE={prod-stable-channel-catalog-source}
+export OLM_PACKAGE={prod-stable-channel-package}
 ----
 <1> Adapt to the {orch-namespace} where {prod-short} is installed.
 


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>


<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

Downstream values:
- `prod-subscription: codeready-workspaces`

## What does this pull request change
It fixes `3-subscribe.sh` script since produce-id and its subscription have different values.

## What issues does this pull request fix or reference
https://issues.redhat.com/browse/CRW-2892

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
