### PR TITLE
feat: Antora assembler

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -26,8 +26,6 @@ TIP: For Antora, a https://docs.antora.org/antora/latest/module-directories/[_mo
 This project is referring to Modular Documentation modules as _content types_.
 To understand the nature of topics, see the link:https://redhat-documentation.github.io/modular-docs/#modular-docs-terms-definitions[Appendix A: Modular Documentation Terms and Definitions].
 
-pass:[<!-- vale RedHat.As = YES -->]
-
 * Use the link:https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow[Git Forking Workflow].
 
 * link:https://www.eclipse.org/che/docs/che-7/hosted-che/[Eclipse Che hosted by Red Hat] is the recommended IDE to edit and build the content.
@@ -48,8 +46,6 @@ pass:[<!-- vale RedHat.As = YES -->]
 == The documentation workflow
 
 .Procedure
-pass:[<!-- vale RedHat.write = NO -->]
-
 . Contributor submits a code pull request in one of the Che repositories with a `status/doc-impact` label.
 
 . The author of the code pull request, or the reviewer ensures the code pull request contains a reference to a documentation pull request for the `main` branch of the `che-docs` repository:
@@ -71,8 +67,6 @@ pass:[<!-- vale RedHat.write = NO -->]
 . link:https://github.com/eclipse/che-docs/blob/main/RELEASE.adoc[Release Eclipse Che documentation].
 
 . https://github.com/eclipse-che/che-docs/blob/publication-builder/README.adoc[Publish Eclipse Che documentation].
-
-pass:[<!-- vale RedHat.write = YES -->]
 
 [id="reviewing-a-documentation-pull-request"]
 == Reviewing a documentation pull request
@@ -146,7 +140,7 @@ See xref:reviewing-a-documentation-pull-request[Reviewing a documentation pull r
 Create a link:https://docs.antora.org/antora/latest/page/[page] and add it to the navigation when:
 
 * It is meaningful to have a navigation entry
-* The content may receive link:https://docs.antora.org/antora/2.3/page/page-id/[cross-references].
+* The content might receive link:https://docs.antora.org/antora/2.3/page/page-id/[cross-references].
 Avoid cross-references to a page link:https://docs.antora.org/antora/2.3/page/page-id/#id-fragment[fragment].
 
 .Procedure
@@ -206,7 +200,7 @@ The page content type can be:
 Create a link:https://docs.antora.org/antora/2.3/page/partials-and-content-snippets/[partial] and add it to an assembly page when:
 
 * The content is a concept, procedure or reference to include in a page.
-* The content may not receive cross-references.
+* The content might not receive cross-references.
 
 .Procedure
 . Copy one of the templates in the `templates/partials` directory to `modules/__<guide_name>__/partials/__<lowercase_title>__.adoc`.

--- a/antora-assembler.yml
+++ b/antora-assembler.yml
@@ -14,5 +14,5 @@ root_level: 1
 component_versions: '*'
 section_merge_strategy: fuse
 build:
-    command: asciidoctor-pdf --attribute toclevels=5 --trace --sourcemap
+    command: asciidoctor-pdf --attribute toclevels=5 --attribute antora-assembler=true --trace --sourcemap
     keep_aggregate_source: true

--- a/antora-playbook-for-development.yml
+++ b/antora-playbook-for-development.yml
@@ -1,48 +1,52 @@
 ---
 # Use this Antora Playbook for development, to build current state in HEAD.
 site:
-  title: Eclipse Che Documentation
-  # Disabling url on purpose to avoid htmltest crawling the live website.
-  # url: https://www.eclipse.org/che/docs
-  start_page: docs:overview:introduction-to-eclipse-che.adoc
-  robots: allow
+    title: Eclipse Che Documentation
+    # Disabling url on purpose to avoid htmltest crawling the live website.
+    # url: https://www.eclipse.org/che/docs
+    start_page: docs:overview:introduction-to-eclipse-che.adoc
+    robots: allow
+
 content:
-  sources:
-    - url: ./
-      branches: HEAD
-      edit_url: "https://github.com/eclipse-che/che-docs/edit/main/{path}"
+    sources:
+        -   url: ./
+            branches: HEAD
+            edit_url: "https://github.com/eclipse-che/che-docs/edit/main/{path}"
+
 antora:
-  extensions:
-    - id: search
-      require: '@antora/lunr-extension'
-      index_latest_only: true
-      snippet_length: 142
-    - id: collector
-      require: '@antora/collector-extension'
-    - id: htmltest
-      require: ./extensions/htmltest.js
-    - id: antora-to-plain-asciidoc
-      require: ./extensions/antora-to-plain-asciidoc.js
+    extensions:
+        -   require: '@antora/lunr-extension' # Search engine, see https://gitlab.com/antora/antora-lunr-extension/
+            index_latest_only: true
+            snippet_length: 142
+        -   require: '@antora/collector-extension' # Single-source content from engineering repositories, see https://gitlab.com/antora/antora-collector-extension
+        -   require: ./extensions/htmltest.js # Test links in HTML, see https://docs.antora.org/antora/latest/extend/extension-tutorial/
+        -   require: '@antora/pdf-extension' # Generate monolithic AsciiDoc files, see  https://gitlab.com/antora/antora-assembler
+
 asciidoc:
-  sourcemap: true
+    sourcemap: true
+
 output:
-  destinations:
-    - provider: fs
-      clean: true
-      path: build/site
-ui:
-  bundle:
-    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
-    snapshot: true
-  supplemental_files: ./supplemental-ui
-  output_dir: docs/_
+    clean: true
+#    destinations:
+#        -   provider: fs
+#            clean: true
+#            path: build/site
+
+ui: # https://docs.antora.org/antora/latest/playbook/configure-ui/
+    bundle:
+        url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
+        snapshot: true
+    supplemental_files: ./supplemental-ui
+    output_dir: docs/_ #
+
 urls:
-  html_extension_style: indexify
-  redirect_facility: static
-  latest_prerelease_version_segment: next
-  latest_version_segment_strategy: replace
-runtime:
-  cache_dir: ./.cache/antora
-  log:
-    failure_level: warn
-    level: info
+    html_extension_style: indexify # For consistency with pages indexed by search engines, see https://docs.antora.org/antora/latest/playbook/urls-html-extension-style/
+    redirect_facility: static # The least convenient, but only available redirect on our hosting platform, see https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/
+    latest_prerelease_version_segment: next # Override the version in the navigation https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/
+    latest_version_segment_strategy: replace # Consequence of static redirect, see https://docs.antora.org/antora/latest/playbook/urls-redirect-facility/
+
+runtime: # https://docs.antora.org/antora/latest/playbook/configure-runtime/
+    cache_dir: ./.cache/antora # Cache in local directory rather than $HOME
+    log:
+        failure_level: warn # Fail on missing attributes
+        level: info # Be more verbose than default warn level

--- a/modules/administration-guide/pages/creating-a-telemetry-plugin.adoc
+++ b/modules/administration-guide/pages/creating-a-telemetry-plugin.adoc
@@ -397,7 +397,7 @@ spec:
       plugins:                           <2>
       - 'http://apache-che.apps-crc.testing/plugin.yaml'
 ----
-<1> The editor Id to set default plug-ins for.
+<1> The editor identification to set the default plug-ins for.
 <2> List of URLs to devfile v2 plug-ins.
 
 

--- a/modules/administration-guide/pages/creating-a-telemetry-plugin.adoc
+++ b/modules/administration-guide/pages/creating-a-telemetry-plugin.adoc
@@ -355,11 +355,8 @@ $ oc apply -f manifest.yaml
 ----
 
 .Verification steps
-
-pass:[<!-- vale RedHat.TermsErrors = NO -->]
-
-After the deployment has started, confirm that `plugin.yaml` is available in the web server:
-
+* After the deployment has started, confirm that `plugin.yaml` is available in the web server:
++
 ----
 $ curl apache-che.apps-crc.testing/plugin.yaml
 ----
@@ -367,7 +364,6 @@ $ curl apache-che.apps-crc.testing/plugin.yaml
 [id="specifying-the-telemetry-plug-in-in-a-devworkspace"]
 == Specifying the telemetry plug-in in a {devworkspace}
 . Add the following to the `components` field of an existing {devworkspace}:
-
 +
 ----
 components:
@@ -376,20 +372,16 @@ components:
     plugin:
       uri: http://apache-che.apps-crc.testing/plugin.yaml
 ----
-+
 
 . Start the {devworkspace} from the {prod-short} dashboard.
 
 
 .Verification steps
-
 . Verify that the `telemetry-plug-in` container is running in the {devworkspace} pod. Here, this is verified by checking the Workspace view within the editor.
-
 +
-image::creating-a-telemetry-plug-in/devworkspace_telemetry_plugin.png[]
+image::creating-a-telemetry-plug-in/devworkspace_telemetry_plugin.png[{devworkspace} telemetry plug-in]
 
 . Edit files within the editor and observe their events in the example telemetry server's logs.
-
 
 == Applying the telemetry plug-in for all {devworkspace}s
 
@@ -405,7 +397,7 @@ spec:
       plugins:                           <2>
       - 'http://apache-che.apps-crc.testing/plugin.yaml'
 ----
-<1> The editorId to set default plug-ins for.
+<1> The editor Id to set default plug-ins for.
 <2> List of URLs to devfile v2 plug-ins.
 
 
@@ -418,5 +410,3 @@ spec:
 . Start a new or existing {devworkspace} from the {prod} dashboard.
 
 . Verify that the telemetry plug-in is working by following the verification steps for xref:specifying-the-telemetry-plug-in-in-a-devworkspace[].
-
-pass:[<!-- vale RedHat.TermsErrors = YES -->]

--- a/modules/administration-guide/pages/defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/pages/defining-the-list-of-images-to-pull.adoc
@@ -11,15 +11,10 @@ The {image-puller-name-short} can pre-pull most images, including scratch images
 
 .Procedure
 
-. Gather a list of relevant container images for prepulling by navigating to the `pass:c,a,q[{prod-url}]/plugin-registry/v3/external_images.txt` URL.
+. Gather a list of relevant container images to pull by navigating to the `pass:c,a,q[{prod-url}]/plugin-registry/v3/external_images.txt` URL.
 
-. Determine images from the list for pre-pulling. For faster workspace startup times, consider pre-pulling workspace related images such as `che-theia`, `che-machine-exec`, `che-theia-endpoint-runtime-binary`, and plug-in sidecar images.
+. Determine images from the list for pre-pulling. For faster workspace startup times, consider pulling workspace related images such as `che-theia`, `che-machine-exec`, `che-theia-endpoint-runtime-binary`, and plug-in sidecar images.
 
 .Additional resources
-
-pass:[<!-- vale CheDocs.Attributes = NO -->]
-
 * xref:installing-image-puller-on-openshift-using-the-web-console.adoc[]
 * xref:installing-image-puller-on-openshift-using-cli.adoc[]
-
-pass:[<!-- vale CheDocs.Attributes = YES -->]

--- a/modules/end-user-guide/examples/snip_che-supported-languages.adoc
+++ b/modules/end-user-guide/examples/snip_che-supported-languages.adoc
@@ -1,6 +1,4 @@
-pass:[<!-- vale RedHat.TermsErrors = NO -->]
-
-Apache Camel K:: Stack with tooling ready to develop Integration projects with Apache Camel K
+Apache Camel K:: Stack ready to develop Integration projects with Apache Camel K
 Apache Camel based on Spring Boot:: Stack with environment ready to develop Integration projects with Apache Camel based on Spring Boot.
 Bash:: Stack with environment ready to develop bash scripts.
 C/C++:: Stack with C/C++ and Clang 8
@@ -8,17 +6,15 @@ ASP.NET Core Web Application:: Stack for developing ASP.NET Core Web Application
 Go:: Stack with Go 1.14
 Java Lombok:: Java Stack with Lombok 1.18.18, OpenJDK 11 and Maven 3.6.0
 Java with Spring Boot and MongoDB:: Java stack with OpenJDK 8, MongoDB and Spring Boot Guestbook demo application
-Java Spring Boot:: Java stack with OpenJDK 11 and Spring Boot Petclinic demo application
-NodeJS Angular Web Application:: Stack for developing NodeJS Angular Web Application
-NodeJS Express Web Application:: Stack with NodeJS 10
-NodeJS MongoDB Web Application:: Stack with NodeJS 10 and MongoDB 3.4
-NodeJS React Web Application:: Stack for developing NodeJS React Web Application
-NodeJS Web Application based on Yarn:: Stack for developing NodeJS Web Application based on Yarn 
+Java Spring Boot:: Java stack with OpenJDK 11 and Spring Boot Pet clinic demo application
+NodeJS Angular Web Application:: Stack for developing Node.js Angular Web Application
+NodeJS Express Web Application:: Stack with Node.js 10
+NodeJS MongoDB Web Application:: Stack with Node.js 10 and MongoDB 3.4
+NodeJS React Web Application:: Stack for developing Node.js React Web Application
+NodeJS Web Application based on Yarn:: Stack for developing Node.js Web Application based on Yarn 
 PHP Symfony:: PHP Stack with Symfony Demo Application https://symfony.com/
 Python Django:: Python Stack with Python 3.8 and Django application
 Python:: Python Stack with Python 3.8
 Quarkus REST API:: Quarkus stack with a default REST endpoint application sample
 Rust:: Rust Stack with Rust 1.57
 Scala:: Scala Stack with OpenJDK 11 and sbt 1.x
-
-pass:[<!-- vale RedHat.TermsErrors = YES -->]

--- a/modules/extensions/partials/proc_installing-openshift-connector-in-che.adoc
+++ b/modules/extensions/partials/proc_installing-openshift-connector-in-che.adoc
@@ -16,9 +16,7 @@ To install and enable OpenShift Connector in a {prod-short} instance, use instru
 
 .Procedure
 
-// "Plugins" in the UI.
-pass:[<!-- vale RedHat.TermsErrors = NO -->]
-
+ifndef::page-module[pass:[<!-- vale RedHat.TermsErrors = NO -->] // Deactivate the `RedHat.TermsErrors` rule to accept "Plugins" in the UI.]
 
 Install OpenShift Connector in {prod-short} by adding it as an extension in the {prod-short} *Plugins* panel.
 

--- a/tools/checluster_docs_gen.sh
+++ b/tools/checluster_docs_gen.sh
@@ -80,9 +80,6 @@ parse_content() {
   parse_section "networking" "Networking, {prod-short} authentication and TLS configuration."
   parse_section "containerRegistry" "Configuration of an alternative registry that stores {prod-short} images."
   parse_section "status" "\`CheCluster\` Custom Resource \`status\` defines the observed state of {prod-short} installation"
-  BUFF="pass:[<!-- vale off -->]
-
-$BUFF"
   echo "$BUFF" >"$OUTPUT_PATH"
   info "Single-sourced $OUTPUT_PATH" >&2
 }

--- a/tools/environment_docs_gen.sh
+++ b/tools/environment_docs_gen.sh
@@ -112,9 +112,6 @@ parse_content() {
     fi
   done <<<"$RAW_CONTENT"
   # BUFF="$BUFF$TABLE_FOOTER"                             # close last table
-  BUFF="pass:[<!-- vale off -->]
-
-$BUFF"
   echo "$BUFF" >"$OUTPUT_PATH" # flush buffer into file
   info "Single-sourced $OUTPUT_PATH" >&2
 }

--- a/tools/validate_language_changes.sh
+++ b/tools/validate_language_changes.sh
@@ -16,11 +16,19 @@ info() {
 # Get fresh vale styles if required
 test -d .vale/styles/RedHat/ || vale sync
 
+case $CI in
+true)
+  # Avoid error on GitHub: fatal: detected dubious ownership in repository at '/__w/che-docs/che-docs'
+  git config --global --add safe.directory $(pwd)
+  ;;
+esac
+
 BRANCH=origin/${GITHUB_BASE_REF:-main}
 
 FILES=$(git diff --name-only --diff-filter=AM "$BRANCH")
 
 info "Validating files changed in comparison to branch $BRANCH:"
 
+set -x
 # shellcheck disable=SC2086 (We want to split on spaces)
 vale ${FILES}


### PR DESCRIPTION
Use Antora Assembler to produce a monolithic AsciiDoc file for each module.

This technique is used to produce the downstream documentation. 

Applying the same technique upstream will help prevent committing incompatible content.

See: https://gitlab.com/antora/antora-assembler/

As a side effect, the Antora Assembler is producing PDF output. We have to be cautious with HTML specific content (use `ifndef`). I fixed legit vale warnings. I removed obsolete statements that were disabling vale, but are not required anymore.  One is left, and I found a workaround to avoid an error during PDF generation. Discussion in Antora community about this workaround, see: https://antora.zulipchat.com/#narrow/stream/282400-users/topic/Assembler.20specific.20attributes/near/308605574

In downstream, we also have different steps that are not reproduced here:
* Define different AsciiDoc attributes in the Antora playbook
* Define different examples in an [Antora Distributed Component Version](https://docs.antora.org/antora/latest/distributed-component-version/)
* Remove some pages from the navigation by using an Antora extension that injects Antora Collector configuration.