### PR TITLE
docs: update PostgreSQL info to use relevant images

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -64,7 +64,7 @@ asciidoc:
     platforms-ingress: Kubernetes Ingress or OpenShift Route
     platforms-name: Kubernetes or OpenShift
     platforms-namespace: Kubernetes namespace or OpenShift project
-    postgresql-image-url: quay.io/eclipse/che-postgres
+    postgresql-image-url: quay.io/eclipse/che--centos--postgresql-96-centos13
     prod-checluster: eclipse-che
     prod-cli: chectl
     prod-deployment: che

--- a/modules/administration-guide/examples/snip_che-postgresql-additional-resources.adoc
+++ b/modules/administration-guide/examples/snip_che-postgresql-additional-resources.adoc
@@ -1,2 +1,2 @@
-* link:https://quay.io/repository/eclipse/che-postgres?tab=history[`quay.io/eclipse/che-postgres` container image]
-* link:https://github.com/eclipse-che/che-server/tree/main/dockerfiles/postgres[{prod-short} Postgres repository]
+* link:https://quay.io/repository/eclipse/che--centos--postgresql-96-centos7?tab=history[`quay.io/eclipse/che--centos--postgresql-96-centos7` container image]
+* link:https://quay.io/repository/eclipse/che--centos--postgresql-13-centos7?tab=history[`quay.io/eclipse/che--centos--postgresql-13-centos7` container image]


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>


<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change
Since Che Postgres image has been deprecated, the docs should reference the current images of PostgreSQL (as listed in our Che Operator CSVs):
- quay.io/eclipse/che--centos--postgresql-96-centos7  
- quay.io/eclipse/che--centos--postgresql-13-centos7 

## What issues does this pull request fix or reference
https://github.com/eclipse/che/issues/21348

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
