### PR TITLE
procedure: adding java 8 command for enabling maven artifact repositories

### DIFF
--- a/modules/end-user-guide/pages/enabling-maven-artifact-repositories.adoc
+++ b/modules/end-user-guide/pages/enabling-maven-artifact-repositories.adoc
@@ -85,7 +85,9 @@ data:
 . Optional: When using EAP-based devfiles, apply a second `settings-xml` ConfigMap with the same content, a different name, and the `/home/jboss/.m2` mount path.
 
 . Apply the ConfigMap for the TrustStore initialization script:
+
 +
+Java 8
 [source,yaml,subs="+quotes,+attributes,+macros"]
 ----
 kind: ConfigMap
@@ -99,12 +101,32 @@ metadata:
     controller.devfile.io/mount-to-devworkspace: 'true'
     controller.devfile.io/watch-configmap: 'true'
 data:
-  init-truststore.sh: |
+  init-java8-truststore.sh: |
+    #!/usr/bin/env bash
+
+    keytool -importcert -noprompt -file /home/user/certs/tls.cer -trustcacerts -keystore ~/.java/current/jre/lib/security/cacerts -storepass changeit
+----
+
++
+Java 11
+[source,yaml,subs="+quotes,+attributes,+macros"]
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: init-truststore
+  annotations:
+    controller.devfile.io/mount-as: subpath
+    controller.devfile.io/mount-path: /home/user/
+  labels:
+    controller.devfile.io/mount-to-devworkspace: 'true'
+    controller.devfile.io/watch-configmap: 'true'
+data:
+  init-java11-truststore.sh: |
     #!/usr/bin/env bash
 
     keytool -importcert -noprompt -file /home/user/certs/tls.cer -cacerts -storepass changeit
 ----
-
 . Start a Maven workspace.
 
 . Open a new terminal in the `tools` container.

--- a/modules/end-user-guide/pages/enabling-maven-artifact-repositories.adoc
+++ b/modules/end-user-guide/pages/enabling-maven-artifact-repositories.adoc
@@ -88,6 +88,7 @@ data:
 
 +
 Java 8
++
 [source,yaml,subs="+quotes,+attributes,+macros"]
 ----
 kind: ConfigMap
@@ -109,6 +110,7 @@ data:
 
 +
 Java 11
++
 [source,yaml,subs="+quotes,+attributes,+macros"]
 ----
 kind: ConfigMap


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Added a Java 8-specific command for enabling Maven artifact repositories.

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-4226

## Specify the version of the product this pull request applies to
Dev Spaces 3.0
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
