### PR TITLE
fix: add docs for starting ephemeral/persistent workspaces

### DIFF
--- a/modules/end-user-guide/nav.adoc
+++ b/modules/end-user-guide/nav.adoc
@@ -13,6 +13,7 @@
 *** xref:url-parameter-for-starting-duplicate-workspaces.adoc[]
 *** xref:url-parameter-for-the-devfile-file-name.adoc[]
 *** xref:url-parameter-for-the-devfile-file-path.adoc[]
+*** xref:url-parameter-for-starting-ephemeral-workspaces.adoc[]
 ** xref:basic-actions-you-can-perform-on-a-workspace.adoc[]
 ** xref:authenticating-to-a-git-server-from-a-workspace.adoc[]
 * xref:customizing-workspace-components.adoc[]

--- a/modules/end-user-guide/pages/optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc
+++ b/modules/end-user-guide/pages/optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc
@@ -14,3 +14,4 @@ When you start a new workspace, {prod-short} configures the workspace according 
 * xref:url-parameter-for-starting-duplicate-workspaces.adoc[]
 * xref:url-parameter-for-the-devfile-file-name.adoc[]
 * xref:url-parameter-for-the-devfile-file-path.adoc[]
+* xref:url-parameter-for-starting-ephemeral-workspaces.adoc[]

--- a/modules/end-user-guide/pages/url-parameter-for-starting-ephemeral-workspaces.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-starting-ephemeral-workspaces.adoc
@@ -1,0 +1,23 @@
+:_content-type: CONCEPT
+:description: URL parameter starting ephemeral workspaces
+:keywords: ephemeral-workspace, persistent-workspace
+:navtitle: URL parameter starting ephemeral workspaces
+:page-aliases:
+
+[id="url-parameter-for-starting-ephemeral-workspaces_{context}"]
+= URL parameter for starting ephemeral workspaces
+
+If the URL for starting a new workspace doesn't contain a URL parameter specifying the storage type, {prod-short} will not persist by default the workspace and its data and they'll be lost when the workspace stops.
+
+The URL parameter for specifying a supported storage Type is `storageType=__<storage_type>__`:
+
+[source,subs="+quotes,+attributes,+macros"]
+----
+pass:c,a,q[{prod-url}]#__<git_repository_url>__?storageType=__<storage_type>__
+----
+
+The URL parameter `__<storage_type>__` values for supported storage types are `ephemeral` and `persistent`.
+
+.Additional resources
+
+* xref:requesting-persistent-storage-for-workspaces.adoc[]

--- a/modules/end-user-guide/pages/url-parameter-for-starting-ephemeral-workspaces.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-starting-ephemeral-workspaces.adoc
@@ -9,7 +9,7 @@
 
 If the URL for starting a new workspace doesn't contain a URL parameter specifying the storage type, {prod-short} will not persist by default the workspace and its data and they'll be lost when the workspace stops.
 
-The URL parameter for specifying a supported storage Type is `storageType=__<storage_type>__`:
+The URL parameter for specifying a supported storage type is `storageType=__<storage_type>__`:
 
 [source,subs="+quotes,+attributes,+macros"]
 ----


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

This PR adds some info about the URL parameter `storageType` that can be used for starting a new workspace.

## What issues does this pull request fix or reference?

https://github.com/eclipse/che/issues/21569#issuecomment-1198060211

## Specify the version of the product this pull request applies to

7.52

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
