### PR TITLE
docs: in installing-che-in-a-restricted-environment, link configuring-network-policies

### DIFF
--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -13,9 +13,13 @@ In the context of {prod-short}, this makes it possible for a workspace Pod in on
 For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
 However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in user {orch-namespace}s.
 
-For a cluster with network restrictions such as multitenant isolation already configured, you must apply the `allow-from-{prod-namespace}` NetworkPolicy to each user {orch-namespace}. The `allow-from-{prod-namespace}` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
+.Prerequisites
+* The {orch-name} cluster has network restrictions such as multitenant isolation.
 
-
+.Procedure
+* Apply the `allow-from-{prod-namespace}` NetworkPolicy to each user {orch-namespace}.
+The `allow-from-{prod-namespace}` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
++
 .`allow-from-{prod-namespace}.yaml`
 ====
 [source,yaml,subs="+quotes,attributes"]
@@ -35,11 +39,12 @@ spec:
     - Ingress
 ----
 ====
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
++
+<1> The {prod-short} namespace.
+The default is `{prod-namespace}`.
 <2> The empty `podSelector` selects all Pods in the {orch-namespace}.
 
 .Additional resources
-
 * xref:configuring-namespace-provisioning.adoc[]
 
 * link:https://kubernetes.io/docs/concepts/security/multi-tenancy/#network-isolation[Network isolation]

--- a/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
+++ b/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
@@ -29,4 +29,6 @@ $ {prod-cli} server:deploy --platform=openshift \
   --che-operator-cr-patch-yaml=che-operator-cr-patch.yaml
 ----
 
+. Allow incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}s. See: xref:configuring-network-policies.adoc[].
+
 include::partial$snip_installing-che-in-a-restricted-environment-additional-resources.adoc[]


### PR DESCRIPTION
## What does this pull request change?

In installing-che-in-a-restricted-environment, add a last step pointing to configuring-network-policies

## What issues does this pull request fix or reference?

fixes https://issues.redhat.com/browse/RHDEVDOCS-4407

## Specify the version of the product this pull request applies to

`7.50.x` to `main`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
