### PR TITLE
chore: adding Asciidoctor configuration to handle display in IDEs 

### DIFF
--- a/.asciidoctor/docinfo-footer.html
+++ b/.asciidoctor/docinfo-footer.html
@@ -1,0 +1,7 @@
+<footer class="footer">
+    <div><a href="https://www.eclipse.org" target="_blank">Eclipse Foundation</a> |
+        <a href="https://www.eclipse.org/legal/privacy.php" target="_blank">Privacy Policy</a> |
+        <a href="https://www.eclipse.org/legal/termsofuse.php" target="_blank">Terms of Use</a> |
+        <a href="https://www.eclipse.org/legal/epl-2.0/" target="_blank">Eclipse Public License</a> |
+        <a href="https://www.eclipse.org/legal" target="_blank">Legal Resources</a></div>
+</footer>

--- a/.asciidoctor/docinfo.html
+++ b/.asciidoctor/docinfo.html
@@ -1,0 +1,24 @@
+<link rel="stylesheet" href="{docinfodir}/../css/extra.css">
+<link rel="stylesheet" href="{docinfodir}/../font-awesome-4.7.0/css/font-awesome.min.css">
+<header class="header">
+  <nav class="navbar">
+    <div class="navbar-brand">
+      <div class="navbar-item">
+        <button class="navbar-burger" data-target="topbar-nav">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+        <img src="{docinfodir}/../supplemental-ui/img/icon-eclipse-che.svg" class="navbar-logo" alt="Eclipse Che logo">
+        <a href="https://www.eclipse.org/che/docs/">{prod} Documentation - development preview</a>
+      </div>
+    </div>
+    <div id="topbar-nav" class="navbar-menu">
+      <div class="navbar-end">
+        <a class="navbar-item" href="https://www.eclipse.org/che/">Home</a>
+        <a class="navbar-item" href="https://che.eclipseprojects.io/">Blog</a>
+        <a class="navbar-item" href="https://github.com/eclipse/che">Source Code</a>
+      </div>
+    </div>
+  </nav>
+</header>

--- a/.asciidoctorconfig
+++ b/.asciidoctorconfig
@@ -1,0 +1,5 @@
+:docinfo: shared
+:docinfodir: {asciidoctorconfigdir}/.asciidoctor
+:linkcss:
+:stylesdir: https://www.eclipse.org/che/docs/_/css/
+:stylesheet: site.css


### PR DESCRIPTION
chore: adding Asciidoctor configuration to handle display in IDEs supporting the feature.

See:

* https://docs.asciidoctor.org/asciidoctor/latest/docinfo/#header
* https://docs.asciidoctor.org/asciidoctor/latest/html-backend/custom-stylesheet/
* https://intellij-asciidoc-plugin.ahus1.de/docs/users-guide/features/advanced/antora.html#antora-preview-support
* https://intellij-asciidoc-plugin.ahus1.de/docs/users-guide/features/advanced/asciidoctorconfig-file.html

Example: file preview in PyCharm:

![Screenshot from 2022-08-24 15-17-25](https://user-images.githubusercontent.com/243761/186428532-283c54b6-f193-4067-aac8-11b67c61685b.png)

