### PR TITLE
fix: add DWO uninstallation crosslink

### DIFF
--- a/modules/administration-guide/pages/uninstalling-che.adoc
+++ b/modules/administration-guide/pages/uninstalling-che.adoc
@@ -36,3 +36,9 @@ $ {prod-cli} server:delete -n __<{prod-namespace}>__
 ----
 
 include::example$snip_{project-context}-note-uninstalling-in-minikube-cluster.adoc[]
+
+[NOTE] 
+====
+If {prod-short} was installed from the OpenShift web console, `{prod-cli}` will not uninstall the {devworkspace} operator.
+To uninstall the {devworkspace} Operator, see link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/odc-about-web-terminal.html#deleting-the-devworkspace-operator-dependency[Deleting the {devworkspace} Operator dependency].
+====


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

Preview:
![image](https://user-images.githubusercontent.com/83611742/170303759-dc32a6ba-2316-40cd-9109-bc843515b759.png)

<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change
Adds a link for how to uninstall the devworkspace operator dependency, since the devworkspace operator is not uninstalled when Che is installed from the OpenShift web console.

## What issues does this pull request fix or reference

## Specify the version of the product this pull request applies to
Any version where the devworkspace operator is installed alongside Che.

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
