### PR TITLE
fix: clarification for maven users

### DIFF
--- a/modules/end-user-guide/pages/mounting-secrets.adoc
+++ b/modules/end-user-guide/pages/mounting-secrets.adoc
@@ -77,7 +77,7 @@ With Maven, you can set a custom path for the `settings.xml` file.
 For example:
 [subs="+quotes,+attributes"]
 ----
-`$ mvn --settings /home/user/.m2/settings.xml clean install`
+$ mvn --settings /home/user/.m2/settings.xml clean install
 ----
 
 ====

--- a/modules/end-user-guide/pages/mounting-secrets.adoc
+++ b/modules/end-user-guide/pages/mounting-secrets.adoc
@@ -55,7 +55,8 @@ Defaults to `file`.
 
 .Mounting a Secret as a file
 ====
-[source,yaml,subs="+quotes"]
+
+[source,yaml,subs="+quotes,+attributes"]
 ----
 apiVersion: v1
 kind: Secret
@@ -71,4 +72,12 @@ data:
 ----
 
 When you start a workspace, the `/home/user/.m2/settings.xml` file will be available in the `{devworkspace}` containers.
+
+Maven allows you to set a custom path for `settings.xml`.
+For example:
+[subs="+quotes,+attributes"]
+----
+`$ mvn --settings /home/user/.m2/settings.xml clean install`
+----
+
 ====

--- a/modules/end-user-guide/pages/mounting-secrets.adoc
+++ b/modules/end-user-guide/pages/mounting-secrets.adoc
@@ -73,7 +73,7 @@ data:
 
 When you start a workspace, the `/home/user/.m2/settings.xml` file will be available in the `{devworkspace}` containers.
 
-Maven allows you to set a custom path for the `settings.xml` file.
+With Maven, you can set a custom path for the `settings.xml` file.
 For example:
 [subs="+quotes,+attributes"]
 ----

--- a/modules/end-user-guide/pages/mounting-secrets.adoc
+++ b/modules/end-user-guide/pages/mounting-secrets.adoc
@@ -73,7 +73,7 @@ data:
 
 When you start a workspace, the `/home/user/.m2/settings.xml` file will be available in the `{devworkspace}` containers.
 
-Maven allows you to set a custom path for `settings.xml`.
+Maven allows you to set a custom path for the `settings.xml` file.
 For example:
 [subs="+quotes,+attributes"]
 ----


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change
This PR adds a note about the possibility of specifying a custom path of the `settings.xml` file for Maven users to improve UX.

## What issues does this pull request fix or reference
RHDEVDOCS-2595

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
