### PR TITLE
fix: adding an xref about authentication as an optional prerequisite

### DIFF
--- a/modules/end-user-guide/pages/starting-a-new-workspace-with-a-clone-of-a-git-repository.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-with-a-clone-of-a-git-repository.adoc
@@ -22,7 +22,7 @@ TIP: You can also use the *Git Repo URL ** field on the *Create Workspace* page 
 
 * Your organization has a running instance of {prod-short}.
 * You know the FQDN URL of your organization's {prod-short} instance: `pass:c,a,q[{prod-url}]`.
-* Optional: xref:authenticating-yourself-to-a-git-server-from-a-workspace.adoc[Authentication to the Git server] is configured.
+* Optional: You have xref:authenticating-yourself-to-a-git-server-from-a-workspace.adoc[authentication to the Git server] configured.
 * Your Git repository maintainer keeps the `devfile.yaml` or `.devfile.yaml` file in the root directory of the Git repository. (For alternative file names and file paths, see xref:optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc[].)
 +
 TIP: You can also start a new workspace by supplying the URL of a Git repository that contains no devfile. Doing so results in a workspace with the Che-Theia IDE and the Universal Developer Image.

--- a/modules/end-user-guide/pages/starting-a-new-workspace-with-a-clone-of-a-git-repository.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-with-a-clone-of-a-git-repository.adoc
@@ -22,6 +22,7 @@ TIP: You can also use the *Git Repo URL ** field on the *Create Workspace* page 
 
 * Your organization has a running instance of {prod-short}.
 * You know the FQDN URL of your organization's {prod-short} instance: `pass:c,a,q[{prod-url}]`.
+* Optional: xref:authenticating-yourself-to-a-git-server-from-a-workspace.adoc[Authentication to the Git server] is configured.
 * Your Git repository maintainer keeps the `devfile.yaml` or `.devfile.yaml` file in the root directory of the Git repository. (For alternative file names and file paths, see xref:optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc[].)
 +
 TIP: You can also start a new workspace by supplying the URL of a Git repository that contains no devfile. Doing so results in a workspace with the Che-Theia IDE and the Universal Developer Image.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Add an optional prerequisite regarding authentication to a Git server to the procedure about starting a new workspace.

In the new docs, relevant pages for RHDEVDOCS-4061 are:

- https://www.eclipse.org/che/docs/next/end-user-guide/starting-a-new-workspace-with-a-clone-of-a-git-repository/
- https://www.eclipse.org/che/docs/next/end-user-guide/authenticating-yourself-to-a-git-server-from-a-workspace/

This PR aims to solve RHDEVDOCS-4061 by additionally linking the second mentioned page as an optional prerequisite in the first mentioned page.

## What issues does this pull request fix or reference?
RHDEVDOCS-4061

## Specify the version of the product this pull request applies to
7.46

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
