### PR TITLE
chore - add Vale GitHub action

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,0 +1,27 @@
+---
+#
+# Copyright (c) 2022 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Linting with Vale
+on:
+  - pull_request
+jobs:
+  vale:
+    name: Linting with Vale
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Vale Linter
+        uses: errata-ai/vale-action@reviewdog
+        with:
+          fail_on_error: true
+        env:
+          # Required, set by GitHub actions automatically:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
The Vale GitHub action reports Vale errors in the _Files changed_ view.

Example: 

![Screenshot from 2022-09-12 12-58-22](https://user-images.githubusercontent.com/243761/189637178-6f07c095-a1e1-45db-a752-e873e35e4dc6.png)
