### PR TITLE
docs: backporting PR 2393 to `7.50.x`

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -80,7 +80,7 @@ asciidoc:
     prod-host: che-host
     prod-id-short: che
     prod-id: eclipse-che
-    prod-last-version-pre-dwo: v7.41
+    prod-last-version-pre-dwo: 7.41
     prod-namespace: eclipse-che
     prod-operator-bundle-name: eclipse-che
     prod-operator-image-name: che-operator

--- a/modules/administration-guide/examples/proc_che-manually-upgrading-che-7-41-to-7-49-on-openshift.adoc
+++ b/modules/administration-guide/examples/proc_che-manually-upgrading-che-7-41-to-7-49-on-openshift.adoc
@@ -1,8 +1,8 @@
 :_content-type: PROCEDURE
 
-:parent-context-of-manually-upgrading-{prod-id-short}-{prod-last-version-pre-dwo}-to-7.49-on-openshift: {context}
+:parent-context-of-manually-upgrading-che-7.41-to-7.49-on-red-hat-openshift: {context}
 
-[id="manually-upgrading-{prod-id-short}-{prod-last-version-pre-dwo}-to-7.49-on-openshift_{context}"]
+[id="manually-upgrading-che-7.41-to-7.49-on-red-hat-openshift_{context}"]
 = Manually upgrading Che 7.41 to 7.49 on Red Hat OpenShift
 
 You can manually upgrade Che 7.41 to 7.49 on Red Hat OpenShift.
@@ -74,4 +74,4 @@ $ chmod +x ./1-prepare.sh ./2-migrate.sh ./3-subscribe.sh ./4-wait.sh; \
  
 * In the {prod-short} dashboard, go to menu:About[Server Version] to verify that it is *7.49*.
 
-:context: {parent-context-of-manually-upgrading-{prod-id-short}-{prod-last-version-pre-dwo}-to-7.49-on-openshift}
+:context: {parent-context-of-manually-upgrading-che-7.41-to-7.49-on-red-hat-openshift}

--- a/modules/administration-guide/examples/proc_che-manually-upgrading-che-7-41-to-7-49-on-openshift.adoc
+++ b/modules/administration-guide/examples/proc_che-manually-upgrading-che-7-41-to-7-49-on-openshift.adoc
@@ -1,0 +1,77 @@
+:_content-type: PROCEDURE
+
+:parent-context-of-manually-upgrading-{prod-id-short}-{prod-last-version-pre-dwo}-to-7.49-on-openshift: {context}
+
+[id="manually-upgrading-{prod-id-short}-{prod-last-version-pre-dwo}-to-7.49-on-openshift_{context}"]
+= Manually upgrading Che 7.41 to 7.49 on Red Hat OpenShift
+
+You can manually upgrade Che 7.41 to 7.49 on Red Hat OpenShift.
+
+.Prerequisites
+
+* An instance of {prod-prev-short} deployed on one of the xref:supported-platforms.adoc[]. The instance uses the default internal PostgreSQL database and has OAuth enabled on Red Hat OpenShift. See {prod-docs-url-enable-oauth}.
+* The following command line tools are available:
+** `oc`
+** `curl`
+** `jq`
+* The host running the upgrade commands is running on Linux.
+* Optional:
+.. All changes from all workspaces have been committed and pushed to their Git remotes.
+.. All workspaces have been stopped to avoid UX degradation.
+.. The {prod-prev-short} data have been backed up. See {prod-docs-url-backup-recovery}.
+
+.Procedure
+
+. Download xref:attachment$migration/1-prepare.sh[1-prepare.sh].
++
+`1-prepare.sh` shuts down {prod-prev-short} and {identity-provider}, fetches the existing users' data, and dumps the {prod-short} database.
+
+. Download xref:attachment$migration/2-migrate.sh[2-migrate.sh].
++
+`2-migrate.sh` fetches {prod-prev-short} {identity-provider} and database data, and repopulates the database with updated data.
+
+. Download xref:attachment$migration/3-subscribe.sh[3-subscribe.sh].
++
+`3-subscribe.sh` deletes {prod-prev-short} Operator and {identity-provider} resources, updates the CheCluster CR, and creates a new {prod-short} Operator subscription.
+
+. Download xref:attachment$migration/4-wait.sh[4-wait.sh].
++
+`4-wait.sh` waits until {prod-short} is ready, which can take more than 5 minutes.
+
+. Set the environment variables to use in the upgrade scripts:
++
+[source,bash,subs="+attributes"]
+----
+export INSTALLATION_NAMESPACE={prod-namespace} # <1>
+export PRODUCT_ID={prod-id}
+export PRODUCT_DEPLOYMENT_NAME={prod-deployment}
+export PRODUCT_OPERATOR_NAME={prod-operator}
+export PRODUCT_OLM_STABLE_CHANNEL={prod-stable-channel}
+export PRODUCT_OLM_CATALOG_SOURCE={prod-stable-channel-catalog-source}
+export PRODUCT_OLM_PACKAGE={prod-stable-channel-package}
+export PRODUCT_OLM_STARTING_CSV={prod-stable-channel-starting-csv}
+export PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE={prod-namespace} # <2>
+export PRE_MIGRATION_PRODUCT_SHORT_ID={pre-migration-prod-id-short}
+export PRE_MIGRATION_PRODUCT_DEPLOYMENT_NAME={pre-migration-prod-deployment}
+export PRE_MIGRATION_PRODUCT_OPERATOR_NAME={pre-migration-prod-operator}
+export PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME={pre-migration-prod-checluster}
+export PRE_MIGRATION_PRODUCT_IDENTITY_PROVIDER_DEPLOYMENT_NAME={identity-provider-id}
+export PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME={pre-migration-prod-subscription}
+----
+<1> `{prod-namespace}` or another {orch-namespace} where {prod-prev-short} was previously installed.
+<2> `{prod-namespace}` or another {orch-namespace} where {prod-prev-short} was previously installed.
+
+
+. Run the upgrade scripts:
++
+[source,terminal]
+----
+$ chmod +x ./1-prepare.sh ./2-migrate.sh ./3-subscribe.sh ./4-wait.sh; \
+  ./1-prepare.sh && ./2-migrate.sh && ./3-subscribe.sh && ./4-wait.sh
+----
+
+.Verification
+ 
+* In the {prod-short} dashboard, go to menu:About[Server Version] to verify that it is *7.49*.
+
+:context: {parent-context-of-manually-upgrading-{prod-id-short}-{prod-last-version-pre-dwo}-to-7.49-on-openshift}

--- a/modules/administration-guide/examples/proc_che-rolling-the-upgrade-back-from-che-7-49-to-che-7-41-on-openshift.adoc
+++ b/modules/administration-guide/examples/proc_che-rolling-the-upgrade-back-from-che-7-49-to-che-7-41-on-openshift.adoc
@@ -1,0 +1,46 @@
+:_content-type: PROCEDURE
+
+:parent-context-of-rolling-the-upgrade-back-to-{prod-prev-id-short}-{prod-last-version-pre-dwo}-on-openshift: {context}
+
+[id="rolling-the-upgrade-back-to-{prod-prev-id-short}-{prod-last-version-pre-dwo}-on-openshift_{context}"]
+= Rolling the upgrade back to {prod-prev-short} {prod-last-version-pre-dwo} on Red Hat OpenShift
+
+If upgrading {prod-short} 7.41 to 7.49 on Red Hat OpenShift fails, you can run a rollback script to restore {prod-short} 7.41.
+
+.Procedure
+
+. Download the xref:attachment$migration/rollback.sh[rollback.sh] script.
+
+. Set the environment variables to use in the `rollback.sh` script:
++
+[source,bash,subs="+attributes"]
+----
+export INSTALLATION_NAMESPACE={prod-namespace} # <1>
+export PRODUCT_ID={prod-id}
+export PRODUCT_SHORT_ID={prod-id-short}
+export PRODUCT_DEPLOYMENT_NAME={prod-deployment}
+export PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE={prod-namespace} # <2>
+export PRE_MIGRATION_PRODUCT_DEPLOYMENT_NAME={pre-migration-prod-deployment}
+export PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME={pre-migration-prod-subscription}
+export PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME={pre-migration-prod-checluster}
+export PRE_MIGRATION_PRODUCT_OPERATOR_NAME={pre-migration-prod-operator}
+export PRE_MIGRATION_PRODUCT_OLM_PACKAGE={pre-migration-prod-package}
+export PRE_MIGRATION_PRODUCT_OLM_CHANNEL={pre-migration-prod-channel}
+export PRE_MIGRATION_PRODUCT_OLM_CATALOG_SOURCE={pre-migration-prod-catalog-source}
+export PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV={pre-migration-prod-starting-csv}
+----
+<1> `{prod-namespace}` or another {orch-namespace} where {prod-prev-short} was previously installed.
+<2> `{prod-namespace}` or another {orch-namespace} where {prod-prev-short} was previously installed.
+
+. Run the `rollback.sh` script.
++
+[source,terminal]
+----
+$ chmod +x ./rollback.sh; ./rollback.sh
+----
+
+.Verification
+
+* In the {prod-prev-short} dashboard, go to menu:About[Server Version] to verify that it is *7.41*.
+
+:context: {parent-context-of-rolling-the-upgrade-back-to-{prod-prev-id-short}-{prod-last-version-pre-dwo}-on-openshift}

--- a/modules/administration-guide/examples/proc_che-rolling-the-upgrade-back-from-che-7-49-to-che-7-41-on-openshift.adoc
+++ b/modules/administration-guide/examples/proc_che-rolling-the-upgrade-back-from-che-7-49-to-che-7-41-on-openshift.adoc
@@ -1,9 +1,9 @@
 :_content-type: PROCEDURE
 
-:parent-context-of-rolling-the-upgrade-back-to-{prod-prev-id-short}-{prod-last-version-pre-dwo}-on-openshift: {context}
+:parent-context-of-rolling-the-upgrade-back-to-che-7.41-on-red-hat-openshift: {context}
 
-[id="rolling-the-upgrade-back-to-{prod-prev-id-short}-{prod-last-version-pre-dwo}-on-openshift_{context}"]
-= Rolling the upgrade back to {prod-prev-short} {prod-last-version-pre-dwo} on Red Hat OpenShift
+[id="rolling-the-upgrade-back-to-che-7.41-on-red-hat-openshift_{context}"]
+= Rolling the upgrade back to Che 7.41 on Red Hat OpenShift
 
 If upgrading {prod-short} 7.41 to 7.49 on Red Hat OpenShift fails, you can run a rollback script to restore {prod-short} 7.41.
 
@@ -43,4 +43,4 @@ $ chmod +x ./rollback.sh; ./rollback.sh
 
 * In the {prod-prev-short} dashboard, go to menu:About[Server Version] to verify that it is *7.41*.
 
-:context: {parent-context-of-rolling-the-upgrade-back-to-{prod-prev-id-short}-{prod-last-version-pre-dwo}-on-openshift}
+:context: {parent-context-of-rolling-the-upgrade-back-to-che-7.41-on-red-hat-openshift}

--- a/modules/administration-guide/examples/proc_che-upgrading-che-7-41-to-latest-version-on-openshift.adoc
+++ b/modules/administration-guide/examples/proc_che-upgrading-che-7-41-to-latest-version-on-openshift.adoc
@@ -1,0 +1,15 @@
+:_content-type: PROCEDURE
+
+:parent-context-of-{prod-prev-id-short}-{prod-last-version-pre-dwo}-to-{prod-id-short}-{prod-ver}-on-openshift: {context}
+
+[id="{prod-prev-id-short}-{prod-last-version-pre-dwo}-to-{prod-id-short}-{prod-ver}-on-openshift_{context}"]
+= Upgrading Che 7.41 to {prod-ver} on Red Hat OpenShift
+
+Upgrading Che 7.41 to {prod-ver} on Red Hat OpenShift requires first upgrading it to Che 7.49.
+
+.Procedure
+
+. Manually upgrade Che 7.41 to 7.49. See the next section.
+. Use link:https://docs.openshift.com/container-platform/4.10/operators/understanding/olm/olm-understanding-olm.html[Operator Lifecycle Manager] to update Che 7.49 to {prod-ver}.
+
+:context: {parent-context-of-{prod-prev-id-short}-{prod-last-version-pre-dwo}-to-{prod-id-short}-{prod-ver}-on-openshift}

--- a/modules/administration-guide/examples/proc_che-upgrading-che-7-41-to-latest-version-on-openshift.adoc
+++ b/modules/administration-guide/examples/proc_che-upgrading-che-7-41-to-latest-version-on-openshift.adoc
@@ -1,15 +1,15 @@
 :_content-type: PROCEDURE
 
-:parent-context-of-{prod-prev-id-short}-{prod-last-version-pre-dwo}-to-{prod-id-short}-{prod-ver}-on-openshift: {context}
+:parent-context-of-uprading-che-7.41-to-{prod-ver}-on-red-hat-openshift: {context}
 
-[id="{prod-prev-id-short}-{prod-last-version-pre-dwo}-to-{prod-id-short}-{prod-ver}-on-openshift_{context}"]
+[id="uprading-che-7.41-to-{prod-ver}-on-red-hat-openshift_{context}"]
 = Upgrading Che 7.41 to {prod-ver} on Red Hat OpenShift
 
 Upgrading Che 7.41 to {prod-ver} on Red Hat OpenShift requires first upgrading it to Che 7.49.
 
 .Procedure
 
-. Manually upgrade Che 7.41 to 7.49. See the next section.
+. Manually upgrade Che 7.41 to 7.49.
 . Use link:https://docs.openshift.com/container-platform/4.10/operators/understanding/olm/olm-understanding-olm.html[Operator Lifecycle Manager] to update Che 7.49 to {prod-ver}.
 
-:context: {parent-context-of-{prod-prev-id-short}-{prod-last-version-pre-dwo}-to-{prod-id-short}-{prod-ver}-on-openshift}
+:context: {parent-context-of-uprading-che-7.41-to-{prod-ver}-on-red-hat-openshift}

--- a/modules/administration-guide/pages/upgrading-che-7-41-on-openshift.adoc
+++ b/modules/administration-guide/pages/upgrading-che-7-41-on-openshift.adoc
@@ -1,130 +1,16 @@
-:_content-type: PROCEDURE
-:navtitle: Upgrading {prod-prev-short} {prod-last-version-pre-dwo} on OpenShift
-:description: Upgrading {prod-prev-short} {prod-last-version-pre-dwo} on OpenShift
-:keywords: administration-guide, migration, devworkspace
+:_content-type: ASSEMBLY
+:navtitle: Upgrading {prod-prev-short} {prod-last-version-pre-dwo} on Red Hat OpenShift
+:description: Upgrading {prod-prev-short} {prod-last-version-pre-dwo} on Red Hat OpenShift
+:keywords: administration-guide, migration, devworkspace, upgrade, upgrading
 :page-aliases: 
 
 [id="upgrading-{prod-prev-id-short}-{prod-last-version-pre-dwo}-on-openshift_{context}"]
-= Upgrading {prod-prev-short} {prod-last-version-pre-dwo} on OpenShift
+= Upgrading {prod-prev-short} {prod-last-version-pre-dwo} on Red Hat OpenShift
 
-The workspace engine and authentication system used up to and including {prod-prev-short} version {prod-last-version-pre-dwo} are deprecated, which requires manual steps.
+The workspace engine and authentication system used in {prod-prev-short} {prod-last-version-pre-dwo} and earlier versions are deprecated. Due to this deprecation, upgrading {prod-prev-short} {prod-last-version-pre-dwo} involves running upgrade scripts.
 
-.Prerequisites
+include::example$proc_{project-context}-upgrading-che-7-41-to-latest-version-on-openshift.adoc[leveloffset=+1]
 
-* An instance of {prod-prev-short} deployed on one of the xref:supported-platforms.adoc[]. The instance uses the default internal PostgreSQL database and has OpenShift OAuth enabled. See {prod-docs-url-enable-oauth}.
-* The following command line tools are available:
-** `oc`
-** `curl`
-** `jq`
-* The host running the upgrade commands is running on Linux.
-* Optional:
-.. All changes from all workspaces have been commited and pushed to their Git remotes.
-.. All workspaces have been stopped to avoid UX degradation.
-.. The {prod-prev-short} data have been backed up. See {prod-docs-url-backup-recovery}.
+include::example$proc_{project-context}-manually-upgrading-che-7-41-to-7-49-on-openshift.adoc[leveloffset=+1]
 
-.Procedure
-
-. Download xref:attachment$migration/1-prepare.sh[1-prepare.sh].
-+
-`1-prepare.sh` is a migration script that shuts down {prod-prev-short} and {identity-provider}, fetches users data, and dumps the {prod-short} database.
-
-. Download xref:attachment$migration/2-migrate.sh[2-migrate.sh].
-+
-`2-migrate.sh` is a migration script that fetches {prod-prev-short} {identity-provider} and database data, and repopulates the database with updated data.
-
-. Download xref:attachment$migration/3-subscribe.sh[3-subscribe.sh].
-+
-`3-subscribe.sh` is a migration script that deletes {prod-prev-short} Operator and {identity-provider} resources, updates the CheCluster CR, and creates a new {prod-short} Operator subscription.
-
-. Download xref:attachment$migration/4-wait.sh[4-wait.sh].
-+
-`4-wait.sh` is a migration script that waits until {prod-short} is ready, which can take more than 5 minutes.
-
-. Set the environment variables to use in the migration scripts:
-+
-[source,bash,subs="+attributes"]
-----
-export INSTALLATION_NAMESPACE={prod-namespace} # <1>
-export PRODUCT_ID={prod-id}
-export PRODUCT_DEPLOYMENT_NAME={prod-deployment}
-export PRODUCT_OPERATOR_NAME={prod-operator}
-export PRODUCT_OLM_STABLE_CHANNEL={prod-stable-channel}
-export PRODUCT_OLM_CATALOG_SOURCE={prod-stable-channel-catalog-source}
-export PRODUCT_OLM_PACKAGE={prod-stable-channel-package}
-export PRODUCT_OLM_STARTING_CSV={prod-stable-channel-starting-csv}
-export PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE={prod-namespace} # <2>
-export PRE_MIGRATION_PRODUCT_SHORT_ID={pre-migration-prod-id-short}
-export PRE_MIGRATION_PRODUCT_DEPLOYMENT_NAME={pre-migration-prod-deployment}
-export PRE_MIGRATION_PRODUCT_OPERATOR_NAME={pre-migration-prod-operator}
-export PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME={pre-migration-prod-checluster}
-export PRE_MIGRATION_PRODUCT_IDENTITY_PROVIDER_DEPLOYMENT_NAME={identity-provider-id}
-export PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME={pre-migration-prod-subscription}
-----
-<1> `{prod-namespace}` or another {orch-namespace} where {prod-prev-short} was previously installed.
-<2> `{prod-namespace}` or another {orch-namespace} where {prod-prev-short} was previously installed.
-
-. Run `chmod` on the downloaded scripts:
-+
-[source,terminal]
-----
-$ chmod +x ./1-prepare.sh ./2-migrate.sh ./3-subscribe.sh ./4-wait.sh
-----
-
-. Run the migration scripts:
-+
-[source,terminal]
-----
-$ ./1-prepare.sh && ./2-migrate.sh && ./3-subscribe.sh && ./4-wait.sh
-----
-
-.Verification
-
-* Open {prod-short} dashboard and log in.
-
-[IMPORTANT]
-====
-If migration fails, use the following steps to roll back to the pre-migration {prod-prev-short} state.
-
-. Set the environment variables to use in the migration scripts:
-+
-[source,bash,subs="+attributes"]
-----
-export INSTALLATION_NAMESPACE={prod-namespace} # <1>
-export PRODUCT_ID={prod-id}
-export PRODUCT_SHORT_ID={prod-id-short}
-export PRODUCT_DEPLOYMENT_NAME={prod-deployment}
-export PRE_MIGRATION_PRODUCT_OPERATOR_NAMESPACE={prod-namespace} # <2>
-export PRE_MIGRATION_PRODUCT_DEPLOYMENT_NAME={pre-migration-prod-deployment}
-export PRE_MIGRATION_PRODUCT_SUBSCRIPTION_NAME={pre-migration-prod-subscription}
-export PRE_MIGRATION_PRODUCT_CHE_CLUSTER_CR_NAME={pre-migration-prod-checluster}
-export PRE_MIGRATION_PRODUCT_OPERATOR_NAME={pre-migration-prod-operator}
-export PRE_MIGRATION_PRODUCT_OLM_PACKAGE={pre-migration-prod-package}
-export PRE_MIGRATION_PRODUCT_OLM_CHANNEL={pre-migration-prod-channel}
-export PRE_MIGRATION_PRODUCT_OLM_CATALOG_SOURCE={pre-migration-prod-catalog-source}
-export PRE_MIGRATION_PRODUCT_OLM_STARTING_CSV={pre-migration-prod-starting-csv}
-----
-<1> `{prod-namespace}` or another {orch-namespace} where {prod-prev-short} was previously installed.
-<2> `{prod-namespace}` or another {orch-namespace} where {prod-prev-short} was previously installed.
-
-. Download the xref:attachment$migration/rollback.sh[rollback.sh] script.
-
-. Run `chmod` on the `rollback.sh` script:
-+
-[source,terminal]
-----
-$ chmod +x ./rollback.sh
-----
-
-. Run the `rollback.sh` script.
-+
-[source,terminal]
-----
-$ ./rollback.sh
-----
-
-
-.Verification
-
-* Open {prod-prev-short} dashboard and log in.
-
-====
+include::example$proc_{project-context}-rolling-the-upgrade-back-from-che-7-49-to-che-7-41-on-openshift.adoc[leveloffset=+1]


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Backport https://github.com/eclipse-che/che-docs/pull/2393 to `7.50.x`.

## What issues does this pull request fix or reference?
RHDEVDOCS-4135

## Specify the version of the product this pull request applies to
Che **7.50**

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.  **No testing was performed for the changes introduced in this PR.**
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
