### PR TITLE
fix: Patch CheCluster after DS is deployed

### DIFF
--- a/modules/administration-guide/attachments/migration/3-subscribe.sh
+++ b/modules/administration-guide/attachments/migration/3-subscribe.sh
@@ -39,7 +39,7 @@ deleteOperatorSubscription() {
     sleep 30
 }
 
-patchCheCluster() {
+patchPreMigrationCheCluster() {
     echo "[INFO] Updating ${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME} CheCluster CR to switch to DevWorkspace and single-host."
     "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
         '[{"op": "replace", "path": "/spec/devWorkspace/enable", "value": true}]'
@@ -52,19 +52,21 @@ patchCheCluster() {
       "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
               '[{"op": "replace", "path": "/spec/server/cheHost", "value": ""}]'
     fi
+}
 
-    echo "[INFO] Updating ${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME} CheCluster CR to set 'spec.devWorkspace.runningLimit' field"
-    RUNNING_LIMIT=$("${K8S_CLI}" get checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" -o jsonpath='{.spec.devWorkspace.runningLimit}' | tr -d "\r\n")
-    if [[ -z ${RUNNING_LIMIT} ]]; then
-      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT=$("${K8S_CLI}" get checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" -o jsonpath='{.spec.server.customCheProperties.CHE_LIMITS_USER_WORKSPACES_RUN_COUNT}' | tr -d "\r\n")
-      if [[ ${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT} == -1 ]]; then
-        "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
-                '[{"op": "replace", "path": "/spec/devWorkspace/runningLimit", "value": "99999"}]'
-      elif [[ ! -z ${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT} ]]; then
-        "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
-                  '[{"op": "replace", "path": "/spec/devWorkspace/runningLimit", "value": "'${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT}'"}]'
+patchCheCluster() {
+      echo "[INFO] Updating ${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME} CheCluster CR to set 'spec.devWorkspace.runningLimit' field"
+      RUNNING_LIMIT=$("${K8S_CLI}" get checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" -o jsonpath='{.spec.devWorkspace.runningLimit}' | tr -d "\r\n")
+      if [[ -z ${RUNNING_LIMIT} ]]; then
+        CHE_LIMITS_USER_WORKSPACES_RUN_COUNT=$("${K8S_CLI}" get checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" -o jsonpath='{.spec.server.customCheProperties.CHE_LIMITS_USER_WORKSPACES_RUN_COUNT}' | tr -d "\r\n")
+        if [[ ${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT} == -1 ]]; then
+          "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
+                  '[{"op": "replace", "path": "/spec/devWorkspace/runningLimit", "value": "99999"}]'
+        elif [[ ! -z ${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT} ]]; then
+          "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
+                    '[{"op": "replace", "path": "/spec/devWorkspace/runningLimit", "value": "'${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT}'"}]'
+        fi
       fi
-    fi
 }
 
 cleanupObsoleteObjects() {
@@ -102,12 +104,15 @@ spec:
     sourceNamespace: openshift-marketplace
 EOF
 
+    echo "[INFO] Waiting 30s for the new ${PRODUCT_ID} operator creation."
+    sleep 30
 }
 
 deleteOperatorCSV
 deleteOperatorSubscription
-patchCheCluster
+patchPreMigrationCheCluster
 cleanupObsoleteObjects
 createOperatorSubscription
+patchCheCluster
 
 echo "[INFO] Done."

--- a/modules/administration-guide/attachments/migration/3-subscribe.sh
+++ b/modules/administration-guide/attachments/migration/3-subscribe.sh
@@ -60,9 +60,9 @@ patchCheCluster() {
       if [[ ${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT} == -1 ]]; then
         "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
                 '[{"op": "replace", "path": "/spec/devWorkspace/runningLimit", "value": "99999"}]'
-      else
+      elif [[ ! -z ${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT} ]]; then
         "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
-                        '[{"op": "replace", "path": "/spec/devWorkspace/runningLimit", "value": "'${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT}'"}]'
+                  '[{"op": "replace", "path": "/spec/devWorkspace/runningLimit", "value": "'${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT}'"}]'
       fi
     fi
 }

--- a/modules/administration-guide/attachments/migration/3-subscribe.sh
+++ b/modules/administration-guide/attachments/migration/3-subscribe.sh
@@ -52,6 +52,19 @@ patchCheCluster() {
       "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
               '[{"op": "replace", "path": "/spec/server/cheHost", "value": ""}]'
     fi
+
+    echo "[INFO] Updating ${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME} CheCluster CR to set 'spec.devWorkspace.runningLimit' field"
+    RUNNING_LIMIT=$("${K8S_CLI}" get checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" -o jsonpath='{.spec.devWorkspace.runningLimit}' | tr -d "\r\n")
+    if [[ -z ${RUNNING_LIMIT} ]]; then
+      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT=$("${K8S_CLI}" get checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" -o jsonpath='{.spec.server.customCheProperties.CHE_LIMITS_USER_WORKSPACES_RUN_COUNT}' | tr -d "\r\n")
+      if [[ ${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT} == -1 ]]; then
+        "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
+                '[{"op": "replace", "path": "/spec/devWorkspace/runningLimit", "value": "99999"}]'
+      else
+        "${K8S_CLI}" patch checluster/"${PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME}" -n "${INSTALLATION_NAMESPACE}" --type=json -p \
+                        '[{"op": "replace", "path": "/spec/devWorkspace/runningLimit", "value": "'${CHE_LIMITS_USER_WORKSPACES_RUN_COUNT}'"}]'
+      fi
+    fi
 }
 
 cleanupObsoleteObjects() {


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change
Patch CheCluster after DS is deployed since `spec.devWorkspace.runningLimits` field does not exists for CRW 2.15

## What issues does this pull request fix or reference
https://issues.redhat.com/browse/CRW-3012

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
