### PR TITLE
fix: users migration from 7.41.2 to 7.49.0 on OpenShift

### DIFF
--- a/modules/administration-guide/attachments/migration/1-prepare.sh
+++ b/modules/administration-guide/attachments/migration/1-prepare.sh
@@ -38,7 +38,7 @@ sed_in_place() {
 }
 
 refreshToken() {
-  echo "[INFO] Refreshing identity provier token"
+  echo "[INFO] Refreshing identity provider token"
   IDENTITY_PROVIDER_TOKEN=$(curl -ks \
     -d "client_id=admin-cli" \
     -d "username=${IDENTITY_PROVIDER_USERNAME}" \
@@ -61,41 +61,57 @@ getUsers() {
   rm -f "${ALL_USERS_DUMP}"
   refreshToken
   echo "[INFO] Dumping users list in file ${ALL_USERS_DUMP}"
-  ALL_USERS=$(curl -ks  -H "Authorization: bearer ${IDENTITY_PROVIDER_TOKEN}" "${IDENTITY_PROVIDER_URL}/${IDENTITY_PROVIDER_USERNAME}/realms/${IDENTITY_PROVIDER_REALM}/users")
-  IFS=" " read -r -a ALL_USERS_IDS <<< "$(echo "${ALL_USERS}" | jq ".[] | .id" | tr "\r\n" " ")"
 
-  for USER_ID in "${ALL_USERS_IDS[@]}"; do
-      refreshToken
+  TOTAL=0
+  FIRST=0
+  MAX=100
 
-      USER_ID=$(echo "${USER_ID}" | tr -d "\"")
-      FEDERATED_IDENTITY=$(curl -ks -H "Authorization: bearer ${IDENTITY_PROVIDER_TOKEN}" "${IDENTITY_PROVIDER_URL}/${IDENTITY_PROVIDER_USERNAME}/realms/${IDENTITY_PROVIDER_REALM}/users/${USER_ID}/federated-identity")
-      IDENTITY_PROVIDER=$(echo "${FEDERATED_IDENTITY}" | jq -r ".[] | select(.identityProvider == \"openshift-v4\")")
-      if [ -n "${IDENTITY_PROVIDER}" ]; then
-        USER_PROFILE=$(echo "${ALL_USERS}" | jq -r ".[] | select(.id == \"${USER_ID}\")")
-        USER_EMAIL=$(echo "${USER_PROFILE}" | jq -r ".email")
-        USER_NAME=$(echo "${USER_PROFILE}" | jq -r ".username")
-        USER_FIRST_NAME=$(echo "${USER_PROFILE}" | jq -r ".firstName")
-        USER_LAST_NAME=$(echo "${USER_PROFILE}" | jq -r ".lastName")
+  while :
+  do
+    ALL_USERS=$(curl -ks  -H "Authorization: bearer ${IDENTITY_PROVIDER_TOKEN}" "${IDENTITY_PROVIDER_URL}/${IDENTITY_PROVIDER_USERNAME}/realms/${IDENTITY_PROVIDER_REALM}/users?first=${FIRST}&max=${MAX}")
+    IFS=" " read -r -a ALL_USERS_IDS <<< "$(echo "${ALL_USERS}" | jq ".[] | .id" | tr "\r\n" " ")"
 
-        # Don't put null values into profile
-        [[ "${USER_FIRST_NAME}" == "null" ]] && USER_FIRST_NAME=""
-        [[ "${USER_LAST_NAME}" == "null" ]] && USER_LAST_NAME=""
+    # break the cycle if page is empty
+    [[ ${#ALL_USERS_IDS[@]} == 0 ]] && break
 
-        OPENSHIFT_USER_ID=$(echo "${IDENTITY_PROVIDER}" | jq ".userId" | tr -d "\"")
-        echo "[INFO] Found ${PRODUCT_ID} user: ${USER_ID} and corresponding OpenShift user: ${OPENSHIFT_USER_ID}"
+    for USER_ID in "${ALL_USERS_IDS[@]}"; do
+        refreshToken
 
-        # Save profile by encoding data and trimming \r\n
-        echo "${USER_ID} ${OPENSHIFT_USER_ID} username:$(echo "${USER_NAME}" | tr -d "\r\n" | base64) email:$(echo "${USER_EMAIL}" | tr -d "\r\n" | base64) firstName:$(echo "${USER_FIRST_NAME}" | tr -d "\r\n" | base64) lastName:$(echo "${USER_LAST_NAME}" | tr -d "\r\n" | base64) " >> "${ALL_USERS_DUMP}"
-      fi
+        USER_ID=$(echo "${USER_ID}" | tr -d "\"")
+        FEDERATED_IDENTITY=$(curl -ks -H "Authorization: bearer ${IDENTITY_PROVIDER_TOKEN}" "${IDENTITY_PROVIDER_URL}/${IDENTITY_PROVIDER_USERNAME}/realms/${IDENTITY_PROVIDER_REALM}/users/${USER_ID}/federated-identity")
+        IDENTITY_PROVIDER=$(echo "${FEDERATED_IDENTITY}" | jq -r ".[] | select(.identityProvider == \"openshift-v4\")")
+        if [ -n "${IDENTITY_PROVIDER}" ]; then
+          USER_PROFILE=$(echo "${ALL_USERS}" | jq -r ".[] | select(.id == \"${USER_ID}\")")
+          USER_EMAIL=$(echo "${USER_PROFILE}" | jq -r ".email")
+          USER_NAME=$(echo "${USER_PROFILE}" | jq -r ".username")
+          USER_FIRST_NAME=$(echo "${USER_PROFILE}" | jq -r ".firstName")
+          USER_LAST_NAME=$(echo "${USER_PROFILE}" | jq -r ".lastName")
+
+          # Don't put null values into profile
+          [[ "${USER_FIRST_NAME}" == "null" ]] && USER_FIRST_NAME=""
+          [[ "${USER_LAST_NAME}" == "null" ]] && USER_LAST_NAME=""
+
+          OPENSHIFT_USER_ID=$(echo "${IDENTITY_PROVIDER}" | jq ".userId" | tr -d "\"")
+          echo "[INFO] Found ${PRODUCT_ID} user: ${USER_ID} and corresponding OpenShift user: ${OPENSHIFT_USER_ID}"
+
+          # Save profile by encoding data and trimming \r\n
+          echo "${USER_ID} ${OPENSHIFT_USER_ID} username:$(echo "${USER_NAME}" | tr -d "\r\n" | base64) email:$(echo "${USER_EMAIL}" | tr -d "\r\n" | base64) firstName:$(echo "${USER_FIRST_NAME}" | tr -d "\r\n" | base64) lastName:$(echo "${USER_LAST_NAME}" | tr -d "\r\n" | base64) " >> "${ALL_USERS_DUMP}"
+          TOTAL=$((TOTAL+1))
+        else
+          echo "[WARN] Ignored ${PRODUCT_ID} user: ${USER_ID}. Corresponding OpenShift user not found."
+        fi
+    done
+
+    FIRST=$((FIRST + MAX))
   done
-  echo "[INFO] Users list dump completed."
 
+  echo "[INFO] Users list dump completed. Found ${TOTAL} users."
 }
 
 dumpDB() {
   echo "[INFO] Dumping database in file ${DB_DUMP}"
 
-  echo "[INFO] Retriving database name"
+  echo "[INFO] Retrieving database name"
   CHE_POSTGRES_DB=$("${K8S_CLI}" get cm/che -n "${INSTALLATION_NAMESPACE}" -o jsonpath='{.data.CHE_JDBC_URL}' | awk -F '/' '{print $NF}')
   if [ -z "${CHE_POSTGRES_DB}" ] || [ "${CHE_POSTGRES_DB}" = "null" ]; then CHE_POSTGRES_DB="dbche"; fi
   echo "[INFO] Database name is ${CHE_POSTGRES_DB}"

--- a/modules/administration-guide/attachments/migration/2-migrate.sh
+++ b/modules/administration-guide/attachments/migration/2-migrate.sh
@@ -44,8 +44,8 @@ migrateUserProfiles() {
     OPENSHIFT_USER_ID=${IDS[1]}
     USER_NAME=$(echo "${IDS[2]}" | cut -d ":" -f 2- | base64 -d)
     USER_EMAIL=$(echo "${IDS[3]}" | cut -d ":" -f 2- | base64 -d)
-    USER_FIRST_NAME=$(echo "${IDS[4]}" | cut -d ":" -f 2- | base64 -d)
-    USER_LAST_NAME=$(echo "${IDS[5]}" | cut -d ":" -f 2- | base64 -d)
+    USER_FIRST_NAME=$(echo "${IDS[4]}" | cut -d ":" -f 2- | base64 -d | sed "s|'|''|g")
+    USER_LAST_NAME=$(echo "${IDS[5]}" | cut -d ":" -f 2- | base64 -d | sed "s|'|''|g")
 
     OPENSHIFT_USER_ID_EXISTS_IN_DB_CHE=$("${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"SELECT COUNT(*) from usr WHERE id='${OPENSHIFT_USER_ID}';\"")
     if [[ ${OPENSHIFT_USER_ID_EXISTS_IN_DB_CHE} == 0 ]]; then

--- a/modules/administration-guide/attachments/migration/2-migrate.sh
+++ b/modules/administration-guide/attachments/migration/2-migrate.sh
@@ -47,11 +47,17 @@ migrateUserProfiles() {
     USER_FIRST_NAME=$(echo "${IDS[4]}" | cut -d ":" -f 2- | base64 -d)
     USER_LAST_NAME=$(echo "${IDS[5]}" | cut -d ":" -f 2- | base64 -d)
 
+    OPENSHIFT_USER_ID_EXISTS_IN_DB_CHE=$("${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"SELECT COUNT(*) from usr WHERE id='${OPENSHIFT_USER_ID}';\"")
+    if [[ ${OPENSHIFT_USER_ID_EXISTS_IN_DB_CHE} == 0 ]]; then
+        echo "[WARN] OpenShift user ${OPENSHIFT_USER_ID} does not exist in ${CHE_POSTGRES_DB} database."
+        continue
+    fi
+
     "${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"INSERT INTO profile(userid) VALUES ('${OPENSHIFT_USER_ID}');\""
-    "${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"INSERT INTO profile_attributes(user_id,name, value) VALUES ('${OPENSHIFT_USER_ID}', 'preferred_username', '${USER_NAME}');\""
-    "${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"INSERT INTO profile_attributes(user_id,name, value) VALUES ('${OPENSHIFT_USER_ID}', 'email', '${USER_EMAIL}');\""
-    "${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"INSERT INTO profile_attributes(user_id,name, value) VALUES ('${OPENSHIFT_USER_ID}', 'firstName', '${USER_FIRST_NAME}');\""
-    "${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"INSERT INTO profile_attributes(user_id,name, value) VALUES ('${OPENSHIFT_USER_ID}', 'lastName', '${USER_LAST_NAME}');\""
+    "${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"INSERT INTO profile_attributes(user_id, name, value) VALUES ('${OPENSHIFT_USER_ID}', 'preferred_username', '${USER_NAME}');\""
+    "${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"INSERT INTO profile_attributes(user_id, name, value) VALUES ('${OPENSHIFT_USER_ID}', 'email', '${USER_EMAIL}');\""
+    "${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"INSERT INTO profile_attributes(user_id, name, value) VALUES ('${OPENSHIFT_USER_ID}', 'firstName', '${USER_FIRST_NAME}');\""
+    "${K8S_CLI}" exec deploy/postgres -n "${INSTALLATION_NAMESPACE}"  -- bash  -c "psql ${CHE_POSTGRES_DB} -tAc \"INSERT INTO profile_attributes(user_id, name, value) VALUES ('${OPENSHIFT_USER_ID}', 'lastName', '${USER_LAST_NAME}');\""
 
     echo "[INFO] Added profile for \"${OPENSHIFT_USER_ID}\"."
   done < "${ALL_USERS_DUMP}"


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>


<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
* Fetch ALL keycloak users by pages
* Check if user exists in `dbche` database before inserting its profile
* Escaping `'` in user first and last name

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-3282

## How to test this PR
1. Deploy CRW on OpenShift
2. Create around 200 users in keycloak and OpenShift
3. Login for 10 users (to add them to dbche)
4. check `codeready-users.txt` file, it must be at least 200 records
5. run migration, check that only 10 users migrated

## Specify the version of the product this pull request applies to
7.49.x 7.50.x 7.51.x 7.52.x

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
