### PR TITLE
[docs] feat: add CHE_INFRA_KUBERNETES_PORT, CHE_INFRA_KUBERNETES_PORT_44…

### DIFF
--- a/modules/administration-guide/examples/system-variables.adoc
+++ b/modules/administration-guide/examples/system-variables.adoc
@@ -979,6 +979,37 @@ Default::: empty
 
 '''
 
+== `+CHE_INFRA_KUBERNETES_PORT+`
+
+Will set the value of KUBERNETES_PORT in che-dashboard. 
+
+Default::: empty
+
+'''
+
+== `+CHE_INFRA_KUBERNETES_PORT_443_TCP_ADDR+`
+
+Will set the value of KUBERNETES_PORT_443_TCP_ADDR in che-dashboard.
+
+Default::: empty
+
+'''
+
+== `+CHE_INFRA_KUBERNETES_PORT_443_TCP+`
+
+Will set the value of KUBERNETES_PORT_443_TCP in che-dashboard.
+
+Default::: empty
+
+'''
+
+== `+CHE_INFRA_KUBERNETES_SERVICE_HOST+`
+
+Will set the value of KUBERNETES_SERVICE_HOST in che-dashboard.
+
+Default::: empty
+
+'''
 
 [id="openshift-infra-parameters"]
 = OpenShift Infra parameters


### PR DESCRIPTION
…3_TCP_ADDR, CHE_INFRA_KUBERNETES_PORT_443_TCP, CHE_INFRA_KUBERNETES_SERVICE_HOST to docs for kubernetes. These will be used in che-dashboard


<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

Adds CHE_INFRA_KUBERNETES_PORT, CHE_INFRA_KUBERNETES_PORT_443_TCP_ADDR, CHE_INFRA_KUBERNETES_PORT_443_TCP, CHE_INFRA_KUBERNETES_SERVICE_HOST which will then be used in che-dashboard. This allows for non dex kubernetes auth for che-dashboard.

## What issues does this pull request fix or reference?

Adds the ability to use non dex oidc auth for kubernetes with che-dashboard.

## Specify the version of the product this pull request applies to
https://github.com/eclipse-che/che-dashboard/pull/596
https://github.com/eclipse-che/che-operator/pull/1465

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
