### PR TITLE
fix: attributes around upgrading from prev to next version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -83,6 +83,7 @@ asciidoc:
     prod-operator-package-name: eclipse-che
     prod-operator: che-operator
     prod-prev-short: Che
+    prod-prev-id-short: che
     prod-prev-ver: "previous minor version"
     prod-short: Che
     prod-stable-channel-catalog-source: community-operators

--- a/modules/administration-guide/pages/installing-che-on-openshift-using-the-web-console.adoc
+++ b/modules/administration-guide/pages/installing-che-on-openshift-using-the-web-console.adoc
@@ -10,7 +10,7 @@ This section describes how to install {prod-short} using the OpenShift web conso
 
 .Prerequisites
 
-* A web console session with administrative access on the destination OpenShift instance. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/web-console.html[Accessing the web console].
+* An OpenShift web console session by a cluster administrator. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/web-console.html[Accessing the web console].
 
 .Procedure
 

--- a/modules/administration-guide/pages/installing-image-puller-on-openshift-using-the-web-console.adoc
+++ b/modules/administration-guide/pages/installing-image-puller-on-openshift-using-the-web-console.adoc
@@ -14,7 +14,7 @@ You can install the {image-puller-operator-name} on OpenShift using the OpenShif
 
 * xref:defining-the-memory-parameters-for-the-image-puller.adoc[].
 
-* A web console session with administrative access on the destination OpenShift instance. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/web-console.html[Accessing the web console].
+* An OpenShift web console session by a cluster administrator. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/web-console.html[Accessing the web console].
 
 .Procedure
 

--- a/modules/administration-guide/pages/specifying-the-update-approval-strategy.adoc
+++ b/modules/administration-guide/pages/specifying-the-update-approval-strategy.adoc
@@ -4,10 +4,10 @@
 :page-aliases: installation-guide:upgrading-che-using-operatorhub
 
 [id="specifying-the-{prod-id-short}-operator-update-approval-strategy-using-the-web-console_{context}"]
-= Specifying the {prod-short} operator update approval strategy using the web console
+= Specifying the update approval strategy for the {prod} Operator
 
 
-The {prod-short} operator supports two upgrade strategies:
+The {prod} Operator supports two upgrade strategies:
 
 `Automatic`::
 The Operator installs new updates when they become available.
@@ -15,17 +15,17 @@ The Operator installs new updates when they become available.
 `Manual`::
 New updates need to be manually approved before installation begins.
 
-You can specify the {prod-short} operator update approval strategy using the OpenShift web console.
+You can specify the update approval strategy for the {prod} Operator by using the OpenShift web console.
 
 .Prerequisites
 
-* A web console session with administrative access on the destination OpenShift instance. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/web-console.html[Accessing the web console].
+* An OpenShift web console session by a cluster administrator. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/web-console.html[Accessing the web console].
 
 * An instance of {prod-short} that was installed by using Red Hat Ecosystem Catalog.
 
 .Procedure
 
-. Navigate to the *Operators* -> *Installed Operators* page in the OpenShift web console.
+. In the OpenShift web console, navigate to menu:Operators[Installed Operators].
 
 . Click *{prod}* in the list of installed Operators.
 

--- a/modules/administration-guide/pages/upgrading-che-7-41-on-openshift.adoc
+++ b/modules/administration-guide/pages/upgrading-che-7-41-on-openshift.adoc
@@ -1,12 +1,12 @@
 :_content-type: PROCEDURE
-:navtitle: Upgrading {prod-short} {prod-last-version-pre-dwo} on OpenShift
+:navtitle: Upgrading {prod-prev-short} {prod-last-version-pre-dwo} on OpenShift
 :keywords: administration-guide, migration, devworkspace
 :page-aliases: 
 
-[id="upgrading-{prod-id-short}-{prod-last-version-pre-dwo}-on-openshift_{context}"]
+[id="upgrading-{prod-prev-id-short}-{prod-last-version-pre-dwo}-on-openshift_{context}"]
 = Upgrading {prod-prev-short} {prod-last-version-pre-dwo} on OpenShift
 
-The workspace engine and authentication system used up to and including {prod-prev-short} version {prod-last-version-pre-dwo} are deprecated. Upgrading from version {prod-last-version-pre-dwo} requires manual steps.
+The workspace engine and authentication system used up to and including {prod-prev-short} version {prod-last-version-pre-dwo} are deprecated, which requires manual steps.
 
 .Prerequisites
 

--- a/modules/administration-guide/pages/upgrading-che-using-the-cli-management-tool-in-restricted-environment.adoc
+++ b/modules/administration-guide/pages/upgrading-che-using-the-cli-management-tool-in-restricted-environment.adoc
@@ -1,18 +1,18 @@
 :_content-type: PROCEDURE
-:navtitle: Upgrading {prod-short} in restricted environment
-:keywords: Upgrading {prod-short} in restricted environment
+:navtitle: Upgrading {prod-prev-short} in a restricted environment
+:keywords: Upgrading {prod-prev-short} in a restricted environment
 :page-aliases: installation-guide:upgrading-che-using-the-cli-management-tool-in-restricted-environment, installation-guide:upgrading-che-in-restricted-environment
 
-[id="upgrading-{prod-id-short}-using-the-cli-management-tool-in-restricted-environment_{context}"]
-= Upgrading {prod-short} using the CLI management tool in restricted environment
+[id="upgrading-{prod-prev-id-short}-using-the-cli-management-tool-in-restricted-environment_{context}"]
+= Upgrading {prod-prev-short} using the CLI management tool in a restricted environment
 
 
-This section describes how to upgrade {prod} using the CLI management tool in restricted environment. The upgrade path supports minor version update, from {prod-short} {prod-prev-ver} to version {prod-ver}.
+This section describes how to upgrade {prod-prev-short} {prod-prev-ver} to {prod-short} {prod-ver} using the CLI management tool in a restricted environment. The upgrade path supports minor version update.
 
 .Prerequisites
 
 
-* An instance running {prod-prev-short} {prod-prev-ver}, installed on the same instance of OpenShift, with the `{prod-cli} --installer operator` method, in the `_<{prod-namespace}>_` project. See xref:installing-che-in-a-restricted-environment.adoc[].
+* An instance running {prod-prev-short} {prod-prev-ver}, installed on the same instance of OpenShift using the `{prod-cli} --installer operator` method in the `{prod-namespace}` project. See xref:installing-che-in-a-restricted-environment.adoc[].
 
 include::partial$snip_preparing-images-for-a-restricted-environment.adoc[]
 

--- a/modules/administration-guide/pages/upgrading-che-using-the-cli-management-tool-in-restricted-environment.adoc
+++ b/modules/administration-guide/pages/upgrading-che-using-the-cli-management-tool-in-restricted-environment.adoc
@@ -1,18 +1,16 @@
 :_content-type: PROCEDURE
-:navtitle: Upgrading {prod-prev-short} in a restricted environment
-:keywords: Upgrading {prod-prev-short} in a restricted environment
+:navtitle: Upgrading {prod-short} in a restricted environment
+:keywords: Upgrading {prod-short} in a restricted environment
 :page-aliases: installation-guide:upgrading-che-using-the-cli-management-tool-in-restricted-environment, installation-guide:upgrading-che-in-restricted-environment
 
-[id="upgrading-{prod-prev-id-short}-using-the-cli-management-tool-in-restricted-environment_{context}"]
-= Upgrading {prod-prev-short} using the CLI management tool in a restricted environment
+[id="upgrading-{prod-id-short}-using-the-cli-management-tool-in-restricted-environment_{context}"]
+= Upgrading {prod-short} using the CLI management tool in a restricted environment
 
-
-This section describes how to upgrade {prod-prev-short} {prod-prev-ver} to {prod-short} {prod-ver} using the CLI management tool in a restricted environment. The upgrade path supports minor version update.
+This section describes how to upgrade {prod} and perform minor version updates by using the CLI management tool in a restricted environment.
 
 .Prerequisites
 
-
-* An instance running {prod-prev-short} {prod-prev-ver}, installed on the same instance of OpenShift using the `{prod-cli} --installer operator` method in the `{prod-namespace}` project. See xref:installing-che-in-a-restricted-environment.adoc[].
+* The {prod-short} instance was installed on OpenShift using the `{prod-cli} --installer operator` method in the `{prod-namespace}` project. See xref:installing-che-in-a-restricted-environment.adoc[].
 
 include::partial$snip_preparing-images-for-a-restricted-environment.adoc[]
 

--- a/modules/administration-guide/pages/upgrading-che-using-the-cli-management-tool.adoc
+++ b/modules/administration-guide/pages/upgrading-che-using-the-cli-management-tool.adoc
@@ -1,10 +1,10 @@
 :_content-type: PROCEDURE
-:navtitle: Upgrading {prod-short} using the CLI management tool
+:navtitle: Upgrading {prod-prev-short} using the CLI management tool
 :keywords: administration guide, upgrading-che-using-the-cli-management-tool
 :page-aliases: installation-guide:upgrading-che-using-the-cli-management-tool
 
-[id="upgrading-{prod-id-short}-using-the-cli-management-tool_{context}"]
-= Upgrading {prod-short} using the CLI management tool
+[id="upgrading-{prod-prev-id-short}-using-the-cli-management-tool_{context}"]
+= Upgrading {prod-prev-short} using the CLI management tool
 
 This section describes how to upgrade from the previous minor version using the CLI management tool.
 

--- a/modules/administration-guide/pages/upgrading-che-using-the-cli-management-tool.adoc
+++ b/modules/administration-guide/pages/upgrading-che-using-the-cli-management-tool.adoc
@@ -1,10 +1,10 @@
 :_content-type: PROCEDURE
-:navtitle: Upgrading {prod-prev-short} using the CLI management tool
+:navtitle: Upgrading {prod-short} using the CLI management tool
 :keywords: administration guide, upgrading-che-using-the-cli-management-tool
 :page-aliases: installation-guide:upgrading-che-using-the-cli-management-tool
 
-[id="upgrading-{prod-prev-id-short}-using-the-cli-management-tool_{context}"]
-= Upgrading {prod-prev-short} using the CLI management tool
+[id="upgrading-{prod-id-short}-using-the-cli-management-tool_{context}"]
+= Upgrading {prod-short} using the CLI management tool
 
 This section describes how to upgrade from the previous minor version using the CLI management tool.
 

--- a/modules/administration-guide/pages/upgrading-che-using-the-web-console.adoc
+++ b/modules/administration-guide/pages/upgrading-che-using-the-web-console.adoc
@@ -1,18 +1,18 @@
 :_content-type: ASSEMBLY
-:navtitle: Upgrading {prod-short} using the web console
+:navtitle: Upgrading {prod-prev-short} using the OpenShift web console
 :keywords: administration guide, upgrading-che-using-operatorhub
 :page-aliases:
 
-[id="upgrading-{prod-id-short}-using-the-web-console_{context}"]
-= Upgrading {prod-short} using the web console
+[id="upgrading-{prod-prev-id-short}-using-the-openshift-web-console_{context}"]
+= Upgrading {prod-prev-short} using the OpenShift web console
 
 You can manually approve an upgrade from an earlier minor version using the {prod} Operator from the Red Hat Ecosystem Catalog in the OpenShift web console.
 
 .Prerequisites
 
-* A web console session with administrative access on the destination OpenShift instance. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/web-console.html[Accessing the web console].
+* An OpenShift web console session by a cluster administrator. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/web-console.html[Accessing the web console].
 
-* An instance of {prod-short} that was installed by using the Red Hat Ecosystem Catalog.
+* An instance of {prod-prev-short} that was installed by using the Red Hat Ecosystem Catalog.
 
 * The approval strategy in the subscription is `Manual`. See xref:specifying-the-update-approval-strategy.adoc[].
 

--- a/modules/administration-guide/pages/upgrading-che-using-the-web-console.adoc
+++ b/modules/administration-guide/pages/upgrading-che-using-the-web-console.adoc
@@ -1,10 +1,10 @@
 :_content-type: ASSEMBLY
-:navtitle: Upgrading {prod-prev-short} using the OpenShift web console
+:navtitle: Upgrading {prod-short} using the OpenShift web console
 :keywords: administration guide, upgrading-che-using-operatorhub
 :page-aliases:
 
-[id="upgrading-{prod-prev-id-short}-using-the-openshift-web-console_{context}"]
-= Upgrading {prod-prev-short} using the OpenShift web console
+[id="upgrading-{prod-id-short}-using-the-openshift-web-console_{context}"]
+= Upgrading {prod-short} using the OpenShift web console
 
 You can manually approve an upgrade from an earlier minor version using the {prod} Operator from the Red Hat Ecosystem Catalog in the OpenShift web console.
 
@@ -12,7 +12,7 @@ You can manually approve an upgrade from an earlier minor version using the {pro
 
 * An OpenShift web console session by a cluster administrator. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/web-console.html[Accessing the web console].
 
-* An instance of {prod-prev-short} that was installed by using the Red Hat Ecosystem Catalog.
+* An instance of {prod-short} that was installed by using the Red Hat Ecosystem Catalog.
 
 * The approval strategy in the subscription is `Manual`. See xref:specifying-the-update-approval-strategy.adoc[].
 

--- a/modules/administration-guide/pages/upgrading-che.adoc
+++ b/modules/administration-guide/pages/upgrading-che.adoc
@@ -1,14 +1,14 @@
 :_content-type: ASSEMBLY
-:navtitle: Upgrading Che
+:navtitle: Upgrading {prod-short}
 :keywords: administration guide, upgrading-che
 :page-aliases: installation-guide:upgrading-che, installation-guide:upgrading-che-known-issues, installation-guide:rolling-back-a-che-upgrade,installation-guide: upgrading-che-namespace-strategies-other-than-per-user
 
 :parent-context-of-upgrading-che: {context}
 
-[id="upgrading-{prod-id-short}_{context}"]
-= Upgrading {prod-short}
+[id="upgrading-{prod-prev-id-short}_{context}"]
+= Upgrading {prod-prev-short}
 
-:context: upgrading-{prod-id-short}
+:context: upgrading-{prod-prev-id-short}
 
 This chapter describes how to upgrade from {prod-prev-short} {prod-prev-ver} to {prod-short} {prod-ver}.
 

--- a/modules/administration-guide/pages/upgrading-che.adoc
+++ b/modules/administration-guide/pages/upgrading-che.adoc
@@ -5,10 +5,10 @@
 
 :parent-context-of-upgrading-che: {context}
 
-[id="upgrading-{prod-prev-id-short}_{context}"]
-= Upgrading {prod-prev-short}
+[id="upgrading-{prod-id-short}_{context}"]
+= Upgrading {prod-short}
 
-:context: upgrading-{prod-prev-id-short}
+:context: upgrading-{prod-id-short}
 
 This chapter describes how to upgrade from {prod-prev-short} {prod-prev-ver} to {prod-short} {prod-ver}.
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change
The downstream values in some attributes due to the downstream product name change cause confusion on various pages in [the section about upgrading](https://www.eclipse.org/che/docs/next/administration-guide/upgrading-che/) in the admin guide.

## What issues does this pull request fix or reference
RHDEVDOCS-4121 & https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools/-/merge_requests/1502/

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
