### PR TITLE
VS Code is the new default IDE, Theia is deprecated

### DIFF
--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -2,7 +2,7 @@
 | `che-incubator/che-code/insiders`
 | This is the default IDE that loads in a new workspace when the URL parameter or `che-editor.yaml` is not used.
 
-| link:https://www.jetbrains.com/help/idea/discover-intellij-idea.html[IntelliJ IDEA]
+| link:https://www.jetbrains.com/help/idea/discover-intellij-idea.html[JetBrains IntelliJ IDEA Community Edition]
 | `che-incubator/che-idea/latest`
 | Community Edition - stable version
 

--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -14,7 +14,7 @@
 | `che-incubator/che-pycharm/latest`
 | Community Edition - stable version
 
-| link:https://www.jetbrains.com/help/pycharm/quick-start-guide.html[PyCharm]
+| link:https://www.jetbrains.com/help/pycharm/quick-start-guide.html[JetBrains PyCharm Community Edition]
 | `che-incubator/che-pycharm/next`
 | Community Edition - development version
 

--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -18,10 +18,10 @@
 | `che-incubator/che-pycharm/next`
 | Development version
 
-| link:https://github.com/eclipse-che/che-theia[Che-Theia]
+| link:https://github.com/eclipse-che/che-theia[Eclipse Theia]
 | `eclipse/che-theia/latest`
 | Stable version. Deprecated, will be removed in next releases.
 
-| link:https://github.com/eclipse-che/che-theia[Che-Theia]
+| link:https://github.com/eclipse-che/che-theia[Eclipse Theia]
 | `eclipse/che-theia/next`
 | Development version. Deprecated, will be removed in next releases.

--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -1,14 +1,6 @@
-| link:https://github.com/eclipse-che/che-theia[Che-Theia]
-| `eclipse/che-theia/latest`
-| This is the default IDE that loads in a new workspace when the URL parameter or `che-editor.yaml` is not used.
-
-| link:https://github.com/eclipse-che/che-theia[Che-Theia]
-| `eclipse/che-theia/next`
-| When using the `next` link:https://github.com/che-incubator/chectl/[chectl] channel, this IDE loads as a default without the URL parameter.
-
 | link:https://github.com/che-incubator/che-code[Visual Studio Code - Open Source]
 | `che-incubator/che-code/insiders`
-| Visual Studio Code Insiders version packaged to run on Kubernetes
+| This is the default IDE that loads in a new workspace when the URL parameter or `che-editor.yaml` is not used.
 
 | link:https://www.jetbrains.com/help/idea/discover-intellij-idea.html[IntelliJ IDEA]
 | `che-incubator/che-idea/latest`
@@ -25,3 +17,11 @@
 | link:https://www.jetbrains.com/help/pycharm/quick-start-guide.html[PyCharm]
 | `che-incubator/che-pycharm/next`
 | Community Edition - development version
+
+| link:https://github.com/eclipse-che/che-theia[Che-Theia]
+| `eclipse/che-theia/latest`
+| Stable version. Deprecated, will be removed in next releases.
+
+| link:https://github.com/eclipse-che/che-theia[Che-Theia]
+| `eclipse/che-theia/next`
+| Development version. Deprecated, will be removed in next releases.

--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -2,26 +2,22 @@
 | `che-incubator/che-code/insiders`
 | This is the default IDE that loads in a new workspace when the URL parameter or `che-editor.yaml` is not used.
 
-| link:https://www.jetbrains.com/help/idea/discover-intellij-idea.html[JetBrains IntelliJ IDEA Community Edition]
-| `che-incubator/che-idea/latest`
-| Community Edition - stable version
+| link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community Edition]
+|
+* `che-incubator/che-idea/latest`
+* `che-incubator/che-idea/next`
+|
+* `latest` is the stable version.
+* `next` is the development version.
 
-| link:https://www.jetbrains.com/help/idea/discover-intellij-idea.html[IntelliJ IDEA]
-| `che-incubator/che-idea/next`
-| Community Edition - development version
-
-| link:https://www.jetbrains.com/help/pycharm/quick-start-guide.html[PyCharm]
-| `che-incubator/che-pycharm/latest`
-| Community Edition - stable version
-
-| link:https://www.jetbrains.com/help/pycharm/quick-start-guide.html[JetBrains PyCharm Community Edition]
-| `che-incubator/che-pycharm/next`
-| Development version
+| link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains PyCharm Community Edition]
+|
+* `che-incubator/che-pycharm/latest`
+* `che-incubator/che-pycharm/next`
+|
+* `latest` is the stable version.
+* `next` is the development version.
 
 | link:https://github.com/eclipse-che/che-theia[Eclipse Theia]
 | `eclipse/che-theia/latest`
-| Stable version. Deprecated, will be removed in next releases.
-
-| link:https://github.com/eclipse-che/che-theia[Eclipse Theia]
-| `eclipse/che-theia/next`
-| Development version. Deprecated, will be removed in next releases.
+| Stable and planned for deprecation and removal in future releases.

--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -1,4 +1,4 @@
-| link:https://github.com/che-incubator/che-code[Visual Studio Code - Open Source]
+| link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code - Open Source]
 | `che-incubator/che-code/insiders`
 | This is the default IDE that loads in a new workspace when the URL parameter or `che-editor.yaml` is not used.
 

--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -16,7 +16,7 @@
 
 | link:https://www.jetbrains.com/help/pycharm/quick-start-guide.html[JetBrains PyCharm Community Edition]
 | `che-incubator/che-pycharm/next`
-| Community Edition - development version
+| Development version
 
 | link:https://github.com/eclipse-che/che-theia[Che-Theia]
 | `eclipse/che-theia/latest`

--- a/modules/end-user-guide/pages/selecting-a-workspace-ide.adoc
+++ b/modules/end-user-guide/pages/selecting-a-workspace-ide.adoc
@@ -7,7 +7,7 @@
 [id="selecting-a-workspace-ide"]
 = Selecting a workspace IDE
 
-The default in-browser IDE in a new workspace is link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code - Open Source]. In addition, link:https://github.com/che-incubator/jetbrains-editor-images[Community Editions of JetBrains IntelliJ IDEA and JetBrains PyCharm] are available as link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] features. link:https://theia-ide.org/docs/[Che-Theia] is deprecated and will be removed in the next release.
+The default in-browser IDE in a new workspace is link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code - Open Source]. In addition, link:https://github.com/che-incubator/jetbrains-editor-images[Community Editions of JetBrains IntelliJ IDEA and JetBrains PyCharm] are available as link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] features. link:https://theia-ide.org/docs/[Eclipse Theia] is deprecated and will be removed in the next release.
 
 You can select another supported in-browser IDE by either method:
 

--- a/modules/end-user-guide/pages/selecting-a-workspace-ide.adoc
+++ b/modules/end-user-guide/pages/selecting-a-workspace-ide.adoc
@@ -7,7 +7,7 @@
 [id="selecting-a-workspace-ide"]
 = Selecting a workspace IDE
 
-The default in-browser IDE in a new workspace is link:https://github.com/che-incubator/che-code[Visual Studio Code]. In addition, link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA and PyCharm] are available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature. link:https://theia-ide.org/docs/[Che Theia] is available as well but is planned to be removed in next releases.
+The default in-browser IDE in a new workspace is link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code - Open Source]. In addition, link:https://github.com/che-incubator/jetbrains-editor-images[Community Editions of JetBrains IntelliJ IDEA and JetBrains PyCharm] are available as link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] features. link:https://theia-ide.org/docs/[Che-Theia] is deprecated and will be removed in the next release.
 
 You can select another supported in-browser IDE by either method:
 

--- a/modules/end-user-guide/pages/selecting-a-workspace-ide.adoc
+++ b/modules/end-user-guide/pages/selecting-a-workspace-ide.adoc
@@ -7,7 +7,7 @@
 [id="selecting-a-workspace-ide"]
 = Selecting a workspace IDE
 
-The default in-browser IDE in a new workspace is link:https://theia-ide.org/docs/[Che Theia]. In addition, link:https://github.com/che-incubator/che-code[Visual Studio Code] is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature for non-restricted environments.
+The default in-browser IDE in a new workspace is link:https://github.com/che-incubator/che-code[Visual Studio Code]. In addition, link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA and PyCharm] are available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature. link:https://theia-ide.org/docs/[Che Theia] is available as well but is planned to be removed in next releases.
 
 You can select another supported in-browser IDE by either method:
 

--- a/modules/end-user-guide/pages/selecting-a-workspace-ide.adoc
+++ b/modules/end-user-guide/pages/selecting-a-workspace-ide.adoc
@@ -7,7 +7,7 @@
 [id="selecting-a-workspace-ide"]
 = Selecting a workspace IDE
 
-The default in-browser IDE in a new workspace is link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code - Open Source]. In addition, link:https://github.com/che-incubator/jetbrains-editor-images[Community Editions of JetBrains IntelliJ IDEA and JetBrains PyCharm] are available as link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] features. link:https://theia-ide.org/docs/[Eclipse Theia] is deprecated and will be removed in the next release.
+The default in-browser IDE in a new workspace is Microsoft Visual Studio Code - Open Source.
 
 You can select another supported in-browser IDE by either method:
 
@@ -16,6 +16,7 @@ You can select another supported in-browser IDE by either method:
 
 .Supported in-browser IDEs 
 
+[cols="1,1a,1a"]
 |===
 | IDE | `id` | Note
 

--- a/modules/end-user-guide/pages/starting-a-new-workspace-with-a-clone-of-a-git-repository.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-with-a-clone-of-a-git-repository.adoc
@@ -25,7 +25,7 @@ TIP: You can also use the *Git Repo URL ** field on the *Create Workspace* page 
 * Optional: You have xref:authenticating-to-a-git-server-from-a-workspace.adoc[authentication to the Git server] configured.
 * Your Git repository maintainer keeps the `devfile.yaml` or `.devfile.yaml` file in the root directory of the Git repository. (For alternative file names and file paths, see xref:optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc[].)
 +
-TIP: You can also start a new workspace by supplying the URL of a Git repository that contains no devfile. Doing so results in a workspace with the Che-Theia IDE and the Universal Developer Image.
+TIP: You can also start a new workspace by supplying the URL of a Git repository that contains no devfile. Doing so results in a workspace with Universal Developer Image and with Microsoft Visual Studio Code - Open Source as the workspace IDE.
 //provide a link to a page about the Universal Developer Image similar to https://developers.redhat.com/products/rhel/ubi for UBI and, if applicable, devfile-less defaults for new workspaces. max-cx
 
 .Procedure

--- a/modules/end-user-guide/pages/url-parameter-for-the-workspace-ide.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-workspace-ide.adoc
@@ -7,7 +7,7 @@
 [id="url-parameter-for-the-workspace-ide"]
 = URL parameter for the workspace IDE
 
-If the URL for starting a new workspace doesn't contain a URL parameter specifying the integrated development environment (IDE), the workspace loads with the default IDE: Che Theia.
+If the URL for starting a new workspace doesn't contain a URL parameter specifying the integrated development environment (IDE), the workspace loads with the default in-browser IDE, which is Microsoft Visual Studio Code - Open Source.
 
 The URL parameter for specifying another supported IDE is `che-editor=__<editor_key>__`:
 
@@ -16,8 +16,11 @@ The URL parameter for specifying another supported IDE is `che-editor=__<editor_
 pass:c,a,q[{prod-url}]#__<git_repository_url>__?che-editor=__<editor_key>__
 ----
 
+NOTE: The workspace IDE might be already set for a remote Git repository in the xref:selecting-an-in-browser-ide-for-all-workspaces-that-clone-the-same-git-repository.adoc[`che-editor.yaml` file of the repository].
+
 .The URL parameter `__<editor_key>__` values for supported IDEs 
 
+[cols="1,1a,1a"]
 |===
 | IDE | `__<editor_key>__` value | Note
 


### PR DESCRIPTION
## What does this pull request change?

Changes related to the fact that VS Code is now the default editor and Che Theia is going to be deprecated.

## What issues does this pull request fix or reference?

https://github.com/eclipse/che/issues/21771

## Specify the version of the product this pull request applies to

Eclipse Che 7.56 and Dev Spaces 3.3 ([corresponding che-operator PR](https://github.com/eclipse-che/che-operator/pull/1551))

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
