### PR TITLE
fix: Theia is deprecated in table of supported editors

### DIFF
--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -20,4 +20,4 @@
 
 | link:https://github.com/eclipse-che/che-theia[Eclipse Theia]
 | `eclipse/che-theia/latest`
-| Stable and planned for deprecation and removal in future releases.
+| *Deprecated and will be removed in a future release.*


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Eclipse Theia is marked as deprecated in the table of supported IDEs.

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-4723

## Specify the version of the product this pull request applies to
`main` and `7.58.x`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
