### PR TITLE
fix: RHDEVDOCS-3405 Indicating Technology Preview features added snippet

### DIFF
--- a/modules/administration-guide/examples/snip_che-technology-preview.adoc
+++ b/modules/administration-guide/examples/snip_che-technology-preview.adoc
@@ -1,21 +1,16 @@
-//To indicate that a feature is in Technology Preview, include the snippets/technology-preview.adoc file in the feature’s assembly or module to keep the supportability wording consistent across Technology Preview features. Provide a value for the :FeatureName: variable before you include this module.
+//To indicate that a feature is in Technology Preview, include the examples/snip_che-technology-preview.adoc file in the feature’s assembly or module to keep the supportability wording consistent across Technology Preview features. 
+//Provide a value for the :FeatureName: variable before you include this module.
 //e.g.:
 //:FeatureName: The XYZ plug-in
-//include::snippets/technology-preview.adoc[]
+//include::examples/snip_che-technology-preview.adoc[]
 //If you don't do this, the result will be an incorrect replacement.
 
 [IMPORTANT]
 ====
 [subs="attributes+"]
-{FeatureName} is a Technology Preview feature only. Technology Preview features
-are not supported with Red Hat production service level agreements (SLAs) and
-might not be functionally complete. Red Hat does not recommend using them
-in production. These features provide early access to upcoming product
-features, enabling customers to test functionality and provide feedback during
-the development process.
-
-For more information about the support scope of Red Hat Technology Preview
-features, see https://access.redhat.com/support/offerings/techpreview/.
+{FeatureName} is a Technology Preview feature only. 
+Technology Preview features might not be functionally complete. 
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 ====
 // Undefine {FeatureName} attribute, so that any mistakes are easily spotted
 :!FeatureName:

--- a/modules/administration-guide/examples/snip_che-technology-preview.adoc
+++ b/modules/administration-guide/examples/snip_che-technology-preview.adoc
@@ -1,0 +1,21 @@
+//To indicate that a feature is in Technology Preview, include the snippets/technology-preview.adoc file in the feature’s assembly or module to keep the supportability wording consistent across Technology Preview features. Provide a value for the :FeatureName: variable before you include this module.
+//e.g.:
+//:FeatureName: The XYZ plug-in
+//include::snippets/technology-preview.adoc[]
+//If you don't do this, the result will be an incorrect replacement.
+
+[IMPORTANT]
+====
+[subs="attributes+"]
+{FeatureName} is a Technology Preview feature only. Technology Preview features
+are not supported with Red Hat production service level agreements (SLAs) and
+might not be functionally complete. Red Hat does not recommend using them
+in production. These features provide early access to upcoming product
+features, enabling customers to test functionality and provide feedback during
+the development process.
+
+For more information about the support scope of Red Hat Technology Preview
+features, see https://access.redhat.com/support/offerings/techpreview/.
+====
+// Undefine {FeatureName} attribute, so that any mistakes are easily spotted
+:!FeatureName:


### PR DESCRIPTION

## What does this pull request change
It adds a snippet to the examples folder that can be added to assemblies that are tech previews. It contains some basic text about how tech previews are not the final product etc.

## What issues does this pull request fix or reference
https://issues.redhat.com/browse/RHDEVDOCS-3405

