### PR TITLE
chore: update container

### DIFF
--- a/.github/workflows/container-on-pull-request.yml
+++ b/.github/workflows/container-on-pull-request.yml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2022 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: "Build and verify container"
+
+on:
+  - pull_request
+
+jobs:
+  build:
+    name: "Build and verify container"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Necessary for git diff in vale step
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and verify the container
+        run: tools/build-and-verify-container.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,19 +28,6 @@ RUN wget -qO- https://github.com/wjdp/htmltest/archive/refs/tags/v${HTMLTEST_VER
     &&  GOOS=linux GOARCH=${ARCH} CGO_ENABLED=0 go build -tags closed -ldflags "-X main.date=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=${HTMLTEST_VERSION}" -o bin/htmltest . \
     &&  /htmltest/bin/htmltest --version
 
-# Build vale
-WORKDIR /vale
-ARG VALE_VERSION=2.20.0
-RUN wget -qO- https://github.com/errata-ai/vale/archive/v${VALE_VERSION}.tar.gz | tar --strip-components=1 -zxvf - \
-    &&  export ARCH="$(uname -m)" \
-    &&  if [[ ${ARCH} == "x86_64" ]]; \
-    then export ARCH="amd64"; \
-    elif [[ ${ARCH} == "aarch64" ]]; \
-    then export ARCH="arm64"; \
-    fi \
-    &&  GOOS=linux GOARCH=${ARCH} CGO_ENABLED=0 go build -tags closed -ldflags "-X main.date=`date -u +%Y-%m-%dT%H:%M:%SZ` -X main.version=${VALE_VERSION}" -o bin/vale ./cmd/vale \
-    &&  /vale/bin/vale --version
-
 # Download shellcheck
 ARG SHELLCHECK_VERSION=0.8.0
 RUN wget -qO- https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.$(uname -m).tar.xz | tar -C /usr/local/bin/ --no-anchored 'shellcheck' --strip=1 -xJf -
@@ -50,7 +37,6 @@ RUN wget -qO- https://github.com/koalaman/shellcheck/releases/download/v${SHELLC
 FROM registry.access.redhat.com/ubi8/nodejs-16
 USER root
 
-COPY --from=builder /vale/bin/vale /usr/local/bin/vale
 COPY --from=builder /htmltest/bin/htmltest /usr/local/bin/htmltest
 COPY --from=builder /usr/local/bin/shellcheck /usr/local/bin/shellcheck
 
@@ -69,15 +55,18 @@ LABEL \
     vendor="Eclipse Che documentation team" \
     version="2022.06"
 
-ARG ANTORA_VERSION=3.0.2
+# Install system packages
 RUN set -x \
     && dnf upgrade --assumeyes --quiet \
+    && dnf install --assumeyes --quiet dnf-plugins-core \
+    && dnf copr enable --assumeyes --quiet mczernek/vale \
     && dnf install --assumeyes --quiet \
     bash \
     curl \
     file \
     findutils \
     git-core \
+    graphviz \
     grep \
     jq \
     nodejs \
@@ -85,16 +74,28 @@ RUN set -x \
     python3-wheel \
     tar \
     unzip \
+    vale \
     wget \
-    && dnf clean all --quiet \
+    && dnf clean all --quiet
+
+# Install Python packages
+RUN set -x \
     && pip3 install --no-cache-dir --no-input --quiet \
     diagrams \
     jinja2-cli \
-    yq \
-    && corepack enable \
-    && yarnpkg global add --non-interactive \
+    yq
+
+# Install Node.JS packaages
+ARG ANTORA_VERSION=3.1
+# Avoid error: Local gulp not found in /projects
+ENV NODE_PATH="/opt/app-root/src/.npm-global/lib/node_modules/"
+RUN set -x \
+    && npm install --no-save --location=global \
+    @antora/assembler \
     @antora/cli@${ANTORA_VERSION} \
+    @antora/collector-extension \
     @antora/lunr-extension \
+    @antora/pdf-extension \
     @antora/site-generator@${ANTORA_VERSION} \
     asciidoctor \
     asciidoctor-emoji \
@@ -105,8 +106,6 @@ RUN set -x \
     js-yaml \
     && rm /tmp/* -rfv
 
-# Avoid error: Local gulp not found in /projects
-ENV NODE_PATH="/usr/local/share/.config/yarn/global/node_modules"
 VOLUME /projects
 WORKDIR /projects
 USER 1001
@@ -124,5 +123,4 @@ RUN set -x \
     && jq --version \
     && pip3 freeze \
     && vale -v \
-    && yarnpkg global list \
     && yq --version

--- a/antora.yml
+++ b/antora.yml
@@ -95,7 +95,7 @@ asciidoc:
     prod-stable-channel-package: eclipse-che
     prod-stable-channel: stable
     prod-stable-channel-starting-csv: eclipse-che.v7.49.0
-    prod-upstream: Eclipse{nbsp}Che
+    prod-upstream: Eclipse&#160Che
     prod-url: "https://__&lt;che_fqdn&gt;__"
     prod-ver-major: "7"
     prod-ver-patch: "7.50.0"

--- a/tools/build-and-verify-container.sh
+++ b/tools/build-and-verify-container.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+#
+# Copyright (c) 2022 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Fail on errors
+set -e
+
+CHE_DOCS_IMAGE=che-docs-devel
+export CHE_DOCS_IMAGE
+
+# Detect available runner
+if [ -z ${RUNNER+x} ]; then
+  if command -v podman >/dev/null; then
+    RUNNER=podman
+  elif command -v docker >/dev/null; then
+    RUNNER=docker
+  else
+    echo "No installation of podman or docker found in the PATH"
+    exit 1
+  fi
+fi
+
+# Display commands
+set -x
+
+$RUNNER build -t "${CHE_DOCS_IMAGE}" .
+
+# --volume:
+# The z option tells Podman that two containers share the volume content.
+# --user="root": workaround for docker running in the GitHub workflow
+
+${RUNNER} run --rm -ti \
+  --entrypoint="./tools/build.sh" \
+  --name che-docs-devel \
+  --user="root" \
+  --volume="$PWD:/projects:z" \
+  --workdir="/projects" \
+  -p 4000:4000 -p 35729:35729 \
+  "${CHE_DOCS_IMAGE}"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+#
+# Copyright (c) 2022 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Fail on errors
+set -ex
+id
+ls -ltr
+umask 002
+./tools/checluster_docs_gen.sh
+./tools/environment_docs_gen.sh
+./tools/create_architecture_diagrams.py
+CI=true antora generate antora-playbook-for-development.yml --stacktrace --log-failure-level=warn
+htmltest
+./tools/detect-unused-content.sh
+./tools/validate_language_changes.sh
+./tools/antora-to-plain-asciidoc.sh

--- a/tools/create_architecture_diagrams.py
+++ b/tools/create_architecture_diagrams.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 #
 # Copyright (c) 2021 Red Hat, Inc.
 # This program and the accompanying materials are made
@@ -24,7 +24,7 @@ import os
 def ArchitectureDiagrams(prod_short, project_context, orch_name):
     script_path = os.path.dirname(os.path.realpath(__file__))
     file_path = script_path + \
-        '/../modules/administration-guide/images/architecture/' + project_context + '-'
+                '/../modules/administration-guide/images/architecture/' + project_context + '-'
     prod_icon = script_path + '/' + project_context + '-icon.png'
     graph_attr = {
         "bgcolor": "white",
@@ -32,20 +32,6 @@ def ArchitectureDiagrams(prod_short, project_context, orch_name):
         "overlap": "false",
         # "splines": "curved"
     }
-
-    filename = file_path + 'architecture-with-che-server-engine'
-    with Diagram(filename=filename,
-                 show=False,
-                 direction="TB",
-                 outformat="png",
-                 edge_attr={"constraint": "false"},
-                 graph_attr=graph_attr):
-        devfile = Git('Devfile v1')
-        dashboard = Custom('User dashboard', prod_icon)
-        che_host = Custom(prod_short + ' server', prod_icon)
-        with Cluster(orch_name + ' API'):
-            workspace = Compute('User workspace')
-        devfile >> dashboard >> che_host >> workspace
 
     filename = file_path + 'interacting-with-devworkspace'
     with Diagram(filename=filename,
@@ -179,7 +165,7 @@ def ArchitectureDiagrams(prod_short, project_context, orch_name):
 ArchitectureDiagrams(project_context='che',
                      prod_short='Che',
                      orch_name='Kubernetes')
-
-ArchitectureDiagrams(project_context='crw',
-                     prod_short='CodeReady Workspaces',
-                     orch_name='OpenShift')
+#
+# ArchitectureDiagrams(project_context='devspaces',
+#                      prod_short='Dev Spaces',
+#                      orch_name='OpenShift')


### PR DESCRIPTION
* Update: Antora 3.1
* Update: Vale 2.20.2, use vale DNF package
* Add Antora extensions: Assembler, Collector, PDF
* Use `npm` rather than `yarn`, that appears to be removed from `ubi8/nodejs16`
* Add a script to build locally
* Add a GitHub workflow to test container creation on pull request
* Fix build errors and warnings
* Don't update to `ubi9`: it doesn't have the `graphviz` package
* Don't update to a fedora based image: it would have more packages, but other issues appear
