### PR TITLE
chore: Address deprecation warnings in GitHub workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10

--- a/.github/workflows/build-and-validate-on-pr.yaml
+++ b/.github/workflows/build-and-validate-on-pr.yaml
@@ -20,7 +20,7 @@ jobs:
     container: "quay.io/eclipse/che-docs:next"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Necessary for git diff in vale step
 
@@ -33,17 +33,16 @@ jobs:
       # See: http://man7.org/linux/man-pages/man1/date.1.html
       - name: Get Date
         id: get-date
-        run: |
-          echo "::set-output name=yearweek::$(/bin/date -u "+%Y%U")"
+        run: echo "YEAR_WEEK=$(/bin/date -u +%Y%U)" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Restore cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache
         with:
           path: .cache
-          key: ${{ steps.get-date.outputs.yearweek }}
+          key: ${{ steps.get-date.outputs.YEAR_WEEK }}
 
       - name: Build using antora # and fail on warning
         id: antora-build
@@ -55,7 +54,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > PR_SHA
 
       - name: Upload artifact doc-content
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: doc-content
           path: |

--- a/.github/workflows/build-and-validate-on-push.yaml
+++ b/.github/workflows/build-and-validate-on-push.yaml
@@ -22,7 +22,7 @@ jobs:
     container: "quay.io/eclipse/che-docs:next"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -35,8 +35,7 @@ jobs:
       # See: http://man7.org/linux/man-pages/man1/date.1.html
       - name: Get Date
         id: get-date
-        run: |
-          echo "::set-output name=yearweek::$(/bin/date -u "+%Y%U")"
+        run: echo "YEAR_WEEK=$(/bin/date -u +%Y%U)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore cache
         uses: actions/cache@v2
@@ -44,7 +43,7 @@ jobs:
           cache-name: cache
         with:
           path: .cache
-          key: ${{ steps.get-date.outputs.yearweek }}
+          key: ${{ steps.get-date.outputs.YEAR_WEEK }}
 
       - name: Build using antora
         id: antora-build

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to quay.io
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/container-on-pull-request.yml
+++ b/.github/workflows/container-on-pull-request.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Necessary for git diff in vale step
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Build and verify the container
         run: tools/build-and-verify-container.sh

--- a/.github/workflows/preview-sticky-comment.yml
+++ b/.github/workflows/preview-sticky-comment.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: create
-        uses: actions-cool/maintain-one-comment@v1.1.0
+        uses: actions-cool/maintain-one-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |

--- a/.github/workflows/publish-netlify.yml
+++ b/.github/workflows/publish-netlify.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Set PR_NUMBER and PR_SHA variables
         id: vars
         run: |
-          echo "::set-output name=pr_number::$(<content/PR_NUMBER)"
-          echo "::set-output name=pr_sha::$(<content/PR_SHA)"
+          echo "pr_number=$(<content/PR_NUMBER)" >> $GITHUB_OUTPUT
+          echo "pr_sha=$(<content/PR_SHA)" >> $GITHUB_OUTPUT
 
       - name: Publish preview netlify
         uses: netlify/actions/cli@master
@@ -47,7 +47,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
       - name: Update status comment
-        uses: actions-cool/maintain-one-comment@v1.1.0
+        uses: actions-cool/maintain-one-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Vale Linter
         uses: errata-ai/vale-action@reviewdog
         with:


### PR DESCRIPTION
Address deprecation warnings in GitHub workflows:


*    Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/cache, actions/cache, actions/checkout
*    The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
*    The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Add a dependabot configuration. See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

See https://issues.redhat.com/browse/RHDEVDOCS-4668