### PR TITLE
Remove a weird blank char in gitlab URL (cherry-pick from main)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
       "redhat.vscode-yaml",
       "redhat.vscode-xml",
       "timonwong.shellcheck",
-      "errata-ai.vale-server"
+      "errata-ai.vale-server",
+      "asciidoctor.asciidoctor-vscode"
     ]
 }

--- a/modules/administration-guide/partials/proc_applying-the-gitlab-authorized-application-secret.adoc
+++ b/modules/administration-guide/partials/proc_applying-the-gitlab-authorized-application-secret.adoc
@@ -42,7 +42,7 @@ data:
   secret: __<Base64_GitLab_Client_Secret>__ <4>
 ----
 <1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The *GitLab server URL*. Use `https​://gitlab.com` for the `SAAS` version.
+<2> The *GitLab server URL*. Use `https://gitlab.com` for the `SAAS` version.
 <3> The Base64-encoded *GitLab Application ID*.
 <4> The Base64-encoded *GitLab Client Secret*.
 


### PR DESCRIPTION
## What does this pull request change?

Port of #2404 to 7.46.x branch

## What issues does this pull request fix or reference?

https://issues.redhat.com/browse/CRW-3139

## Specify the version of the product this pull request applies to

Che 7.46.x and OpenShift Dev Spaces 3.0

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
