### PR TITLE
fix: update the web console install procedure to account for downstream variation

### DIFF
--- a/modules/administration-guide/examples/snip_che-web-console-installation-steps.adoc
+++ b/modules/administration-guide/examples/snip_che-web-console-installation-steps.adoc
@@ -1,0 +1,1 @@
+. Create a {prod-short} instance from the {prod} Operator.

--- a/modules/administration-guide/pages/installing-che-on-openshift-using-the-web-console.adoc
+++ b/modules/administration-guide/pages/installing-che-on-openshift-using-the-web-console.adoc
@@ -27,7 +27,18 @@ Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "ch
 
 . Install the {prod} Operator. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console].
 
-. Create a {prod-short} instance from the {prod} Operator. See https://docs.openshift.com/container-platform/4.10/operators/user/olm-creating-apps-from-installed-operators.html[Creating applications from installed Operators].
+. Create the `{prod-namespace}` project in OpenShift as follows:
++
+[subs="+attributes"]
+----
+oc create namespace {prod-namespace}
+----
+
+. In the *Administrator* view of the OpenShift web console, go to menu:Operators[Installed Operators > {prod} instance Specification > Create CheCluster > YAML view].
+
+. In the *YAML view*, replace `namespace: openshift-operators` with `namespace: {prod-namespace}`.
+
+. Select *Create*. See https://docs.openshift.com/container-platform/4.10/operators/user/olm-creating-apps-from-installed-operators.html[Creating applications from installed Operators].
 
 .Verification
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Some steps in the following procedure are moved into a new snip to allow for a downstream variation of the procedure due to a different namespace that has to be manually created and specified:
https://www.eclipse.org/che/docs/stable/administration-guide/installing-che-on-openshift-using-the-web-console/
This is just reshuffling some content across lines and files, so no need for engineering or language reviews here.

Latest preview: https://632b1060c061fa35023632d9--eclipse-che-docs-pr.netlify.app/docs/next/administration-guide/installing-che-on-openshift-using-the-web-console/

## What issues does this pull request fix or reference?
RHDEVDOCS-4341

## Specify the version of the product this pull request applies to
`main` and cherry-pick to `7.50.x` and `7.52`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
