### PR TITLE
feat: add documentation about required network policy for multitentan…

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -54,6 +54,7 @@
 **** xref:monitoring-the-dev-workspace-operator.adoc[]
 **** xref:monitoring-che.adoc[]
 ** xref:configuring-networking.adoc[]
+*** xref:configuring-network-policies.adoc[]
 *** xref:configuring-che-hostname.adoc[]
 *** xref:importing-untrusted-tls-certificates.adoc[]
 *** xref:configuring-ingresses.adoc[]

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -13,7 +13,7 @@ In the context of {prod-short}, this makes it possible for a workspace Pod in on
 For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
 However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in user {orch-namespace}s.
 
-For a cluster with network restrictions such as multitenant isolation already configured, you must apply the `allow-from-eclipse-che.yaml` NetworkPolicy to each user {orch-namespace}. The `allow-from-eclipse-che` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
+For a cluster with network restrictions such as multitenant isolation already configured, you must apply the `allow-from-eclipse-che` NetworkPolicy to each user {orch-namespace}. The `allow-from-eclipse-che` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
 
 
 .`allow-from-eclipse-che.yaml`

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -1,0 +1,48 @@
+:_content-type: CONCEPT
+:description: Configuring network policies
+:keywords: administration guide, configuring, namespace, network policy, network policies, multitenant isolation
+:navtitle: Configuring network policies
+:page-aliases: installation-guide:configuring-network-policies.adoc
+
+[id="configuring-networking-policies_{context}"]
+= Configuring network policies
+
+By default all Pods in a {orch-name} cluster can communicate with each other even if they are in different namespaces.
+In the context of {prod-short}, this makes it possible for a workspace Pod from one user {orch-namespace} to send traffic to another workspace Pod from a different user {orch-namespace}.
+
+For security, multitenant isolation can be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
+However for {prod-short}, it is necessary for Pods in the {prod-short} {orch-namespace} to be able to communicate with Pods in {orch-namespace}s. 
+
+For a {prod-short} installation with network restrictions such as multitenant isolation configured, the `allow-from-eclipse-che.yaml` NetworkPolicy must be applied to each user {orch-namespace}.
+
+The `allow-from-eclipse-che` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
+
+.`allow-from-eclipse-che.yaml`
+====
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: allow-from-eclipse-che
+spec:
+    ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+                kubernetes.io/metadata.name: {prod-namespace}   <1>
+    podSelector: {}   <2>
+    policyTypes:
+    - Ingress
+----
+====
+<1> The {prod-short} namespace. The default is `{prod-namespace}`.
+<2> The empty podSelector selects all Pods in the {orch-namespace}.
+
+.Additional resources
+
+* xref:configuring-namespace-provisioning.adoc[]
+
+* link:https://kubernetes.io/docs/concepts/security/multi-tenancy/#network-isolation[Network isolation]
+
+include::partial$snip_configuring-network-policies.adoc[]

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -45,4 +45,4 @@ spec:
 
 * link:https://kubernetes.io/docs/concepts/security/multi-tenancy/#network-isolation[Network isolation]
 
-include::partial$snip_configuring-network-policies.adoc[]
+* link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy]

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -7,7 +7,7 @@
 [id="configuring-networking-policies_{context}"]
 = Configuring network policies
 
-By default all Pods in a {orch-name} cluster can communicate with each other even if they are in different namespaces.
+By default, all Pods in a {orch-name} cluster can communicate with each other even if they are in different namespaces.
 In the context of {prod-short}, this makes it possible for a workspace Pod from one user {orch-namespace} to send traffic to another workspace Pod from a different user {orch-namespace}.
 
 For security, multitenant isolation can be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -11,7 +11,7 @@ By default, all Pods in a {orch-name} cluster can communicate with each other ev
 In the context of {prod-short}, this makes it possible for a workspace Pod in one user {orch-namespace} to send traffic to another workspace Pod in a different user {orch-namespace}.
 
 For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
-However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in {orch-namespace}s.
+However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in user {orch-namespace}s.
 
 For a {prod-short} installation with network restrictions such as multitenant isolation configured, the `allow-from-eclipse-che.yaml` NetworkPolicy must be applied to each user {orch-namespace}.
 

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -36,7 +36,7 @@ spec:
 ----
 ====
 <1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The empty podSelector selects all Pods in the {orch-namespace}.
+<2> The empty `podSelector` selects all Pods in the {orch-namespace}.
 
 .Additional resources
 

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -15,7 +15,6 @@ However, Pods in the {prod-short} {orch-namespace} must be able to communicate w
 
 For a cluster with network restrictions such as multitenant isolation already configured, you must apply the `allow-from-eclipse-che.yaml` NetworkPolicy to each user {orch-namespace}. The `allow-from-eclipse-che` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
 
-The `allow-from-eclipse-che` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
 
 .`allow-from-eclipse-che.yaml`
 ====

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -8,7 +8,7 @@
 = Configuring network policies
 
 By default, all Pods in a {orch-name} cluster can communicate with each other even if they are in different namespaces.
-In the context of {prod-short}, this makes it possible for a workspace Pod from one user {orch-namespace} to send traffic to another workspace Pod from a different user {orch-namespace}.
+In the context of {prod-short}, this makes it possible for a workspace Pod in one user {orch-namespace} to send traffic to another workspace Pod in a different user {orch-namespace}.
 
 For security, multitenant isolation can be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
 However for {prod-short}, it is necessary for Pods in the {prod-short} {orch-namespace} to be able to communicate with Pods in {orch-namespace}s. 

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -13,7 +13,7 @@ In the context of {prod-short}, this makes it possible for a workspace Pod in on
 For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
 However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in user {orch-namespace}s.
 
-For a {prod-short} installation with network restrictions such as multitenant isolation configured, the `allow-from-eclipse-che.yaml` NetworkPolicy must be applied to each user {orch-namespace}.
+For a cluster with network restrictions such as multitenant isolation already configured, you must apply the `allow-from-eclipse-che.yaml` NetworkPolicy to each user {orch-namespace}. The `allow-from-eclipse-che` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
 
 The `allow-from-eclipse-che` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
 

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -11,7 +11,7 @@ By default, all Pods in a {orch-name} cluster can communicate with each other ev
 In the context of {prod-short}, this makes it possible for a workspace Pod in one user {orch-namespace} to send traffic to another workspace Pod in a different user {orch-namespace}.
 
 For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
-However for {prod-short}, it is necessary for Pods in the {prod-short} {orch-namespace} to be able to communicate with Pods in {orch-namespace}s. 
+However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in {orch-namespace}s.
 
 For a {prod-short} installation with network restrictions such as multitenant isolation configured, the `allow-from-eclipse-che.yaml` NetworkPolicy must be applied to each user {orch-namespace}.
 

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -10,7 +10,7 @@
 By default, all Pods in a {orch-name} cluster can communicate with each other even if they are in different namespaces.
 In the context of {prod-short}, this makes it possible for a workspace Pod in one user {orch-namespace} to send traffic to another workspace Pod in a different user {orch-namespace}.
 
-For security, multitenant isolation can be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
+For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
 However for {prod-short}, it is necessary for Pods in the {prod-short} {orch-namespace} to be able to communicate with Pods in {orch-namespace}s. 
 
 For a {prod-short} installation with network restrictions such as multitenant isolation configured, the `allow-from-eclipse-che.yaml` NetworkPolicy must be applied to each user {orch-namespace}.

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -13,17 +13,17 @@ In the context of {prod-short}, this makes it possible for a workspace Pod in on
 For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
 However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in user {orch-namespace}s.
 
-For a cluster with network restrictions such as multitenant isolation already configured, you must apply the `allow-from-eclipse-che` NetworkPolicy to each user {orch-namespace}. The `allow-from-eclipse-che` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
+For a cluster with network restrictions such as multitenant isolation already configured, you must apply the `allow-from-{prod-namespace}` NetworkPolicy to each user {orch-namespace}. The `allow-from-{prod-namespace}` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
 
 
-.`allow-from-eclipse-che.yaml`
+.`allow-from-{prod-namespace}.yaml`
 ====
 [source,yaml,subs="+quotes,attributes"]
 ----
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-    name: allow-from-eclipse-che
+    name: allow-from-{prod-namespace}
 spec:
     ingress:
     - from:

--- a/modules/administration-guide/pages/configuring-networking.adoc
+++ b/modules/administration-guide/pages/configuring-networking.adoc
@@ -7,6 +7,7 @@
 [id="configuring-networking_{context}"]
 = Configuring networking
 
+* xref:configuring-network-policies.adoc[]
 * xref:configuring-che-hostname.adoc[]
 * xref:importing-untrusted-tls-certificates.adoc[]
 * xref:configuring-ingresses.adoc[]

--- a/modules/administration-guide/partials/snip_configuring-network-policies.adoc
+++ b/modules/administration-guide/partials/snip_configuring-network-policies.adoc
@@ -1,1 +1,0 @@
-* link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy]

--- a/modules/administration-guide/partials/snip_configuring-network-policies.adoc
+++ b/modules/administration-guide/partials/snip_configuring-network-policies.adoc
@@ -1,0 +1,1 @@
+* link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy]


### PR DESCRIPTION
…t isolation

Signed-off-by: dkwon17 <dakwon@redhat.com>

<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR adds documentation about the required NetworkPolicy for when there are networking restrictions between pods from different namespaces. 

Preview:
<img width="830" alt="image" src="https://user-images.githubusercontent.com/83611742/187275230-ef785ae8-a4d3-40f5-9c67-2746b0e532b9.png">


## What issues does this pull request fix or reference?
Fixes: https://github.com/eclipse/che/issues/21648

## Specify the version of the product this pull request applies to
All versions

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
