### PR TITLE
fix: use underscores in user-replaced values

### DIFF
--- a/modules/administration-guide/examples/checluster-properties.adoc
+++ b/modules/administration-guide/examples/checluster-properties.adoc
@@ -48,7 +48,7 @@ runningLimit: The maximum number of running workspaces per user.
 [cols="2,5", options="header"]
 :=== 
  Property: Description 
-clusterRoles: ClusterRoles assigned to Che ServiceAccount. The defaults roles are\: - `<che-namespace>-cheworkspaces-namespaces-clusterrole` - `<che-namespace>-cheworkspaces-clusterrole` - `<che-namespace>-cheworkspaces-devworkspace-clusterrole` where the <che-namespace> is the namespace where the CheCluster CRD is created. Each role must have a `app.kubernetes.io/part-of=che.eclipse.org` label. The Che Operator must already have all permissions in these ClusterRoles to grant them.
+clusterRoles: ClusterRoles assigned to Che ServiceAccount. The defaults roles are\: - `<che_namespace>-cheworkspaces-namespaces-clusterrole` - `<che_namespace>-cheworkspaces-clusterrole` - `<che_namespace>-cheworkspaces-devworkspace-clusterrole` where the <che_namespace> is the namespace where the CheCluster CRD is created. Each role must have a `app.kubernetes.io/part-of=che.eclipse.org` label. The Che Operator must already have all permissions in these ClusterRoles to grant them.
 debug: Enables the debug mode for Che server.
 deployment: Deployment override options.
 extraProperties: A map of additional environment variables applied in the generated `che` ConfigMap to be used by the Che server in addition to the values already generated from other fields of the `CheCluster` custom resource (CR). If the `extraProperties` field contains a property normally generated in `che` ConfigMap from other CR fields, the value defined in the `extraProperties` is used instead.
@@ -130,7 +130,7 @@ enable: Enables `metrics` for the Che server endpoint.
  Property: Description 
 annotations: Defines annotations which will be set for an Ingress (a route for OpenShift platform). The defaults for kubernetes platforms are\:     kubernetes.io/ingress.class\:                       \nginx\     nginx.ingress.kubernetes.io/proxy-read-timeout\:    \3600\,     nginx.ingress.kubernetes.io/proxy-connect-timeout\: \3600\,     nginx.ingress.kubernetes.io/ssl-redirect\:          \true\
 auth: Authentication settings.
-domain: For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern\: che-<che-namespace>.<domain>. The <che-namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values\: you must specify them.
+domain: For an OpenShift cluster, the Operator uses the domain to generate a hostname for the route. The generated hostname follows this pattern\: che-<che_namespace>.<domain>. The <che_namespace> is the namespace where the CheCluster CRD is created. In conjunction with labels, it creates a route served by a non-default Ingress controller. For a Kubernetes cluster, it contains a global ingress domain. There are no default values\: you must specify them.
 hostname: The public hostname of the installed Che server.
 labels: Defines labels which will be set for an Ingress (a route for OpenShift platform).
 tlsSecretName: The name of the secret used to set up Ingress TLS termination. If the field is an empty string, the default cluster certificate is used. The secret must have a `app.kubernetes.io/part-of=che.eclipse.org` label.
@@ -163,5 +163,3 @@ postgresVersion: The PostgreSQL version of the image in use.
 reason: A brief CamelCase message indicating details about why the Che deployment is in the current phase.
 workspaceBaseDomain: The resolved workspace base domain. This is either the copy of the explicitly defined property of the same name in the spec or, if it is undefined in the spec and we're running on OpenShift, the automatically resolved basedomain for routes.
 :=== 
-
-

--- a/modules/administration-guide/examples/snip_che-build-a-custom-plug-in-registry.adoc
+++ b/modules/administration-guide/examples/snip_che-build-a-custom-plug-in-registry.adoc
@@ -1,6 +1,6 @@
 [subs="+attributes,+quotes"]
 ----
-$ ./build.sh --organization _<my-org>_ \
-           --registry _<my-registry>_ \
-           --tag _<my-tag>_
+$ ./build.sh --organization _<my_org>_ \
+           --registry _<my_registry>_ \
+           --tag _<my_tag>_
 ----

--- a/modules/administration-guide/examples/system-variables.adoc
+++ b/modules/administration-guide/examples/system-variables.adoc
@@ -847,7 +847,7 @@ Default::: `+true+`
 
 == `+CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON+`
 
-Defines annotations for ingresses which are used for servers exposing. Value depends on the kind of ingress controller. OpenShift infrastructure ignores this property because it uses Routes rather than Ingresses. the {prod-short} Operator that for a single-host deployment strategy to work, a controller supporting URL rewriting has to be used (so that URLs can point to different servers while the servers do not need to support changing the app root). The `che.infra.kubernetes.ingress.path.rewrite_transform` property defines how the path of the ingress should be transformed to support the URL rewriting and this property defines the set of annotations on the ingress itself that instruct the chosen ingress controller to actually do the URL rewriting, potentially building on the path transformation (if required by the chosen ingress controller). For example for Nginx ingress controller 0.22.0 and later the following value is recommended: `{"ingress.kubernetes.io/rewrite-target": "/$1","ingress.kubernetes.io/ssl-redirect": "false",\     "ingress.kubernetes.io/proxy-connect-timeout": "3600","ingress.kubernetes.io/proxy-read-timeout": "3600",     "nginx.org/websocket-services": "<service-name>"}` and the `che.infra.kubernetes.ingress.path.rewrite_transform` should be set to `"%s(.*)"`. For nginx ingress controller older than 0.22.0, the rewrite-target should be set to merely `/` and the path transform to `%s` (see the `che.infra.kubernetes.ingress.path.rewrite_transform` property). See the Nginx ingress controller documentation for the explanation of how the ingress controller uses the regular expression available in the ingress path and how it achieves the URL rewriting.
+Defines annotations for ingresses which are used for servers exposing. Value depends on the kind of ingress controller. OpenShift infrastructure ignores this property because it uses Routes rather than Ingresses. the {prod-short} Operator that for a single-host deployment strategy to work, a controller supporting URL rewriting has to be used (so that URLs can point to different servers while the servers do not need to support changing the app root). The `che.infra.kubernetes.ingress.path.rewrite_transform` property defines how the path of the ingress should be transformed to support the URL rewriting and this property defines the set of annotations on the ingress itself that instruct the chosen ingress controller to actually do the URL rewriting, potentially building on the path transformation (if required by the chosen ingress controller). For example for Nginx ingress controller 0.22.0 and later the following value is recommended: `{"ingress.kubernetes.io/rewrite-target": "/$1","ingress.kubernetes.io/ssl-redirect": "false",\     "ingress.kubernetes.io/proxy-connect-timeout": "3600","ingress.kubernetes.io/proxy-read-timeout": "3600",     "nginx.org/websocket-services": "<service_name>"}` and the `che.infra.kubernetes.ingress.path.rewrite_transform` should be set to `"%s(.*)"`. For nginx ingress controller older than 0.22.0, the rewrite-target should be set to merely `/` and the path transform to `%s` (see the `che.infra.kubernetes.ingress.path.rewrite_transform` property). See the Nginx ingress controller documentation for the explanation of how the ingress controller uses the regular expression available in the ingress path and how it achieves the URL rewriting.
 
 Default::: `+NULL+`
 
@@ -1673,7 +1673,7 @@ Default::: `+true+`
 
 == `+CHE_KEYCLOAK_JS__ADAPTER__URL+`
 
-URL to the Keycloak Javascript adapter to use. if set to NULL, then the default used value is `$++{che.keycloak.auth_server_url}++/js/keycloak.js`, or `<che-server>/api/keycloak/OIDCKeycloak.js` if an alternate `oidc_provider` is used
+URL to the Keycloak Javascript adapter to use. if set to NULL, then the default used value is `$++{che.keycloak.auth_server_url}++/js/keycloak.js`, or `<che_server>/api/keycloak/OIDCKeycloak.js` if an alternate `oidc_provider` is used
 
 Default::: `+NULL+`
 
@@ -1732,5 +1732,3 @@ User name adjustment configuration. {prod-short} needs to use the usernames as p
 Default::: `+NULL+`
 
 '''
-
-

--- a/modules/administration-guide/pages/configuring-che-hostname.adoc
+++ b/modules/administration-guide/pages/configuring-che-hostname.adoc
@@ -32,9 +32,9 @@ $ {orch-cli} create {orch-namespace} {prod-namespace}
 +
 [subs="+quotes,attributes"]
 ----
-$ {orch-cli} create secret TLS __<tls-secret-name>__ \ <1>
---key __<key-file>__ \ <2>
---cert __<cert-file>__ \ <3>
+$ {orch-cli} create secret TLS __<tls_secret_name>__ \ <1>
+--key __<key_file>__ \ <2>
+--cert __<cert_file>__ \ <3>
 -n {prod-namespace}
 ----
 <1> The TLS secret name
@@ -45,7 +45,7 @@ $ {orch-cli} create secret TLS __<tls-secret-name>__ \ <1>
 +
 [subs="+quotes,attributes"]
 ----
-$ {orch-cli} label secret __<tls-secret-name>__ \ <1>
+$ {orch-cli} label secret __<tls_secret_name>__ \ <1>
 app.kubernetes.io/part-of=che.eclipse.org -n {prod-namespace}
 ----
 <1> The TLS secret name

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -53,10 +53,10 @@ Certificate files are typically stored as Base64 files, with extensions such as 
 +
 [subs="+attributes,+quotes"]
 ----
-$ {orch-cli} create configmap custom-certs --from-file=__<bundle-file-path>__ -n={prod-namespace}
+$ {orch-cli} create configmap custom-certs --from-file=__<bundle_file_path>__ -n={prod-namespace}
 ----
 +
-To apply more than one bundle, add another `-from-file=_<bundle-file-path>_`. Alternatively, create another ConfigMap.
+To apply more than one bundle, add another `-from-file=_<bundle_file_path>_`. Alternatively, create another ConfigMap.
 
 . Label created ConfigMaps with the `app.kubernetes.io/part-of=che.eclipse.org` and `app.kubernetes.io/component=ca-bundle` labels:
 +
@@ -125,7 +125,7 @@ To get the SHA1 hash of a certificate on the local filesystem, run:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-$ openssl x509 -in __<certificate-file-path>__ -fingerprint -noout
+$ openssl x509 -in __<certificate_file_path>__ -fingerprint -noout
 SHA1 Fingerprint=3F:DA:BF:E7:A7:A7:90:62:CA:CF:C7:55:0E:1D:7D:05:16:7D:45:60
 ----
 

--- a/modules/administration-guide/pages/installing-che-on-red-hat-openshift-local.adoc
+++ b/modules/administration-guide/pages/installing-che-on-red-hat-openshift-local.adoc
@@ -41,7 +41,7 @@ $ crc setup
 +
 [subs="+quotes"]
 ----
-$ crc start --memory 12288 --disk-size=64 --pull-secret-file __<pull-secret-file>__
+$ crc start --memory 12288 --disk-size=64 --pull-secret-file __<pull_secret_file>__
 ----
 
 . Enable access to the `oc` command line interface embedded in {rh-os-local}:

--- a/modules/administration-guide/pages/repairing-the-devworkspace-operator-on-openshift.adoc
+++ b/modules/administration-guide/pages/repairing-the-devworkspace-operator-on-openshift.adoc
@@ -43,7 +43,7 @@ $ oc delete sub devworkspace-operator \
 ----
 <1> `openshift-operators` or an OpenShift {orch-namespace} where the {devworkspace} Operator is installed.
 
-. Get the {devworkspace} Operator CSVs in the __<devworkspace-operator.vX.Y.Z>__ format:
+. Get the {devworkspace} Operator CSVs in the __<devworkspace_operator.vX.Y.Z>__ format:
 +
 ----
 $ oc get csv | grep devworkspace
@@ -53,7 +53,7 @@ $ oc get csv | grep devworkspace
 +
 [subs="+quotes"]
 ----
-$ oc delete csv __<devworkspace-operator.vX.Y.Z>__ \
+$ oc delete csv __<devworkspace_operator.vX.Y.Z>__ \
 -n openshift-operators <1>
 ----
 <1> `openshift-operators` or an OpenShift {orch-namespace} where the {devworkspace} Operator is installed.

--- a/modules/administration-guide/pages/using-chectl-to-configure-the-checluster-custom-resource-during-installation.adoc
+++ b/modules/administration-guide/pages/using-chectl-to-configure-the-checluster-custom-resource-during-installation.adoc
@@ -24,7 +24,7 @@ To deploy {prod-short} with a suitable configuration, edit the `CheCluster` Cust
 ----
 spec:
   __<component>__:
-      __<property-to-configure>__: __<value>__
+      __<property_to_configure>__: __<value>__
 ----
 ====
 * Deploy {prod-short} and apply the changes described in `che-operator-cr-patch.yaml` file:
@@ -33,7 +33,7 @@ spec:
 ----
 $ {prod-cli} server:deploy \
 --che-operator-cr-patch-yaml=che-operator-cr-patch.yaml \
---platform __<chosen-platform>__
+--platform __<chosen_platform>__
 ----
 
 .Verification
@@ -42,7 +42,7 @@ $ {prod-cli} server:deploy \
 +
 [subs="+attributes,quotes"]
 ----
-$ oc get configmap che -o jsonpath='{.data._<configured-property>_}' \
+$ oc get configmap che -o jsonpath='{.data._<configured_property>_}' \
 -n {prod-namespace}
 ----
 

--- a/modules/administration-guide/pages/using-the-cli-to-configure-the-checluster-custom-resource.adoc
+++ b/modules/administration-guide/pages/using-the-cli-to-configure-the-checluster-custom-resource.adoc
@@ -32,7 +32,7 @@ $ {orch-cli} edit checluster/{prod-checluster} -n {prod-namespace}
 +
 [subs="+attributes,quotes"]
 ----
-$ {orch-cli} get configmap che -o jsonpath='{.data._<configured-property>_}' \
+$ {orch-cli} get configmap che -o jsonpath='{.data._<configured_property>_}' \
 -n {prod-namespace}
 ----
 

--- a/modules/end-user-guide/pages/first-time-contributors.adoc
+++ b/modules/end-user-guide/pages/first-time-contributors.adoc
@@ -14,11 +14,11 @@ image::contribute.svg[Factory badge]
 
 .Procedure
 
-. Substitute your {prod-short} URL (`pass:c,a,q[{prod-url}]`) and repository URL (`__<your-repository-url>__`), and add the link to your repository in the project `README.md` file.
+. Substitute your {prod-short} URL (`pass:c,a,q[{prod-url}]`) and repository URL (`__<your_repository_url>__`), and add the link to your repository in the project `README.md` file.
 +
 [subs="+attributes,+macros,+quotes"]
 ----
-[![Contribute](https://www.eclipse.org/che/contribute.svg)](pass:c,a,q[{prod-url}]/#https://__<your-repository-url>__)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](pass:c,a,q[{prod-url}]/#https://__<your_repository_url>__)
 ----
 
 . The `README.md` file in your Git provider web interface displays the image:contribute.svg[Factory badge] factory badge. Click the badge to open a workspace with your project in your {prod-short} instance.

--- a/modules/end-user-guide/pages/troubleshooting-slow-workspaces.adoc
+++ b/modules/end-user-guide/pages/troubleshooting-slow-workspaces.adoc
@@ -56,7 +56,7 @@ CDN configuration::
 +
 The IDE editor uses a CDN (Content Delivery Network) to serve content. Check that the content uses a CDN to the client (or a local route for offline setup).
 +
-To check that, open Developer Tools in the browser and check for `vendors` in the *Network* tab. `vendors.<random-id>.js` or `editor.main.*` should come from CDN URLs.
+To check that, open Developer Tools in the browser and check for `vendors` in the *Network* tab. `vendors.<random_id>.js` or `editor.main.*` should come from CDN URLs.
 
 
 [id="improving-workspace-runtime-performance_{context}"]

--- a/modules/end-user-guide/partials/proc_using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/partials/proc_using-a-git-provider-access-token.adoc
@@ -50,7 +50,7 @@ data:
 type: Opaque
 ----
 +
-<1> Your Che user ID. You can retrieve `__<che-endpoint>__/api/user` to get the Che user data.
+<1> Your Che user ID. You can retrieve `__<che_endpoint>__/api/user` to get the Che user data.
 <2> The Git provider name: `github` or `gitlab` or `bitbucket-server`.
 <3> The Git provider URL.
 <4> Your Git provider user ID, follow the API documentation to retrieve the user object:

--- a/modules/end-user-guide/partials/proc_verifying-the-state-of-the-netcoredebugoutput-plug-in.adoc
+++ b/modules/end-user-guide/partials/proc_verifying-the-state-of-the-netcoredebugoutput-plug-in.adoc
@@ -14,7 +14,7 @@
 {
  "type": "netcoredbg",
  "request": "launch",
- "program": "$\{workspaceFolder}/bin/Debug/__<target-framework>__/__<project-name.dll>__",
+ "program": "$\{workspaceFolder}/bin/Debug/__<target_framework>__/__<project_name.dll>__",
  "args": [],
  "name": ".NET Core Launch (console)",
  "stopAtEntry": false,
@@ -24,4 +24,3 @@
 ====
 
 . Test the autocompletion feature within the braces of the `configuration` section of the `launch.json` file. If you can find `netcoredbg`, the Che-Theia plug-in is correctly initialized. If not, see xref:viewing-che-workspaces-logs.adoc[].
-

--- a/modules/end-user-guide/partials/proc_viewing-che-theia-ide-logs-on-the-cli.adoc
+++ b/modules/end-user-guide/partials/proc_viewing-che-theia-ide-logs-on-the-cli.adoc
@@ -32,7 +32,7 @@ workspace0zqb2ew3py4srthh.go-cli-549cdcf69-9n4w2  4/4    Running  0         1h
 +
 [subs="+quotes",options="nowrap",role=white-space-pre]
 ----
-$ oc get pods _<name-of-pod>_ --output jsonpath='\{.spec.containers[*].name}'
+$ oc get pods _<name_of_pod>_ --output jsonpath='\{.spec.containers[*].name}'
 ----
 +
 .Example:
@@ -47,7 +47,7 @@ jsonpath='\{.spec.containers[*].name}'
 +
 [subs="+quotes"]
 ----
-$ oc logs --follow _<name-of-pod>_ --container _<name-of-container>_
+$ oc logs --follow _<name_of_pod>_ --container _<name_of_container>_
 ----
 +
 .Example:


### PR DESCRIPTION
Use underscores in user-replaced values, rather than hyphens, to comply with https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values.

fixes: https://issues.redhat.com/browse/RHDEVDOCS-3498