### PR TITLE
chore: get_vale_styles compatible with unzip rather than busybox unzip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ build/site.zip
 build/site-unbranded
 
 # Keep Vale styles external
+.github/styles/
 .vale/styles/
 
 linkchecker-out.html

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,7 +2,7 @@
 # See: https://docs.errata.ai/vale/config
 
 # The relative path to the folder containing linting rules (styles).
-StylesPath = .vale/styles
+StylesPath = .github/styles
 
 # Minimum alert level
 # -------------------

--- a/tools/get_vale_styles.sh
+++ b/tools/get_vale_styles.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # Copyright (c) 2021 Red Hat, Inc.
 # This program and the accompanying materials are made
@@ -7,12 +7,23 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
+# Download a fresh version of the RedHat and CheDocs Vale styles.
 
 # Fail on errors
 set -e
-
-# Get fresh Vale styles
-cd .vale/styles || exit
-rm -rf RedHat CheDocs 
-wget -qO- https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/RedHat.zip | unzip -q -
-wget -qO- https://github.com/eclipse-che/che-docs-vale-style/releases/latest/download/CheDocs.zip | unzip -q -
+# New files will be group writeable (for local builds)
+umask 002
+ScriptDir="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+RootDir="${ScriptDir%/tools*}"
+StylesDir="${RootDir}/.github/styles"
+# Create destination directory if required
+mkdir --parents "${StylesDir}"
+# Download a fresh version of the RedHat Vale style
+wget --output-document="${StylesDir}/RedHat.zip" --quiet --timestamping  https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/RedHat.zip
+rm --force --recursive "${StylesDir}/RedHat"
+unzip -q -d  "${StylesDir}" RedHat.zip
+# Download a fresh version of the CheDocs Vale style
+wget --output-document="${StylesDir}/CheDocs.zip" --quiet --timestamping https://github.com/eclipse-che/che-docs-vale-style/releases/latest/download/CheDocs.zip
+rm --force --recursive "${StylesDir}/CheDocs"
+unzip -q -d  "${StylesDir}" CheDocs.zip
+echo 'INFO: Downloaded a fresh version of the Red Hat Vale style and configuration file.'


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

chore: get_vale_styles compatible with unzip rather than busybox unzip

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
