### PR TITLE
fix: pem 'trusted certificate' update

### DIFF
--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -34,7 +34,7 @@ If the cluster is configured with an intermediate certificate, then the whole ch
 
 == Adding new CA certificates into {prod-short}
 
-Certificate files are typically stored as Base64 ASCII files, such as `.pem`, `.crt`, `.ca-bundle`. But they can also be binary-encoded, for example, as `.cer` files. All Secrets that hold certificate files should use the Base64 ASCII certificate rather than the binary-encoded certificate. The following procedure is applicable for already installed and running instances and for instances that are to be installed.
+Certificate files are typically stored as Base64 files, with extensions such as `.pem`, `.crt`, `.ca-bundle`and others. But they can also be binary-encoded, for example, as `.cer` files. All Secrets that hold certificate files should use the Base64-encoded certificate rather than binary-encoded. The following procedure is applicable for already installed and running instances and for instances that are to be installed.
 
 .Prerequisites
 
@@ -50,7 +50,7 @@ Certificate files are typically stored as Base64 ASCII files, such as `.pem`, `.
 +
 [CAUTION]
 ====
-* A certificate with the `BEGIN TRUSTED CERTIFICATE` introductory phrase is likely in the PEM `TRUSTED CERTIFICATE` format, which is not supported by Java. Convert it to the supported `CERTIFICATE` format with the following command:
+* A certificate with the `BEGIN TRUSTED CERTIFICATE` introductory phrase is likely in the PEM `TRUSTED CERTIFICATE` format, which is not supported. Convert it to the supported `CERTIFICATE` format with the following command:
 ** `openssl x509 -in cert.pem -out cert.cer`
 ====
 

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -34,7 +34,7 @@ If the cluster is configured with an intermediate certificate, then the whole ch
 
 == Adding new CA certificates into {prod-short}
 
-Certificate files are typically stored as Base64 files, with extensions such as `.pem`, `.crt`, `.ca-bundle` and others. All Secrets that hold certificate files should use the Base64-encoded certificate rather than binary-encoded. The following procedure is applicable for already installed and running instances and for instances that are to be installed.
+Certificate files are typically stored as Base64 files, with extensions such as `.pem`, `.crt`, `.ca-bundle`, and others. All Secrets that hold certificate files should use the Base64-encoded certificate rather than binary-encoded certificate. The following procedure is applicable for already installed and running instances and for instances that are to be installed.
 
 .Prerequisites
 

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -48,7 +48,7 @@ The following procedure is applicable for already installed and running instance
 [CAUTION]
 ====
 * Certificate files are typically stored as Base64 ASCII files, such as `.pem`, `.crt`, `.ca-bundle`. But they can also be binary-encoded, for example, as `.cer` files. All Secrets that hold certificate files should use the Base64 ASCII certificate rather than the binary-encoded certificate.
-* A certificate with the introductory phrase `BEGIN TRUSTED CERTIFICATE` is likely in the PEM `TRUSTED CERTIFICATE` format, which is not not supported by Java. Convert it to the supported `CERTIFICATE` format with the following command:
+* A certificate with the `BEGIN TRUSTED CERTIFICATE` introductory phrase is likely in the PEM `TRUSTED CERTIFICATE` format, which is not supported by Java. Convert it to the supported `CERTIFICATE` format with the following command:
 ** `openssl x509 -in cert.pem -out cert.cer`
 * {prod-short} already uses some reserved file names to automatically inject certificates into the ConfigMap, so you should avoid using the following reserved file names to save your certificates:
   ** `ca-bundle.crt`

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -40,7 +40,7 @@ Certificate files are typically stored as Base64 files, with extensions such as 
 
 * An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 * Namespace for {prod-short} exists.
-* {prod-short} already uses some reserved file names to automatically inject certificates into the ConfigMap, so you should avoid using the following reserved file names to save your certificates:
+* {prod-short} already uses some reserved file names to automatically inject certificates into the ConfigMap, so avoid using the following reserved file names to save your certificates:
   ** `ca-bundle.crt`
   ** `ca.crt`
 

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -34,7 +34,7 @@ If the cluster is configured with an intermediate certificate, then the whole ch
 
 == Adding new CA certificates into {prod-short}
 
-Certificate files are typically stored as Base64 files, with extensions such as `.pem`, `.crt`, `.ca-bundle` and others. But they can also be binary-encoded, for example, as `.cer` files. All Secrets that hold certificate files should use the Base64-encoded certificate rather than binary-encoded. The following procedure is applicable for already installed and running instances and for instances that are to be installed.
+Certificate files are typically stored as Base64 files, with extensions such as `.pem`, `.crt`, `.ca-bundle` and others. All Secrets that hold certificate files should use the Base64-encoded certificate rather than binary-encoded. The following procedure is applicable for already installed and running instances and for instances that are to be installed.
 
 .Prerequisites
 

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -34,12 +34,15 @@ If the cluster is configured with an intermediate certificate, then the whole ch
 
 == Adding new CA certificates into {prod-short}
 
-The following procedure is applicable for already installed and running instances and for instances that are to be installed.
+Certificate files are typically stored as Base64 ASCII files, such as `.pem`, `.crt`, `.ca-bundle`. But they can also be binary-encoded, for example, as `.cer` files. All Secrets that hold certificate files should use the Base64 ASCII certificate rather than the binary-encoded certificate. The following procedure is applicable for already installed and running instances and for instances that are to be installed.
 
 .Prerequisites
 
 * An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 * Namespace for {prod-short} exists.
+* {prod-short} already uses some reserved file names to automatically inject certificates into the ConfigMap, so you should avoid using the following reserved file names to save your certificates:
+  ** `ca-bundle.crt`
+  ** `ca.crt`
 
 .Procedure
 
@@ -47,12 +50,8 @@ The following procedure is applicable for already installed and running instance
 +
 [CAUTION]
 ====
-* Certificate files are typically stored as Base64 ASCII files, such as `.pem`, `.crt`, `.ca-bundle`. But they can also be binary-encoded, for example, as `.cer` files. All Secrets that hold certificate files should use the Base64 ASCII certificate rather than the binary-encoded certificate.
 * A certificate with the `BEGIN TRUSTED CERTIFICATE` introductory phrase is likely in the PEM `TRUSTED CERTIFICATE` format, which is not supported by Java. Convert it to the supported `CERTIFICATE` format with the following command:
 ** `openssl x509 -in cert.pem -out cert.cer`
-* {prod-short} already uses some reserved file names to automatically inject certificates into the ConfigMap, so you should avoid using the following reserved file names to save your certificates:
-  ** `ca-bundle.crt`
-  ** `ca.crt`
 ====
 
 . Create a new ConfigMap with the required TLS certificates:

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -47,7 +47,9 @@ The following procedure is applicable for already installed and running instance
 +
 [CAUTION]
 ====
-* Certificate files are typically stored as Base64 ASCII files, such as `.pem`, `.crt`, `.ca-bundle`. But, they can also be binary-encoded, for example, as `.cer` files. All Secrets that hold certificate files should use the Base64 ASCII certificate rather than the binary-encoded certificate.
+* Certificate files are typically stored as Base64 ASCII files, such as `.pem`, `.crt`, `.ca-bundle`. But they can also be binary-encoded, for example, as `.cer` files. All Secrets that hold certificate files should use the Base64 ASCII certificate rather than the binary-encoded certificate.
+* A certificate with the introductory phrase `BEGIN TRUSTED CERTIFICATE` is likely in the PEM `TRUSTED CERTIFICATE` format, which is not not supported by Java. Convert it to the supported `CERTIFICATE` format with the following command:
+** `openssl x509 -in cert.pem -out cert.cer`
 * {prod-short} already uses some reserved file names to automatically inject certificates into the ConfigMap, so you should avoid using the following reserved file names to save your certificates:
   ** `ca-bundle.crt`
   ** `ca.crt`

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -34,7 +34,7 @@ If the cluster is configured with an intermediate certificate, then the whole ch
 
 == Adding new CA certificates into {prod-short}
 
-Certificate files are typically stored as Base64 files, with extensions such as `.pem`, `.crt`, `.ca-bundle`and others. But they can also be binary-encoded, for example, as `.cer` files. All Secrets that hold certificate files should use the Base64-encoded certificate rather than binary-encoded. The following procedure is applicable for already installed and running instances and for instances that are to be installed.
+Certificate files are typically stored as Base64 files, with extensions such as `.pem`, `.crt`, `.ca-bundle` and others. But they can also be binary-encoded, for example, as `.cer` files. All Secrets that hold certificate files should use the Base64-encoded certificate rather than binary-encoded. The following procedure is applicable for already installed and running instances and for instances that are to be installed.
 
 .Prerequisites
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Update of the "Importing untrusted TLS certificates to Che doc"

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-3370

## Specify the version of the product this pull request applies to
3.1

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
