### PR TITLE
fix: Add startingCSV to subscriptions

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -70,6 +70,7 @@ asciidoc:
     pre-migration-prod-package: eclipse-che
     pre-migration-prod-channel: stable
     pre-migration-prod-catalog-source: community-operators
+    pre-migration-prod-starting-csv: eclipse-che.v7.41.2
     prod-checluster: eclipse-che
     prod-cli: chectl
     prod-deployment: che
@@ -93,6 +94,7 @@ asciidoc:
     prod-stable-channel-catalog-source: community-operators
     prod-stable-channel-package: eclipse-che
     prod-stable-channel: stable
+    prod-stable-channel-starting-csv: eclipse-che.v7.49.0
     prod-upstream: Eclipse{nbsp}Che
     prod-url: "https://__&lt;che_fqdn&gt;__"
     prod-ver-major: "7"

--- a/modules/administration-guide/attachments/migration/3-subscribe.sh
+++ b/modules/administration-guide/attachments/migration/3-subscribe.sh
@@ -9,7 +9,6 @@ INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-eclipse-che}                   
 PRODUCT_OLM_STABLE_CHANNEL=${PRODUCT_OLM_STABLE_CHANNEL:-stable}                                 # {prod-stable-channel}
 PRODUCT_OLM_CATALOG_SOURCE=${PRODUCT_OLM_CATALOG_SOURCE:-community-operators}                    # {prod-stable-channel-catalog-source}
 PRODUCT_OLM_PACKAGE=${PRODUCT_OLM_PACKAGE:-eclipse-che}                                          # {prod-stable-channel-package}
-PRODUCT_OLM_STARTING_CSV=${PRODUCT_OLM_STARTING_CSV:-eclipse-che.v7.49.0}                        # {prod-stable-channel-starting-csv}
 
 PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE=${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE:-eclipse-che}        # {prod-namespace}
 PRE_MIGRATION_PRODUCT_SHORT_ID=${PRE_MIGRATION_PRODUCT_SHORT_ID:-che}                                    # {pre-migration-prod-id-short}
@@ -23,7 +22,7 @@ CHE_CLUSTER="${PRODUCT_ID}"-original-checluster.json
 deleteOperatorCSV() {
     if "${K8S_CLI}" get subscription "${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME}" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}" > /dev/null 2>&1 ; then
         echo "[INFO] Deleting operator cluster service version."
-        "${K8S_CLI}" delete csv "$("${K8S_CLI}" get subscription "${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME}" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}" -o jsonpath="{.status.installedCSV}")" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}"
+        "${K8S_CLI}" delete csv "$("${K8S_CLI}" get subscription "${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME}" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}" -o jsonpath="{.status.currentCSV}")" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}"
     else
         echo "[INFO] Skipping CSV deletion. No ${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME} operator subscription found."
     fi
@@ -93,11 +92,10 @@ cleanupObsoleteObjects() {
 }
 
 createOperatorSubscription() {
-    echo "[INFO] Creating new ${PRODUCT_ID} operator subscription." 
-    echo "[INFO] New subscription name: ${PRODUCT_OLM_PACKAGE}."
-    echo "[INFO] New subscription channel: ${PRODUCT_OLM_STABLE_CHANNEL}."
+    echo "[INFO] Creating new ${PRODUCT_ID} operator subscription."
     echo "[INFO] New subscription source: ${PRODUCT_OLM_CATALOG_SOURCE}."
-    echo "[INFO] New subscription starting CSV: ${PRODUCT_OLM_STARTING_CSV}."
+    echo "[INFO] New subscription channel: ${PRODUCT_OLM_STABLE_CHANNEL}."
+    echo "[INFO] New subscription name: ${PRODUCT_OLM_PACKAGE}."
 
     "${K8S_CLI}" apply -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
@@ -107,21 +105,14 @@ metadata:
     namespace: openshift-operators
 spec:
     channel: "${PRODUCT_OLM_STABLE_CHANNEL}"
-    installPlanApproval: Manual
+    installPlanApproval: Automatic
     name: "${PRODUCT_OLM_PACKAGE}"
     source: "${PRODUCT_OLM_CATALOG_SOURCE}"
     sourceNamespace: openshift-marketplace
-    startingCSV: ${PRODUCT_OLM_STARTING_CSV}
 EOF
 
     echo "[INFO] Waiting 30s for the new ${PRODUCT_ID} operator creation."
     sleep 30
-
-    "${K8S_CLI}" wait subscription "${PRODUCT_ID}" -n openshift-operators --for=condition=InstallPlanPending --timeout=120s
-
-    echo "[INFO] Approve install plan."
-    INSTALL_PLAN=$("${K8S_CLI}" get subscription "${PRODUCT_ID}" -n openshift-operators -o jsonpath='{.status.installplan.name}')
-    "${K8S_CLI}" patch installplan ${INSTALL_PLAN} -n openshift-operators --type=merge -p '{"spec": {"approved": true}}'
 }
 
 deleteOperatorCSV

--- a/modules/administration-guide/attachments/migration/3-subscribe.sh
+++ b/modules/administration-guide/attachments/migration/3-subscribe.sh
@@ -9,6 +9,7 @@ INSTALLATION_NAMESPACE=${INSTALLATION_NAMESPACE:-eclipse-che}                   
 PRODUCT_OLM_STABLE_CHANNEL=${PRODUCT_OLM_STABLE_CHANNEL:-stable}                                 # {prod-stable-channel}
 PRODUCT_OLM_CATALOG_SOURCE=${PRODUCT_OLM_CATALOG_SOURCE:-community-operators}                    # {prod-stable-channel-catalog-source}
 PRODUCT_OLM_PACKAGE=${PRODUCT_OLM_PACKAGE:-eclipse-che}                                          # {prod-stable-channel-package}
+PRODUCT_OLM_STARTING_CSV=${PRODUCT_OLM_STARTING_CSV:-eclipse-che.v7.49.0}                        # {prod-stable-channel-starting-csv}
 
 PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE=${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE:-eclipse-che}        # {prod-namespace}
 PRE_MIGRATION_PRODUCT_SHORT_ID=${PRE_MIGRATION_PRODUCT_SHORT_ID:-che}                                    # {pre-migration-prod-id-short}
@@ -22,7 +23,7 @@ CHE_CLUSTER="${PRODUCT_ID}"-original-checluster.json
 deleteOperatorCSV() {
     if "${K8S_CLI}" get subscription "${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME}" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}" > /dev/null 2>&1 ; then
         echo "[INFO] Deleting operator cluster service version."
-        "${K8S_CLI}" delete csv "$("${K8S_CLI}" get subscription "${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME}" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}" -o jsonpath="{.status.currentCSV}")" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}"
+        "${K8S_CLI}" delete csv "$("${K8S_CLI}" get subscription "${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME}" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}" -o jsonpath="{.status.installedCSV}")" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}"
     else
         echo "[INFO] Skipping CSV deletion. No ${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME} operator subscription found."
     fi
@@ -92,10 +93,11 @@ cleanupObsoleteObjects() {
 }
 
 createOperatorSubscription() {
-    echo "[INFO] Creating new ${PRODUCT_ID} operator subscription."
-    echo "[INFO] New subscription source: ${PRODUCT_OLM_CATALOG_SOURCE}."
-    echo "[INFO] New subscription channel: ${PRODUCT_OLM_STABLE_CHANNEL}."
+    echo "[INFO] Creating new ${PRODUCT_ID} operator subscription." 
     echo "[INFO] New subscription name: ${PRODUCT_OLM_PACKAGE}."
+    echo "[INFO] New subscription channel: ${PRODUCT_OLM_STABLE_CHANNEL}."
+    echo "[INFO] New subscription source: ${PRODUCT_OLM_CATALOG_SOURCE}."
+    echo "[INFO] New subscription starting CSV: ${PRODUCT_OLM_STARTING_CSV}."
 
     "${K8S_CLI}" apply -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
@@ -105,14 +107,21 @@ metadata:
     namespace: openshift-operators
 spec:
     channel: "${PRODUCT_OLM_STABLE_CHANNEL}"
-    installPlanApproval: Automatic
+    installPlanApproval: Manual
     name: "${PRODUCT_OLM_PACKAGE}"
     source: "${PRODUCT_OLM_CATALOG_SOURCE}"
     sourceNamespace: openshift-marketplace
+    startingCSV: ${PRODUCT_OLM_STARTING_CSV}
 EOF
 
     echo "[INFO] Waiting 30s for the new ${PRODUCT_ID} operator creation."
     sleep 30
+
+    "${K8S_CLI}" wait subscription "${PRODUCT_ID}" -n openshift-operators --for=condition=InstallPlanPending --timeout=120s
+
+    echo "[INFO] Approve install plan."
+    INSTALL_PLAN=$("${K8S_CLI}" get subscription "${PRODUCT_ID}" -n openshift-operators -o jsonpath='{.status.installplan.name}')
+    "${K8S_CLI}" patch installplan ${INSTALL_PLAN} -n openshift-operators --type=merge -p '{"spec": {"approved": true}}'
 }
 
 deleteOperatorCSV

--- a/modules/administration-guide/attachments/migration/rollback.sh
+++ b/modules/administration-guide/attachments/migration/rollback.sh
@@ -18,6 +18,7 @@ PRE_MIGRATION_PRODUCT_OPERATOR_NAME=${PRE_MIGRATION_PRODUCT_OPERATOR_NAME:-che-o
 PRE_MIGRATION_PRODUCT_OLM_PACKAGE=${PRE_MIGRATION_PRODUCT_OLM_PACKAGE:-eclipse-che}                       # {pre-migration-prod-package}
 PRE_MIGRATION_PRODUCT_OLM_CHANNEL=${PRE_MIGRATION_PRODUCT_OLM_CHANNEL:-stable}                            # {pre-migration-prod-channel}
 PRE_MIGRATION_PRODUCT_OLM_CATALOG_SOURCE=${PRE_MIGRATION_PRODUCT_OLM_CATALOG_SOURCE:-community-operators} # {pre-migration-prod-catalog-source}
+PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV=${PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV:-eclipse-che.v7.49.0}     # {pre-migration-prod-starting-csv}
 
 DB_DUMP="${PRODUCT_ID}"-original-db.sql
 CHE_CLUSTER="${PRODUCT_ID}"-original-checluster.json
@@ -28,7 +29,7 @@ CHE_POSTGRES_DB=$("${K8S_CLI}" get cm/che -n "${INSTALLATION_NAMESPACE}" -o json
 deleteOperatorCSV() {
     if "${K8S_CLI}" get subscription "${PRODUCT_ID}" -n "${OPERATOR_NAMESPACE}" > /dev/null 2>&1 ; then
         echo "[INFO] Deleting operator cluster service version."
-        "${K8S_CLI}" delete csv "$("${K8S_CLI}" get subscription "${PRODUCT_ID}" -n "${OPERATOR_NAMESPACE}" -o jsonpath="{.status.currentCSV}")" -n "${OPERATOR_NAMESPACE}"
+        "${K8S_CLI}" delete csv "$("${K8S_CLI}" get subscription "${PRODUCT_ID}" -n "${OPERATOR_NAMESPACE}" -o jsonpath="{.status.installedCSV}")" -n "${OPERATOR_NAMESPACE}"
     else
         echo "[INFO] Skipping CSV deletion. No ${PRODUCT_ID} operator subscription found."
     fi
@@ -105,9 +106,10 @@ deleteObjects() {
 
 createOperatorSubscription() {
     echo "[INFO] Creating new ${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME} operator subscription." 
-    echo "[INFO] New subscription source: ${PRE_MIGRATION_PRODUCT_OLM_CATALOG_SOURCE}."
-    echo "[INFO] New subscription channel: ${PRE_MIGRATION_PRODUCT_OLM_CHANNEL}."
     echo "[INFO] New subscription name: ${PRE_MIGRATION_PRODUCT_OLM_PACKAGE}."
+    echo "[INFO] New subscription channel: ${PRE_MIGRATION_PRODUCT_OLM_CHANNEL}."
+    echo "[INFO] New subscription source: ${PRE_MIGRATION_PRODUCT_OLM_CATALOG_SOURCE}."
+    echo "[INFO] New subscription starting CSV: ${PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV}."
 
     "${K8S_CLI}" apply -f - <<EOF
 apiVersion: operators.coreos.com/v1alpha1
@@ -117,11 +119,20 @@ metadata:
     namespace: "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}"
 spec:
     channel: "${PRE_MIGRATION_PRODUCT_OLM_CHANNEL}"
-    installPlanApproval: Automatic
+    installPlanApproval: Manual
     name: "${PRE_MIGRATION_PRODUCT_OLM_PACKAGE}"
     source: "${PRE_MIGRATION_PRODUCT_OLM_CATALOG_SOURCE}"
     sourceNamespace: openshift-marketplace
+    startingCSV: ${PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV}
 EOF
+
+  echo "[INFO] Waiting 30s for the new ${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME} operator creation."
+  sleep 30
+  "${K8S_CLI}" wait subscription "${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME}" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}" --for=condition=InstallPlanPending --timeout=120s
+
+  echo "[INFO] Approve install plan."
+  INSTALL_PLAN=$("${K8S_CLI}" get subscription "${PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME}" -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}" -o jsonpath='{.status.installplan.name}')
+  "${K8S_CLI}" patch installplan ${INSTALL_PLAN} -n "${PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE}" --type=merge -p '{"spec": {"approved": true}}'
 }
 
 waitForComponent() {

--- a/modules/administration-guide/attachments/migration/rollback.sh
+++ b/modules/administration-guide/attachments/migration/rollback.sh
@@ -18,7 +18,7 @@ PRE_MIGRATION_PRODUCT_OPERATOR_NAME=${PRE_MIGRATION_PRODUCT_OPERATOR_NAME:-che-o
 PRE_MIGRATION_PRODUCT_OLM_PACKAGE=${PRE_MIGRATION_PRODUCT_OLM_PACKAGE:-eclipse-che}                       # {pre-migration-prod-package}
 PRE_MIGRATION_PRODUCT_OLM_CHANNEL=${PRE_MIGRATION_PRODUCT_OLM_CHANNEL:-stable}                            # {pre-migration-prod-channel}
 PRE_MIGRATION_PRODUCT_OLM_CATALOG_SOURCE=${PRE_MIGRATION_PRODUCT_OLM_CATALOG_SOURCE:-community-operators} # {pre-migration-prod-catalog-source}
-PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV=${PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV:-eclipse-che.v7.49.0}     # {pre-migration-prod-starting-csv}
+PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV=${PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV:-eclipse-che.v7.41.2}     # {pre-migration-prod-starting-csv}
 
 DB_DUMP="${PRODUCT_ID}"-original-db.sql
 CHE_CLUSTER="${PRODUCT_ID}"-original-checluster.json

--- a/modules/administration-guide/pages/upgrading-che-7-41-on-openshift.adoc
+++ b/modules/administration-guide/pages/upgrading-che-7-41-on-openshift.adoc
@@ -51,6 +51,7 @@ export PRODUCT_OPERATOR_NAME={prod-operator}
 export PRODUCT_OLM_STABLE_CHANNEL={prod-stable-channel}
 export PRODUCT_OLM_CATALOG_SOURCE={prod-stable-channel-catalog-source}
 export PRODUCT_OLM_PACKAGE={prod-stable-channel-package}
+export PRODUCT_OLM_STARTING_CSV={prod-stable-channel-starting-csv}
 export PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE={prod-namespace} # <2>
 export PRE_MIGRATION_PRODUCT_SHORT_ID={pre-migration-prod-id-short}
 export PRE_MIGRATION_PRODUCT_DEPLOYMENT_NAME={pre-migration-prod-deployment}
@@ -100,6 +101,7 @@ export PRE_MIGRATION_PRODUCT_OPERATOR_NAME={pre-migration-prod-operator}
 export PRE_MIGRATION_PRODUCT_OLM_PACKAGE={pre-migration-prod-package}
 export PRE_MIGRATION_PRODUCT_OLM_CHANNEL={pre-migration-prod-channel}
 export PRE_MIGRATION_PRODUCT_OLM_CATALOG_SOURCE={pre-migration-prod-catalog-source}
+export PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV={pre-migration-prod-starting-csv}
 ----
 <1> `{prod-namespace}` or another {orch-namespace} where {prod-prev-short} was previously installed.
 <2> `{prod-namespace}` or another {orch-namespace} where {prod-prev-short} was previously installed.


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>


<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

Downstream values:
```
pre-migration-prod-starting-csv: crwoperator.v2.15.4 # (or v2.15.104 if running the Technoogy Preview version)
prod-stable-channel-starting-csv: devspacesoperator.v3.0.0
```

## What does this pull request change
* Get CSV name from `status.installedCSV` field
* Add `startingCSV` field to subscription to avoid migration to the version with CheCluster API v2, in this case rollback won't be possible
* Set `installPlanApproval` to `Manual`
* Install plan approval

## What issues does this pull request fix or reference
https://issues.redhat.com/browse/CRW-3028

## Specify the version of the product this pull request applies to

## Pull request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
