### PR TITLE
fix: clarification of user-specific settings.xml in response to customer feedback

### DIFF
--- a/modules/end-user-guide/pages/using-credentials-and-configurations-in-workspaces.adoc
+++ b/modules/end-user-guide/pages/using-credentials-and-configurations-in-workspaces.adoc
@@ -20,7 +20,7 @@ The mounting process uses the standard {kubernetes} mounting mechanism and requi
 
 You can create permanent mount points for various components:
 
-* Maven configuration, such as the `settings.xml` file 
+* Maven configuration, such as the link:https://maven.apache.org/settings.html[user-specific] `settings.xml` file 
 * SSH key pairs
 * AWS authorization tokens
 * Configuration files


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
A support case identified a potential misunderstanding by customers of how `settings.xml` is to be handled inside a workspace.
This PR adds a clarification of the fact that `settings.xml` has to be user-specific.
Additionally, a link is added to the relevant page in the Maven docs so that the reader can look up the details to understand the distinction and look up more information should they need to.

## What issues does this pull request fix or reference?
RHDEVDOCS-2503

## Specify the version of the product this pull request applies to
`main` and cherry-pick to `7.52.x` and `7.53.x`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
