### PR TITLE
fix: formatting, italicizing for configuring-routes procedure

### DIFF
--- a/modules/administration-guide/pages/configuring-routes.adoc
+++ b/modules/administration-guide/pages/configuring-routes.adoc
@@ -19,14 +19,14 @@ You can configure labels, annotations, and domains for OpenShift Route to work w
 
 * Configure the `CheCluster` Custom Resource. See xref:using-the-cli-to-configure-the-checluster-custom-resource.adoc[].
 +
-[source,yaml,subs="+quotes"]
+[source,yaml,subs="+quotes,+macros"]
 ----
 spec:
   components:
     cheServer:
       extraProperties:
-        CHE_INFRA_OPENSHIFT_ROUTE_LABELS: <labels> <1>
-        CHE_INFRA_OPENSHIFT_ROUTE_HOST_DOMAIN__SUFFIX: <domain> <2>
+        CHE_INFRA_OPENSHIFT_ROUTE_LABELS: __<labels>__ <1>
+        pass:a,c,m[CHE_INFRA_OPENSHIFT_ROUTE_HOST_DOMAIN__SUFFIX]: __<domain>__ <2>
     networking:
       labels: __<labels>__ <1>
       domain: __<domain>__ <2>
@@ -34,7 +34,7 @@ spec:
 ----
 <1> A comma-separated list of labels that the target ingress controller uses to filter the set of Routes to service.
 <2> The DNS name serviced by the target ingress controller.
-<3> An unstructured key value map stored with a resource.```
+<3> An unstructured key value map stored with a resource.
 
 
 .Additional resources


### PR DESCRIPTION
Signed-off-by: dkwon17 <dakwon@redhat.com>

<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This small PR makes some minor formatting and italicizing fixes in the procedure of this page: https://www.eclipse.org/che/docs/next/administration-guide/configuring-routes/

<details open>
<summary>Before this PR (red arrows highlighting some problems)</summary>

![image](https://user-images.githubusercontent.com/83611742/187488535-c61f708d-5c10-4d92-8757-de1c826ef283.png)

</details>

<details open>
<summary>After this PR</summary>

<img width="636" alt="image" src="https://user-images.githubusercontent.com/83611742/187488835-d3f48a0a-8918-44fb-a771-893e4998e8a4.png">

</details>


## What issues does this pull request fix or reference?
No particular issue

## Specify the version of the product this pull request applies to
All versions

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
