### PR TITLE
fix: importing untrusted tls certificates language review

### DIFF
--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -12,7 +12,7 @@ By default, external communications between {prod-short} components are encrypte
 When the certificates used by {prod-short} components or by an external service are signed by an untrusted CA, you must import the CA certificate into the {prod-short} instance so that every {prod-short} component treats the certificates as signed by a trusted CA. You have to do this in the following cases:
 
 * The underlying {orch-name} cluster uses TLS certificates signed by an untrusted CA.
-* {prod-short} server or workspace components connect to external services such as {identity-provider} or a Git server that use TLS certificates signed by an untrusted CA.
+{prod-short} server or workspace components connect to external OIDC providers or a Git server that use TLS certificates signed by an untrusted CA.
 
 {prod-short} uses labeled ConfigMaps in {orch-namespace} as sources for TLS certificates. The ConfigMaps can have an arbitrary number of keys with a random number of certificates each.
 

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -9,7 +9,7 @@
 
 By default, external communications between {prod-short} components are encrypted with TLS. Communications of {prod-short} components with external services such as proxies, source code repositories, and identity provider might also require TLS. All communications encrypted with TLS require the use of TLS certificates signed by trusted Certificate Authorities (CA).
 
-When the certificates used by {prod-short} components or by an external service are signed by an untrusted CA, you must import the CA certificate into the {prod-short} instance so that every {prod-short} component considers the certificates as signed by a trusted CA. Following cases typically require this addition:
+When the certificates used by {prod-short} components or by an external service are signed by an untrusted CA, you must import the CA certificate into the {prod-short} instance so that every {prod-short} component treats the certificates as signed by a trusted CA. You have to do this in the following cases:
 
 * The underlying {orch-name} cluster uses TLS certificates signed by an untrusted CA.
 * {prod-short} server or workspace components connect to external services such as {identity-provider} or a Git server that use TLS certificates signed by an untrusted CA.

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -10,6 +10,7 @@
 By default, external communications between {prod-short} components are encrypted with TLS. Communications of {prod-short} components with external services such as proxies, source code repositories, and identity provider might also require TLS. All communications encrypted with TLS require the use of TLS certificates signed by trusted Certificate Authorities (CA).
 
 When the certificates used by {prod-short} components or by an external service are signed by an untrusted CA, you must import the CA certificate into the {prod-short} instance so that every {prod-short} component considers the certificates as signed by a trusted CA. Following cases typically require this addition:
+
 * The underlying {orch-name} cluster uses TLS certificates signed by an untrusted CA.
 * {prod-short} server or workspace components connect to external services such as {identity-provider} or a Git server that use TLS certificates signed by an untrusted CA.
 

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -7,29 +7,23 @@
 [id="importing-untrusted-tls-certificates_{context}"]
 = Importing untrusted TLS certificates to {prod-short}
 
-External communications between {prod-short} components are, by default, encrypted with TLS. Communications of {prod-short} components with external services such as proxies, source code repositories, and identity provider may require using TLS. Those communications require the use of TLS certificates signed by trusted Certificate Authorities.
+By default, external communications between {prod-short} components are encrypted with TLS. Communications of {prod-short} components with external services such as proxies, source code repositories, and identity provider might also require TLS. All communications encrypted with TLS require the use of TLS certificates signed by trusted Certificate Authorities (CA).
 
-NOTE: When the certificates used by {prod-short} components or by an external service are signed by an untrusted CA, it can be necessary to import the CA certificate in the {prod-short} installation so that every {prod-short} component will consider them as signed by a trusted CA.
-
-Typical cases that may require this addition are:
-
-* When the underlying {orch-name} cluster that uses TLS certificates signed by a CA that is not trusted.
-* When {prod-short} server or workspace components connect to external services such as {identity-provider} or a Git server that use TLS certificates signed by an untrusted CA.
+When the certificates used by {prod-short} components or by an external service are signed by an untrusted CA, it's necessary to import the CA certificate in the {prod-short} installation so that every {prod-short} component considers them as signed by a trusted CA. Following cases typically require this addition:
+* The underlying {orch-name} cluster uses TLS certificates signed by a CA that isn't trusted.
+* {prod-short} server or workspace components connect to external services such as {identity-provider} or a Git server that use TLS certificates signed by an untrusted CA.
 
 {prod-short} uses labeled ConfigMaps in {orch-namespace} as sources for TLS certificates. The ConfigMaps can have an arbitrary number of keys with a random number of certificates each.
 
 [NOTE]
 ====
-When the OpenShift cluster contains cluster-wide trusted CA certificates added through the link:https://docs.openshift.com/container-platform/4.4/networking/configuring-a-custom-pki.html#nw-proxy-configure-object_configuring-a-custom-pki[cluster-wide-proxy configuration], {prod-short} Operator detects them and automatically injects them into this ConfigMap:
-
-- {prod-short} automatically labels the ConfigMap with the `config.openshift.io/inject-trusted-cabundle="true"` label.
-- Based on this annotation, OpenShift automatically injects the cluster-wide trusted CA certificates inside the `ca-bundle.crt` key of ConfigMap
+When an OpenShift cluster contains cluster-wide trusted CA certificates added through the link:https://docs.openshift.com/container-platform/4.10/networking/configuring-a-custom-pki.html#nw-proxy-configure-object_configuring-a-custom-pki[cluster-wide-proxy configuration], {prod-short} Operator detects them and automatically injects them into a ConfigMap. {prod-short} automatically labels the ConfigMap with the `config.openshift.io/inject-trusted-cabundle="true"` label. Based on this annotation, OpenShift automatically injects the cluster-wide trusted CA certificates inside the `ca-bundle.crt` key of ConfigMap.
 ====
 
 [IMPORTANT]
 ====
-Some {prod-short} components require to have a full certificate chain to trust the endpoint.
-If the cluster is configured with an intermediate certificate, then the whole chain (including self-signed root) should be added to {prod-short}.
+Some {prod-short} components require a full certificate chain to trust the endpoint.
+If the cluster is configured with an intermediate certificate, add the whole chain (including self-signed root) to {prod-short}.
 ====
 
 == Adding new CA certificates into {prod-short}
@@ -46,11 +40,11 @@ Certificate files are typically stored as Base64 files, with extensions such as 
 
 .Procedure
 
-. Save the certificates you need to import, to a local file system.
+. Save the certificates you need to import to a local file system.
 +
 [CAUTION]
 ====
-* A certificate with the `BEGIN TRUSTED CERTIFICATE` introductory phrase is likely in the PEM `TRUSTED CERTIFICATE` format, which is not supported. Convert it to the supported `CERTIFICATE` format with the following command:
+* A certificate with the introductory phrase `BEGIN TRUSTED CERTIFICATE` is likely in the PEM `TRUSTED CERTIFICATE` format, which is not not supported by Java. Convert it to the supported `CERTIFICATE` format with the following command:
 ** `openssl x509 -in cert.pem -out cert.cer`
 ====
 
@@ -61,58 +55,63 @@ Certificate files are typically stored as Base64 files, with extensions such as 
 $ {orch-cli} create configmap custom-certs --from-file=__<bundle-file-path>__ -n={prod-namespace}
 ----
 +
-Add another `-from-file=_<bundle-file-path>_` flag to apply more than one bundle. Otherwise, create another ConfigMap.
+To apply more than one bundle, add another `-from-file=_<bundle-file-path>_`. Otherwise, create another ConfigMap. 
+// Wouldn't "alternatively" make more sense than "otherwise"? 
 
-. Label created ConfigMaps with both `app.kubernetes.io/part-of=che.eclipse.org` and `app.kubernetes.io/component=ca-bundle` labels:
+. Label created ConfigMaps with the `app.kubernetes.io/part-of=che.eclipse.org` and `app.kubernetes.io/component=ca-bundle` labels:
 +
 [subs="+attributes,+quotes"]
 ----
 $ {orch-cli} label configmap custom-certs app.kubernetes.io/part-of=che.eclipse.org app.kubernetes.io/component=ca-bundle -n <{project-context}-namespace-name>
 ----
 
-. Deploy {prod-short} if it has not been deployed before. Otherwise wait until the rollout of {prod-short} components finishes. If there are running workspaces, they should be restarted for the changes to take effect.
+. Deploy {prod-short} if it hasn't been deployed before. Otherwise wait until the rollout of {prod-short} components finishes. Restart running workspaces for the changes to take effect.
 
-== Verification at the {prod-short} installation level
+== Troubleshooting imported certificate issues
 
-When something does not work as expected after adding the certificates, here is a list of things to verify:
+If issues occur after adding the certificates, verify the below specified values at a {prod-short} installation and workspace level.
 
-- In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment, the namespace where the `CheCluster` is located contains labeled ConfigMaps with the right content:
+
+.Verifying imported certificates at the {prod-short} installation level
+
+* In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment, the namespace where the `CheCluster` is located contains labeled ConfigMaps with the right content:
+// Correct content? Relevant content?
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} get cm --selector=app.kubernetes.io/component=ca-bundle,app.kubernetes.io/part-of=che.eclipse.org -n {prod-namespace}
 ----
 +
-Check the content of ConfigMap by running:
+Check the content of ConfigMap by entering this command:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} get cm __<name>__ -n {prod-namespace} -o yaml
 ----
 
-- {prod-short} Pod Volumes list contains a volume that uses `ca-certs-merged` ConfigMap as data-source.
-To get the list of Volumes of the {prod-short} Pod:
+* {prod-short} Pod Volumes list contains a volume that uses `ca-certs-merged` ConfigMap as data-source.
+To get the list of Volumes of the {prod-short} Pod, run:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} get pod -o json __<{prod-id-short}-pod-name>__ -n {prod-namespace} | jq .spec.volumes
 ----
 +
-- {prod-short} mounts certificates in folder `/public-certs/` of the {prod-short} server container. This command returns the list of files in that folder:
+* {prod-short} mounts certificates in the `/public-certs/` folder of the {prod-short} server container. Enter the following command to view the list of files in this folder:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} exec -t __<{prod-id-short}-pod-name>__ -n {prod-namespace} -- ls /public-certs/
 ----
 +
-- In the {prod-short} server logs, there is a line for every certificate added to the Java truststore, including configured {prod-short} certificates.
+* In the {prod-short} server logs, there is a line for every certificate added to the Java truststore, including configured {prod-short} certificates. View them with following command:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} logs __<{prod-id-short}-pod-name>__ -n {prod-namespace}
 ----
 +
-- {prod-short} server Java truststore contains the certificates. The certificates SHA1 fingerprints are among the list of the SHA1 of the certificates included in the truststore returned by the following command:
+* {prod-short} server Java truststore contains the certificates. The certificates SHA1 fingerprints are among the list of the SHA1 of the certificates included in the truststore. View the list with the following command:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
@@ -122,7 +121,7 @@ Your keystore contains 141 entries:
 (...)
 ----
 +
-To get the SHA1 hash of a certificate on the local filesystem:
+To get the SHA1 hash of a certificate on the local filesystem, run:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
@@ -130,18 +129,19 @@ $ openssl x509 -in __<certificate-file-path>__ -fingerprint -noout
 SHA1 Fingerprint=3F:DA:BF:E7:A7:A7:90:62:CA:CF:C7:55:0E:1D:7D:05:16:7D:45:60
 ----
 
-== Verification at the workspace level
+.Verifying imported certificates at the workspace level
 
-- Start a workspace, obtain the {orch-namespace} name in which it has been created, and wait for the workspace to be started.
+* Start a workspace, obtain the {orch-namespace} name in which it has been created, and wait for the workspace to be started.
+// What do I need the name for?
 
-- Get the name of the workspace Pod with the following command:
+* Get the name of the workspace Pod with the following command:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} get pods -o=jsonpath='{.items[0].metadata.name}' -n __<workspace namespace>__ | grep '^workspace.*'
 ----
 
-- Get the name of the Che-Theia IDE container in the workspace Pod with the following command:
+* Get the name of the Che-Theia IDE container in the workspace Pod with the following command:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
@@ -149,14 +149,14 @@ $ {orch-cli} get -o json pod __<workspace pod name>__  -n __<workspace namespace
     jq -r '.spec.containers[] | select(.name | startswith("theia-ide")).name'
 ----
 
-- Look for a `ca-certs` ConfigMap that should have been created inside the workspace namespace:
+* Look for a `ca-certs` ConfigMap inside the workspace namespace:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} get cm ca-certs __<workspace namespace>__
 ----
 
-- Check that the entries in the `ca-certs` ConfigMap contain all the additional entries you added before. In addition, it can contain `ca-bundle.crt` entry which is a reserved one:
+* Check that the entries in the `ca-certs` ConfigMap contain all the additional entries you added before. In addition, it can contain `ca-bundle.crt` reserved entry. View the entries with the following command:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
@@ -165,7 +165,7 @@ ca-bundle.crt
 source-config-map-name.data-key.crt
 ----
 
-- Confirm that the `ca-certs` ConfigMap has been added as a volume in the workspace Pod:
+* Confirm that the `ca-certs` ConfigMap is added as a volume in the workspace Pod:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
@@ -180,7 +180,7 @@ $ {orch-cli} get -o json pod __<workspace pod name>__ -n __<workspace namespace>
 }
 ----
 
-- Confirm that the volume is mounted into containers, especially in the Che-Theia IDE container:
+* Confirm that the volume is mounted into containers, especially in the Che-Theia IDE container:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
@@ -193,7 +193,7 @@ $ {orch-cli} get -o json pod __<workspace pod name>__ -n __<workspace namespace>
 }
 ----
 
-- Inspect the `/public-certs` folder in the Che-Theia IDE container and check that its contents match the list of entries in the `ca-certs` ConfigMap:
+* Inspect the `/public-certs` folder in the Che-Theia IDE container and check if its contents match the list of entries in the `ca-certs` ConfigMap:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -72,7 +72,7 @@ $ {orch-cli} label configmap custom-certs app.kubernetes.io/part-of=che.eclipse.
 If issues occur after adding the certificates, verify the specified values at the {prod-short} instance level and workspace level.
 
 
-.Verifying imported certificates at the {prod-short} installation level
+.Verifying imported certificates at the {prod-short} instance level
 
 * In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment, the namespace where the `CheCluster` is located contains labeled ConfigMaps with the correct content:
 +

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -9,7 +9,7 @@
 
 By default, external communications between {prod-short} components are encrypted with TLS. Communications of {prod-short} components with external services such as proxies, source code repositories, and identity provider might also require TLS. All communications encrypted with TLS require the use of TLS certificates signed by trusted Certificate Authorities (CA).
 
-When the certificates used by {prod-short} components or by an external service are signed by an untrusted CA, you must import the CA certificate in the {prod-short} installation so that every {prod-short} component considers the certificates as signed by a trusted CA. Following cases typically require this addition:
+When the certificates used by {prod-short} components or by an external service are signed by an untrusted CA, you must import the CA certificate into the {prod-short} instance so that every {prod-short} component considers the certificates as signed by a trusted CA. Following cases typically require this addition:
 * The underlying {orch-name} cluster uses TLS certificates signed by an untrusted CA.
 * {prod-short} server or workspace components connect to external services such as {identity-provider} or a Git server that use TLS certificates signed by an untrusted CA.
 

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -69,7 +69,7 @@ $ {orch-cli} label configmap custom-certs app.kubernetes.io/part-of=che.eclipse.
 
 == Troubleshooting imported certificate issues
 
-If issues occur after adding the certificates, verify the specified values at a {prod-short} installation and workspace level.
+If issues occur after adding the certificates, verify the specified values at the {prod-short} instance level and workspace level.
 
 
 .Verifying imported certificates at the {prod-short} installation level

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -9,8 +9,8 @@
 
 By default, external communications between {prod-short} components are encrypted with TLS. Communications of {prod-short} components with external services such as proxies, source code repositories, and identity provider might also require TLS. All communications encrypted with TLS require the use of TLS certificates signed by trusted Certificate Authorities (CA).
 
-When the certificates used by {prod-short} components or by an external service are signed by an untrusted CA, it's necessary to import the CA certificate in the {prod-short} installation so that every {prod-short} component considers them as signed by a trusted CA. Following cases typically require this addition:
-* The underlying {orch-name} cluster uses TLS certificates signed by a CA that isn't trusted.
+When the certificates used by {prod-short} components or by an external service are signed by an untrusted CA, you must import the CA certificate in the {prod-short} installation so that every {prod-short} component considers the certificates as signed by a trusted CA. Following cases typically require this addition:
+* The underlying {orch-name} cluster uses TLS certificates signed by an untrusted CA.
 * {prod-short} server or workspace components connect to external services such as {identity-provider} or a Git server that use TLS certificates signed by an untrusted CA.
 
 {prod-short} uses labeled ConfigMaps in {orch-namespace} as sources for TLS certificates. The ConfigMaps can have an arbitrary number of keys with a random number of certificates each.
@@ -23,7 +23,7 @@ When an OpenShift cluster contains cluster-wide trusted CA certificates added th
 [IMPORTANT]
 ====
 Some {prod-short} components require a full certificate chain to trust the endpoint.
-If the cluster is configured with an intermediate certificate, add the whole chain (including self-signed root) to {prod-short}.
+If the cluster is configured with an intermediate certificate, add the whole chain, including self-signed root, to {prod-short}.
 ====
 
 == Adding new CA certificates into {prod-short}
@@ -44,7 +44,7 @@ Certificate files are typically stored as Base64 files, with extensions such as 
 +
 [CAUTION]
 ====
-* A certificate with the introductory phrase `BEGIN TRUSTED CERTIFICATE` is likely in the PEM `TRUSTED CERTIFICATE` format, which is not not supported by Java. Convert it to the supported `CERTIFICATE` format with the following command:
+* A certificate with the introductory phrase `BEGIN TRUSTED CERTIFICATE` is likely in the PEM `TRUSTED CERTIFICATE` format, which is not supported by Java. Convert it to the supported `CERTIFICATE` format with the following command:
 ** `openssl x509 -in cert.pem -out cert.cer`
 ====
 
@@ -55,8 +55,7 @@ Certificate files are typically stored as Base64 files, with extensions such as 
 $ {orch-cli} create configmap custom-certs --from-file=__<bundle-file-path>__ -n={prod-namespace}
 ----
 +
-To apply more than one bundle, add another `-from-file=_<bundle-file-path>_`. Otherwise, create another ConfigMap. 
-// Wouldn't "alternatively" make more sense than "otherwise"? 
+To apply more than one bundle, add another `-from-file=_<bundle-file-path>_`. Alternatively, create another ConfigMap.
 
 . Label created ConfigMaps with the `app.kubernetes.io/part-of=che.eclipse.org` and `app.kubernetes.io/component=ca-bundle` labels:
 +
@@ -65,24 +64,24 @@ To apply more than one bundle, add another `-from-file=_<bundle-file-path>_`. Ot
 $ {orch-cli} label configmap custom-certs app.kubernetes.io/part-of=che.eclipse.org app.kubernetes.io/component=ca-bundle -n <{project-context}-namespace-name>
 ----
 
-. Deploy {prod-short} if it hasn't been deployed before. Otherwise wait until the rollout of {prod-short} components finishes. Restart running workspaces for the changes to take effect.
+. Deploy {prod-short} if it hasn't been deployed before. Otherwise wait until the rollout of {prod-short} components finishes. 
+. Restart running workspaces for the changes to take effect.
 
 == Troubleshooting imported certificate issues
 
-If issues occur after adding the certificates, verify the below specified values at a {prod-short} installation and workspace level.
+If issues occur after adding the certificates, verify the specified values at a {prod-short} installation and workspace level.
 
 
 .Verifying imported certificates at the {prod-short} installation level
 
-* In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment, the namespace where the `CheCluster` is located contains labeled ConfigMaps with the right content:
-// Correct content? Relevant content?
+* In case of a {prod-short} link:https://docs.openshift.com/container-platform/latest/operators/understanding/olm-what-operators-are.html[Operator] deployment, the namespace where the `CheCluster` is located contains labeled ConfigMaps with the correct content:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} get cm --selector=app.kubernetes.io/component=ca-bundle,app.kubernetes.io/part-of=che.eclipse.org -n {prod-namespace}
 ----
 +
-Check the content of ConfigMap by entering this command:
+Check the content of ConfigMap by entering:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
@@ -97,21 +96,21 @@ To get the list of Volumes of the {prod-short} Pod, run:
 $ {orch-cli} get pod -o json __<{prod-id-short}-pod-name>__ -n {prod-namespace} | jq .spec.volumes
 ----
 +
-* {prod-short} mounts certificates in the `/public-certs/` folder of the {prod-short} server container. Enter the following command to view the list of files in this folder:
+* {prod-short} mounts certificates in the `/public-certs/` folder of the {prod-short} server container. To view the list of files in this folder, enter:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} exec -t __<{prod-id-short}-pod-name>__ -n {prod-namespace} -- ls /public-certs/
 ----
 +
-* In the {prod-short} server logs, there is a line for every certificate added to the Java truststore, including configured {prod-short} certificates. View them with following command:
+* In the {prod-short} server logs, there is a line for every certificate added to the Java truststore, including configured {prod-short} certificates. View them:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} logs __<{prod-id-short}-pod-name>__ -n {prod-namespace}
 ----
 +
-* {prod-short} server Java truststore contains the certificates. The certificates SHA1 fingerprints are among the list of the SHA1 of the certificates included in the truststore. View the list with the following command:
+* {prod-short} server Java truststore contains the certificates. The certificates SHA1 fingerprints are among the list of the SHA1 of the certificates included in the truststore. View the list:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
@@ -131,17 +130,16 @@ SHA1 Fingerprint=3F:DA:BF:E7:A7:A7:90:62:CA:CF:C7:55:0E:1D:7D:05:16:7D:45:60
 
 .Verifying imported certificates at the workspace level
 
-* Start a workspace, obtain the {orch-namespace} name in which it has been created, and wait for the workspace to be started.
-// What do I need the name for?
+* Start a workspace, obtain the {orch-namespace} name in which it has been created and wait for the workspace to be started.
 
-* Get the name of the workspace Pod with the following command:
+* Get the name of the workspace Pod:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
 $ {orch-cli} get pods -o=jsonpath='{.items[0].metadata.name}' -n __<workspace namespace>__ | grep '^workspace.*'
 ----
 
-* Get the name of the Che-Theia IDE container in the workspace Pod with the following command:
+* Get the name of the Che-Theia IDE container in the workspace Pod:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
@@ -156,7 +154,7 @@ $ {orch-cli} get -o json pod __<workspace pod name>__  -n __<workspace namespace
 $ {orch-cli} get cm ca-certs __<workspace namespace>__
 ----
 
-* Check that the entries in the `ca-certs` ConfigMap contain all the additional entries you added before. In addition, it can contain `ca-bundle.crt` reserved entry. View the entries with the following command:
+* Check that the entries in the `ca-certs` ConfigMap contain all the additional entries you added before. In addition, it can contain `ca-bundle.crt` reserved entry. View the entries:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
language review of importing-untrusted-tls-certificates.adoc

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-3500

## Specify the version of the product this pull request applies to
3.x

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
