### PR TITLE
fix: add extra steps for monitoring docs

### DIFF
--- a/modules/administration-guide/examples/snip_che-create-monitoring-namespace.adoc
+++ b/modules/administration-guide/examples/snip_che-create-monitoring-namespace.adoc
@@ -1,0 +1,4 @@
+[subs="+attributes,quotes"]
+----
+$ {orch-cli} create {orch-namespace} monitoring
+----

--- a/modules/administration-guide/examples/snip_che-create-monitoring-namespace.adoc
+++ b/modules/administration-guide/examples/snip_che-create-monitoring-namespace.adoc
@@ -1,4 +1,4 @@
-[subs="+attributes,quotes"]
+[source,terminal,subs="+attributes,quotes"]
 ----
 $ {orch-cli} create {orch-namespace} monitoring
 ----

--- a/modules/administration-guide/pages/configuring-observability.adoc
+++ b/modules/administration-guide/pages/configuring-observability.adoc
@@ -12,5 +12,5 @@ To configure {prod-short} observability features, see:
 * xref:che-theia-workspaces.adoc[]
 * xref:configuring-server-logging.adoc[]
 * xref:collecting-logs-using-chectl.adoc[]
-* xref:monitoring-che.adoc[]
 * xref:monitoring-the-dev-workspace-operator.adoc[]
+* xref:monitoring-che.adoc[]

--- a/modules/administration-guide/pages/installing-prometheus-and-grafana.adoc
+++ b/modules/administration-guide/pages/installing-prometheus-and-grafana.adoc
@@ -9,7 +9,7 @@
 [id="installing-prometheus-and-grafana"]
 = Installing Prometheus and Grafana
 
-You can install Prometheus and Grafana by applying `template.yaml` that consists of a Deployment and Service for both Prometheus and Grafana.
+You can install Prometheus and Grafana by applying `template.yaml` which provides an example monitoring stack consisting of basic configuration, Deployments and Services to get started with Prometheus and Grafana.
 
 Alternatively, you can use the link:https://github.com/prometheus-operator/prometheus-operator[Prometheus Operator] and link:https://github.com/grafana-operator/grafana-operator[Grafana Operator].
 
@@ -19,9 +19,18 @@ Alternatively, you can use the link:https://github.com/prometheus-operator/prome
 
 .Procedure
 
-To install Prometheus and Grafana by using `template.yaml`:
+For this example monitoring stack, Prometheus and Grafana will be installed in a new {orch-namespace} called `monitoring`. To install Prometheus and Grafana by using `template.yaml`:
 
-* Apply `template.yaml` to the cluster by running `{orch-cli} apply -f template.yaml`.
+. Create a new {orch-namespace} called `monitoring`:
++
+include::example$snip_{project-context}-create-monitoring-namespace.adoc[]
+
+. Apply `template.yaml` in the `monitoring` {orch-namespace}:
++
+[subs="+attributes,quotes"]
+----
+$ {orch-cli} apply -f template.yaml -n monitoring
+----
 
 .`template.yaml`
 ====
@@ -95,6 +104,7 @@ spec:
       labels:
         app: prometheus
     spec:
+      serviceAccountName: prometheus
       containers:
       - image: quay.io/prometheus/prometheus:v2.36.0
         name: prometheus
@@ -120,7 +130,12 @@ kind: ConfigMap
 metadata:
   name: prometheus-config
 data:
-  prometheus.yml: |
+  prometheus.yml: ""
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
 ---
 ----
 ====

--- a/modules/administration-guide/pages/installing-prometheus-and-grafana.adoc
+++ b/modules/administration-guide/pages/installing-prometheus-and-grafana.adoc
@@ -9,7 +9,7 @@
 [id="installing-prometheus-and-grafana"]
 = Installing Prometheus and Grafana
 
-You can install Prometheus and Grafana by applying `template.yaml` which provides an example monitoring stack consisting of basic configuration, Deployments and Services to get started with Prometheus and Grafana.
+You can install Prometheus and Grafana by applying `template.yaml`. The `template.yaml` file in this example provides a monitoring stack of basic configuration, Deployments and Services to get started with Prometheus and Grafana.
 
 Alternatively, you can use the link:https://github.com/prometheus-operator/prometheus-operator[Prometheus Operator] and link:https://github.com/grafana-operator/grafana-operator[Grafana Operator].
 

--- a/modules/administration-guide/pages/installing-prometheus-and-grafana.adoc
+++ b/modules/administration-guide/pages/installing-prometheus-and-grafana.adoc
@@ -21,7 +21,7 @@ Alternatively, you can use the link:https://github.com/prometheus-operator/prome
 
 To install Prometheus and Grafana by using `template.yaml`:
 
-. Create a new {orch-namespace} called `monitoring`:
+. Create a new {orch-namespace}, `monitoring`, for Prometheus and Grafana:
 +
 include::example$snip_{project-context}-create-monitoring-namespace.adoc[]
 

--- a/modules/administration-guide/pages/installing-prometheus-and-grafana.adoc
+++ b/modules/administration-guide/pages/installing-prometheus-and-grafana.adoc
@@ -19,7 +19,7 @@ Alternatively, you can use the link:https://github.com/prometheus-operator/prome
 
 .Procedure
 
-For this example monitoring stack, Prometheus and Grafana will be installed in a new {orch-namespace} called `monitoring`. To install Prometheus and Grafana by using `template.yaml`:
+To install Prometheus and Grafana by using `template.yaml`:
 
 . Create a new {orch-namespace} called `monitoring`:
 +

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -56,7 +56,7 @@ $ {orch-cli} scale --replicas=0 deployment/prometheus -n monitoring && {orch-cli
 ----
 $ {orch-cli} port-forward svc/prometheus 9090:9090 -n monitoring
 ----
-. Verify that all targets are up by viewing the targets endpoint at `localhost:9090/targets`.
+. Verify that all targets are up by viewing the `targets` endpoint at `localhost:9090/targets`.
 . Use the Prometheus console to view and query metrics:
 ** View the metrics at `localhost:9090/metrics`.
 ** Query metrics from `localhost:9090/graph`.

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -15,7 +15,7 @@ To use Prometheus to collect, store, and query JVM metrics for {prod-short} Serv
 
 . Configure Prometheus to scrape metrics from port `8087`.
 +
-NOTE: The xref:installing-prometheus-and-grafana.adoc[example monitoring stack] already creates the `prometheus-config` ConfigMap with an empty configuration. Edit the `data` field of the ConfigMap to provide the Prometheus configuration details.
+NOTE: The xref:installing-prometheus-and-grafana.adoc[example monitoring stack] already creates the `prometheus-config` ConfigMap with an empty configuration. To provide the Prometheus configuration details, edit the `data` field of the ConfigMap.
 +
 .Prometheus configuration
 ====

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -9,15 +9,17 @@ To use Prometheus to collect, store, and query JVM metrics for {prod-short} Serv
 
 * {prod-short} is exposing metrics on port `8087`. See xref:enabling-and-exposing-{prod-id-short}-metrics_{context}[Enabling and exposing {prod-short} server JVM metrics].
 
-* Prometheus  2.26.0 or later is running. The Prometheus console is running on port `9090` with a corresponding `service` and `route`. See link:https://prometheus.io/docs/introduction/first_steps/[First steps with Prometheus].
+* Prometheus 2.26.0 or later is running. The Prometheus console is running on port `9090` with a corresponding Service. See link:https://prometheus.io/docs/introduction/first_steps/[First steps with Prometheus].
 
 .Procedure
 
-* Configure Prometheus to scrape metrics from port `8087`.
+. Configure Prometheus to scrape metrics from port `8087`.
++
+NOTE: The xref:installing-prometheus-and-grafana.adoc[example monitoring stack] already creates the `prometheus-config` ConfigMap with an empty configuration. Edit the `data` field of the ConfigMap to provide the Prometheus configuration details.
 +
 .Prometheus configuration
 ====
-[source,yaml,subs="+attributes"]
+[source,yaml,subs="+quotes,+attributes,+macros"]
 ----
 apiVersion: v1
 kind: ConfigMap
@@ -28,24 +30,38 @@ data:
       global:
         scrape_interval:     5s             <1>
         evaluation_interval: 5s             <2>
-      scrape_configs:                       <3>  
-        - job_name: 'che'
+      scrape_configs:                       <3>
+        - job_name: 'Che Server'
           static_configs:
-            - targets: ['[che-host]:8087']  <4>          
+            - targets: ['che-host.__<{prod-short}_namespace>__:8087']  <4>
 ----
 <1> The rate at which a target is scraped.
 <2> The rate at which the recording and alerting rules are re-checked.
-<3> The Resources that Prometheus monitors. In the default configuration, a single job, `che`, scrapes the time series data exposed by {prod-short} Server.
-<4> The scrape metrics from port `8087`.
+<3> The Resources that Prometheus monitors. In the default configuration, a single job, `Che Server`, scrapes the time series data exposed by {prod-short} Server.
+<4> Scrape metrics from port `8087`. Replace `__<{prod-short}_namespace>__` with the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
 ====
+
+. Scale down and scale up the `Prometheus` Deployment to read the updated ConfigMap from the previous step.
++
+[subs="+attributes,quotes"]
+----
+$ {orch-cli} scale --replicas=0 deployment/prometheus -n monitoring && {orch-cli} scale --replicas=1 deployment/prometheus -n monitoring
+----
 
 .Verification steps
 
-. View the metrics in the Prometheus console at `http://__<prometheus-url>__/metrics`.
-
-. Query the metrics in the Prometheus console from `http://__<prometheus-url>__/graph`. For more information, see link:https://prometheus.io/docs/introduction/first_steps/#using-the-expression-browser[Using the expression browser].
-
-. Verify that all targets are up by viewing the targets endpoint at `http://__<prometheus-url>__/targets`.
+. Use port forwarding to access the `Prometheus` Service locally:
++
+[subs="+attributes,quotes"]
+----
+$ {orch-cli} port-forward svc/prometheus 9090:9090 -n monitoring
+----
+. Verify that all targets are up by viewing the targets endpoint at `localhost:9090/targets`.
+. Use the Prometheus console to view and query metrics:
+** View the metrics at `localhost:9090/metrics`.
+** Query metrics from `localhost:9090/graph`.
++
+For more information, see link:https://prometheus.io/docs/introduction/first_steps/#using-the-expression-browser[Using the expression browser].
 
 .Additional resources
 

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -41,7 +41,7 @@ data:
 <4> Scrape metrics from port `8087`. Replace `__<{prod-short}_{orch-namespace}>__` with the {prod-short} {orch-namespace}. The default {prod-short} {orch-namespace} is `{prod-namespace}`.
 ====
 
-. Scale down and scale up the `Prometheus` Deployment to read the updated ConfigMap from the previous step.
+. Scale the `Prometheus` Deployment down and up to read the updated ConfigMap from the previous step.
 +
 [subs="+attributes,quotes"]
 ----

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -38,7 +38,7 @@ data:
 <1> The rate at which a target is scraped.
 <2> The rate at which the recording and alerting rules are re-checked.
 <3> The Resources that Prometheus monitors. In the default configuration, a single job, `Che Server`, scrapes the time series data exposed by {prod-short} Server.
-<4> Scrape metrics from port `8087`. Replace `__<{prod-short}_namespace>__` with the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
+<4> Scrape metrics from port `8087`. Replace `__<{prod-short}_{orch-namespace}>__` with the {prod-short} {orch-namespace}. The default {prod-short} {orch-namespace} is `{prod-namespace}`.
 ====
 
 . Scale down and scale up the `Prometheus` Deployment to read the updated ConfigMap from the previous step.

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -58,8 +58,8 @@ $ {orch-cli} port-forward svc/prometheus 9090:9090 -n monitoring
 ----
 . Verify that all targets are up by viewing the `targets` endpoint at `localhost:9090/targets`.
 . Use the Prometheus console to view and query metrics:
-** The metrics are available at `localhost:9090/metrics`.
-** The metrics can be queried from `localhost:9090/graph`.
+** View metrics at `localhost:9090/metrics`.
+** Query metrics from `localhost:9090/graph`.
 +
 For more information, see link:https://prometheus.io/docs/introduction/first_steps/#using-the-expression-browser[Using the expression browser].
 

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -33,17 +33,17 @@ data:
       scrape_configs:                       <3>
         - job_name: 'Che Server'
           static_configs:
-            - targets: ['che-host.__<{prod-short}_namespace>__:8087']  <4>
+            - targets: ['che-host.__<{prod-short}_{orch-namespace}>__:8087']  <4>
 ----
 <1> The rate at which a target is scraped.
 <2> The rate at which the recording and alerting rules are re-checked.
-<3> The Resources that Prometheus monitors. In the default configuration, a single job, `Che Server`, scrapes the time series data exposed by {prod-short} Server.
-<4> Scrape metrics from port `8087`. Replace `__<{prod-short}_{orch-namespace}>__` with the {prod-short} {orch-namespace}. The default {prod-short} {orch-namespace} is `{prod-namespace}`.
+<3> The resources that Prometheus monitors. In the default configuration, a single job, `Che Server`, scrapes the time series data exposed by {prod-short} Server.
+<4> The scrape target for the metrics from port `8087`. Replace `__<{prod-short}_{orch-namespace}>__` with the {prod-short} {orch-namespace}. The default {prod-short} {orch-namespace} is `{prod-namespace}`.
 ====
 
 . Scale the `Prometheus` Deployment down and up to read the updated ConfigMap from the previous step.
 +
-[subs="+attributes,quotes"]
+[source,terminal,subs="+attributes,quotes"]
 ----
 $ {orch-cli} scale --replicas=0 deployment/prometheus -n monitoring && {orch-cli} scale --replicas=1 deployment/prometheus -n monitoring
 ----
@@ -52,14 +52,14 @@ $ {orch-cli} scale --replicas=0 deployment/prometheus -n monitoring && {orch-cli
 
 . Use port forwarding to access the `Prometheus` Service locally:
 +
-[subs="+attributes,quotes"]
+[source,terminal,subs="+attributes,quotes"]
 ----
 $ {orch-cli} port-forward svc/prometheus 9090:9090 -n monitoring
 ----
 . Verify that all targets are up by viewing the `targets` endpoint at `localhost:9090/targets`.
 . Use the Prometheus console to view and query metrics:
-** View the metrics at `localhost:9090/metrics`.
-** Query metrics from `localhost:9090/graph`.
+** The metrics are available at `localhost:9090/metrics`.
+** The metrics can be queried from `localhost:9090/graph`.
 +
 For more information, see link:https://prometheus.io/docs/introduction/first_steps/#using-the-expression-browser[Using the expression browser].
 

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -48,7 +48,7 @@ data:
 $ {orch-cli} scale --replicas=0 deployment/prometheus -n monitoring && {orch-cli} scale --replicas=1 deployment/prometheus -n monitoring
 ----
 
-.Verification steps
+.Verification
 
 . Use port forwarding to access the `Prometheus` Service locally:
 +

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -6,7 +6,7 @@ To use Prometheus to collect, store, and query metrics about the {devworkspace} 
 
 .Prerequisites
 
-* The `devworkspace-controller-metrics` Service is exposing metrics on port `8443`. This is pre-configured by default.
+* The `devworkspace-controller-metrics` Service is exposing metrics on port `8443`. This is preconfigured by default.
 
 * The `devworkspace-webhookserver` Service is exposing metrics on port `9443`. This is pre-configured by default.
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -99,8 +99,8 @@ $ {orch-cli} port-forward svc/prometheus 9090:9090 -n monitoring
 ----
 . Verify that all targets are up by viewing the targets endpoint at `localhost:9090/targets`.
 . Use the Prometheus console to view and query metrics:
-** The metrics are available at `localhost:9090/metrics`.
-** The metrics can be queried from `localhost:9090/graph`.
+** View metrics at `localhost:9090/metrics`.
+** Query metrics from `localhost:9090/graph`.
 +
 For more information, see link:https://prometheus.io/docs/introduction/first_steps/#using-the-expression-browser[Using the expression browser].
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -39,7 +39,7 @@ roleRef:
 
 . Configure Prometheus to scrape metrics from port `8443` exposed by the `devworkspace-controller-metrics` Service and from port `9443` exposed by the `devworkspace-webhookserver` Service.
 +
-NOTE: The example monitoring stack already creates the `prometheus-config` ConfigMap with an empty configuration. Edit the `data` field of the ConfigMap to provide the Prometheus configuration details.
+NOTE: The example monitoring stack already creates the `prometheus-config` ConfigMap with an empty configuration. To provide the Prometheus configuration details, edit the `data` field of the ConfigMap.
 +
 .Prometheus configuration
 ====

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -6,33 +6,17 @@ To use Prometheus to collect, store, and query metrics about the {devworkspace} 
 
 .Prerequisites
 
-* The link:https://github.com/devfile/devworkspace-operator/blob/v0.10.0/deploy/deployment/kubernetes/objects/devworkspace-controller-metrics.Service.yaml[`devworkspace-controller-metrics` Service] is exposing metrics on port `8443`.
+* The `devworkspace-controller-metrics` Service is exposing metrics on port `8443`. This is pre-configured by default.
 
-* The `devworkspace-webhookserver` Service is exposing metrics on port `9443`. By default, the Service exposes metrics on port `9443`.
+* The `devworkspace-webhookserver` Service is exposing metrics on port `9443`. This is pre-configured by default.
 
-* Prometheus 2.26.0 or later is running. The Prometheus console is running on port `9090` with a corresponding `service` and `route`. See link:https://prometheus.io/docs/introduction/first_steps/[First steps with Prometheus].
+* Prometheus 2.26.0 or later is running. The Prometheus console is running on port `9090` with a corresponding Service. See link:https://prometheus.io/docs/introduction/first_steps/[First steps with Prometheus].
 
 .Procedure
 
-. Create a `ClusterRoleBinding` to bind the `ServiceAccount` associated with Prometheus to the link:https://github.com/devfile/devworkspace-operator/blob/main/deploy/deployment/kubernetes/objects/devworkspace-controller-metrics-reader.ClusterRole.yaml[devworkspace-controller-metrics-reader] `ClusterRole`.
+. Create a ClusterRoleBinding to bind the ServiceAccount associated with Prometheus to the link:https://github.com/devfile/devworkspace-operator/blob/main/deploy/deployment/kubernetes/objects/devworkspace-controller-metrics-reader.ClusterRole.yaml[devworkspace-controller-metrics-reader] ClusterRole. For the xref:installing-prometheus-and-grafana.adoc[example monitoring stack], the name of the ServiceAccount to be be used is `prometheus`.
 +
-NOTE: Without the `ClusterRoleBinding`, you cannot access {devworkspace} metrics because access is protected with role-based access control (RBAC).
-+
-.ClusterRole
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: devworkspace-controller-metrics-reader
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
-----
-====
+NOTE: Without the ClusterRoleBinding, you cannot access {devworkspace} metrics because access is protected with role-based access control (RBAC).
 +
 .ClusterRoleBinding
 ====
@@ -44,8 +28,8 @@ metadata:
   name: devworkspace-controller-metrics-binding
 subjects:
   - kind: ServiceAccount
-    name: __<ServiceAccount_name_associated_with_the_Prometheus_Pod>__
-    namespace: __<Prometheus_namespace>__
+    name: prometheus
+    namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -55,6 +39,8 @@ roleRef:
 
 . Configure Prometheus to scrape metrics from port `8443` exposed by the `devworkspace-controller-metrics` Service and from port `9443` exposed by the `devworkspace-webhookserver` Service.
 +
+NOTE: The example monitoring stack already creates the `prometheus-config` ConfigMap with an empty configuration. Edit the `data` field of the ConfigMap to provide the Prometheus configuration details.
++
 .Prometheus configuration
 ====
 [source,yaml,subs="+quotes,+attributes,+macros"]
@@ -63,6 +49,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-config
+  namespace: monitoring
 data:
   prometheus.yml: |-
       global:
@@ -77,7 +64,7 @@ data:
           tls_config:
             insecure_skip_verify: true
           static_configs:
-            - targets: ['devworkspace-controller-metrics:8443'] <4>
+            - targets: ['devworkspace-controller-metrics.__<DWO_{orch-namespace}>__:8443'] <4>
         - job_name: 'DevWorkspace webhooks'
           scheme: https
           authorization:
@@ -86,24 +73,36 @@ data:
           tls_config:
             insecure_skip_verify: true
           static_configs:
-            - targets: ['devworkspace-webhookserver:9443'] <5>
+            - targets: ['devworkspace-webhookserver.__<DWO_{orch-namespace}>__:9443'] <5>
 ----
 <1> The rate at which a target is scraped.
 <2> The rate at which the recording and alerting rules are re-checked.
 <3> The resources that Prometheus monitors. In the default configuration, two jobs, `DevWorkspace` and `DevWorkspace webhooks`, scrape the time series data exposed by the `devworkspace-controller-metrics` and `devworkspace-webhookserver` Services.
-<4> The scrape metrics from port `8443`.
-<5> The scrape metrics from port `9443`.
+<4> Scrape metrics from port `8443`. Replace `__<DWO_namespace>__` with the {orch-namespace} where the `devworkspace-controller-metrics` `Service` is located.
+<5> Scrape metrics from port `9443`. Replace `__<DWO_namespace>__` with the {orch-namespace} where the `devworkspace-webhookserver` `Service` is located.
 ====
+
+. Scale down and scale up the `Prometheus` Deployment to read the updated ConfigMap from the previous step.
++
+[subs="+attributes,quotes"]
+----
+$ {orch-cli} scale --replicas=0 deployment/prometheus -n monitoring && {orch-cli} scale --replicas=1 deployment/prometheus -n monitoring
+----
 
 .Verification steps
 
+. Use port forwarding to access the `Prometheus` Service locally:
++
+[subs="+attributes,quotes"]
+----
+$ {orch-cli} port-forward svc/prometheus 9090:9090 -n monitoring
+----
+. Verify that all targets are up by viewing the targets endpoint at `localhost:9090/targets`.
 . Use the Prometheus console to view and query metrics:
-** View the metrics at `http://__<prometheus_url>__/metrics`.
-** Query metrics from `http://__<prometheus_url>__/graph`.
+** View the metrics at `localhost:9090/metrics`.
+** Query metrics from `localhost:9090/graph`.
 +
 For more information, see link:https://prometheus.io/docs/introduction/first_steps/#using-the-expression-browser[Using the expression browser].
-. Verify that all targets are up by viewing the targets endpoint at `http://__<prometheus-url>__/targets`.
-
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -8,7 +8,7 @@ To use Prometheus to collect, store, and query metrics about the {devworkspace} 
 
 * The `devworkspace-controller-metrics` Service is exposing metrics on port `8443`. This is preconfigured by default.
 
-* The `devworkspace-webhookserver` Service is exposing metrics on port `9443`. This is pre-configured by default.
+* The `devworkspace-webhookserver` Service is exposing metrics on port `9443`. This is preconfigured by default.
 
 * Prometheus 2.26.0 or later is running. The Prometheus console is running on port `9090` with a corresponding Service. See link:https://prometheus.io/docs/introduction/first_steps/[First steps with Prometheus].
 
@@ -39,7 +39,7 @@ roleRef:
 
 . Configure Prometheus to scrape metrics from port `8443` exposed by the `devworkspace-controller-metrics` Service and from port `9443` exposed by the `devworkspace-webhookserver` Service.
 +
-NOTE: The example monitoring stack already creates the `prometheus-config` ConfigMap with an empty configuration. To provide the Prometheus configuration details, edit the `data` field of the ConfigMap.
+NOTE: The xref:installing-prometheus-and-grafana.adoc[example monitoring stack] already creates the `prometheus-config` ConfigMap with an empty configuration. To provide the Prometheus configuration details, edit the `data` field of the ConfigMap.
 +
 .Prometheus configuration
 ====
@@ -78,29 +78,29 @@ data:
 <1> The rate at which a target is scraped.
 <2> The rate at which the recording and alerting rules are re-checked.
 <3> The resources that Prometheus monitors. In the default configuration, two jobs, `DevWorkspace` and `DevWorkspace webhooks`, scrape the time series data exposed by the `devworkspace-controller-metrics` and `devworkspace-webhookserver` Services.
-<4> Scrape metrics from port `8443`. Replace `__<DWO_namespace>__` with the {orch-namespace} where the `devworkspace-controller-metrics` `Service` is located.
-<5> Scrape metrics from port `9443`. Replace `__<DWO_namespace>__` with the {orch-namespace} where the `devworkspace-webhookserver` `Service` is located.
+<4> The scrape target for the metrics from port `8443`. Replace `__<DWO_{orch-namespace}>__` with the {orch-namespace} where the `devworkspace-controller-metrics` `Service` is located.
+<5> The scrape target for the metrics from port `9443`. Replace `__<DWO_{orch-namespace}>__` with the {orch-namespace} where the `devworkspace-webhookserver` `Service` is located.
 ====
 
 . Scale the `Prometheus` Deployment down and up to read the updated ConfigMap from the previous step.
 +
-[subs="+attributes,quotes"]
+[source,terminal,subs="+attributes,quotes"]
 ----
 $ {orch-cli} scale --replicas=0 deployment/prometheus -n monitoring && {orch-cli} scale --replicas=1 deployment/prometheus -n monitoring
 ----
 
-.Verification steps
+.Verification
 
 . Use port forwarding to access the `Prometheus` Service locally:
 +
-[subs="+attributes,quotes"]
+[source,terminal,subs="+attributes,quotes"]
 ----
 $ {orch-cli} port-forward svc/prometheus 9090:9090 -n monitoring
 ----
 . Verify that all targets are up by viewing the targets endpoint at `localhost:9090/targets`.
 . Use the Prometheus console to view and query metrics:
-** View the metrics at `localhost:9090/metrics`.
-** Query metrics from `localhost:9090/graph`.
+** The metrics are available at `localhost:9090/metrics`.
+** The metrics can be queried from `localhost:9090/graph`.
 +
 For more information, see link:https://prometheus.io/docs/introduction/first_steps/#using-the-expression-browser[Using the expression browser].
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -82,7 +82,7 @@ data:
 <5> Scrape metrics from port `9443`. Replace `__<DWO_namespace>__` with the {orch-namespace} where the `devworkspace-webhookserver` `Service` is located.
 ====
 
-. Scale down and scale up the `Prometheus` Deployment to read the updated ConfigMap from the previous step.
+. Scale the `Prometheus` Deployment down and up to read the updated ConfigMap from the previous step.
 +
 [subs="+attributes,quotes"]
 ----

--- a/modules/administration-guide/partials/proc_viewing-che-metrics-on-grafana-dashboards.adoc
+++ b/modules/administration-guide/partials/proc_viewing-che-metrics-on-grafana-dashboards.adoc
@@ -9,7 +9,7 @@ To view the {prod-short} Server metrics on Grafana:
 
 * Prometheus is collecting metrics on the {prod-short} cluster. See xref:monitoring-with-prometheus-and-grafana.adoc[].
 
-* Grafana 6.0 or later is running on port `3000` with a corresponding `service` and `route`. See link:https://grafana.com/docs/grafana/latest/installation/kubernetes/[Installing Grafana].
+* Grafana 6.0 or later is running on port `3000` with a corresponding Service. See link:https://grafana.com/docs/grafana/latest/installation/kubernetes/[Installing Grafana].
 
 
 .Procedure

--- a/modules/administration-guide/partials/proc_viewing-dev-workspace-operator-metrics-on-grafana-dashboards.adoc
+++ b/modules/administration-guide/partials/proc_viewing-dev-workspace-operator-metrics-on-grafana-dashboards.adoc
@@ -9,7 +9,7 @@ To view the {devworkspace} Operator metrics on Grafana with the example dashboar
 
 * Grafana version 7.5.3 or later.
 
-* Grafana is running on port `3000` with a corresponding `service` and `route`. See link:https://grafana.com/docs/grafana/latest/installation/kubernetes/[Installing Grafana].
+* Grafana is running on port `3000` with a corresponding Service. See link:https://grafana.com/docs/grafana/latest/installation/kubernetes/[Installing Grafana].
 
 
 


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR adds/changes steps to the monitoring docs to make them easier to follow along:
* https://www.eclipse.org/che/docs/stable/administration-guide/configuring-observability/
* https://www.eclipse.org/che/docs/stable/administration-guide/installing-prometheus-and-grafana/
* https://www.eclipse.org/che/docs/stable/administration-guide/monitoring-the-dev-workspace-operator/
* https://www.eclipse.org/che/docs/stable/administration-guide/monitoring-che/

## What issues does this pull request fix or reference?
https://github.com/eclipse/che/issues/21444

## Specify the version of the product this pull request applies to
stable, next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
