### PR TITLE
fix: Don't put `null` strings is a user profile

### DIFF
--- a/modules/administration-guide/attachments/migration/1-prepare.sh
+++ b/modules/administration-guide/attachments/migration/1-prepare.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-K8S_CLI=${K8S_CLI:-oc}                                                             # {orch-cli}
+K8S_CLI=${K8S_CLI:-oc}                                                            # {orch-cli}
 PRODUCT_ID=${PRODUCT_ID:-eclipse-che}                                            # {prod-id}
 INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-eclipse-che}                    # {prod-namespace}
 

--- a/modules/administration-guide/attachments/migration/1-prepare.sh
+++ b/modules/administration-guide/attachments/migration/1-prepare.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-K8S_CLI=${K8S_CLI:-oc}                                                            # {orch-cli}
+K8S_CLI=${K8S_CLI:-oc}                                                           # {orch-cli}
 PRODUCT_ID=${PRODUCT_ID:-eclipse-che}                                            # {prod-id}
 INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-eclipse-che}                    # {prod-namespace}
 

--- a/modules/administration-guide/attachments/migration/1-prepare.sh
+++ b/modules/administration-guide/attachments/migration/1-prepare.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-K8S_CLI=${K8S_CLI:-oc}                                                           # {orch-cli}
+K8S_CLI=${K8S_CLI:-oc}                                                             # {orch-cli}
 PRODUCT_ID=${PRODUCT_ID:-eclipse-che}                                            # {prod-id}
 INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-eclipse-che}                    # {prod-namespace}
 
@@ -77,9 +77,15 @@ getUsers() {
         USER_FIRST_NAME=$(echo "${USER_PROFILE}" | jq -r ".firstName")
         USER_LAST_NAME=$(echo "${USER_PROFILE}" | jq -r ".lastName")
 
+        # Don't put null values into profile
+        [[ "${USER_FIRST_NAME}" == "null" ]] && USER_FIRST_NAME=""
+        [[ "${USER_LAST_NAME}" == "null" ]] && USER_LAST_NAME=""
+
         OPENSHIFT_USER_ID=$(echo "${IDENTITY_PROVIDER}" | jq ".userId" | tr -d "\"")
         echo "[INFO] Found ${PRODUCT_ID} user: ${USER_ID} and corresponding OpenShift user: ${OPENSHIFT_USER_ID}"
-        echo "${USER_ID} ${OPENSHIFT_USER_ID} username:$(echo "${USER_NAME}" | base64) email:$(echo "${USER_EMAIL}" | base64) firstName:$(echo "${USER_FIRST_NAME}" | base64) lastName:$(echo "${USER_LAST_NAME}" | base64) " >> "${ALL_USERS_DUMP}"
+
+        # Save profile by encoding data and trimming \r\n
+        echo "${USER_ID} ${OPENSHIFT_USER_ID} username:$(echo "${USER_NAME}" | tr -d "\r\n" | base64) email:$(echo "${USER_EMAIL}" | tr -d "\r\n" | base64) firstName:$(echo "${USER_FIRST_NAME}" | tr -d "\r\n" | base64) lastName:$(echo "${USER_LAST_NAME}" | tr -d "\r\n" | base64) " >> "${ALL_USERS_DUMP}"
       fi
   done
   echo "[INFO] Users list dump completed."


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change
Don't put `null` strings is a user profile. It is a case when OpenShift user is linked to existed keycloak user which might not have completed profile.

## What issues does this pull request fix or reference
https://issues.redhat.com/browse/CRW-2965

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
