### PR TITLE
fix: Replace Eclipse Theia in examples

### DIFF
--- a/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
+++ b/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
@@ -28,23 +28,34 @@ reference: https://__<hostname_and_path_to_a_remote_file>__/che-editor.yaml
 inline:
   schemaVersion: 2.1.0
   metadata:
-    name: theia-ide
-  commands:
-    ...
-  events:
-    ...
+    name: IntelliJ IDEA Community Edition
   components:
-    - name: che-machine-exec
+    - name: intellij
       container:
-        image: 'quay.io/eclipse/che-machine-exec:next'
-        command:
-          ...
-        memoryLimit: 128Mi
+        image: 'quay.io/che-incubator/che-idea@sha256:b02663b2aea521bcbcafdbec7eba27b6d804e3885dc54bb7d5c771ed77d4a97f'
+        volumeMounts:
+          - name: projector-user
+            path: /home/projector-user
+        mountSources: true
+        memoryLimit: 2048M
         memoryRequest: 32Mi
-        cpuLimit: 500m
-        cpuRequest: 30m
-      attributes:
-...
+        cpuLimit: 1500m
+        cpuRequest: 100m
+        endpoints:
+          - name: intellij
+            attributes:
+              type: main
+              cookiesAuthEnabled: true
+              urlRewriteSupported: true
+              discoverable: false
+              path: /?backgroundColor=434343&wss
+            targetPort: 8887
+            exposure: public
+            secure: false
+            protocol: https
+      attributes: {}
+    - name: projector-user
+      volume: {}
 ----
 ====
 

--- a/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
+++ b/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
@@ -28,7 +28,7 @@ reference: https://__<hostname_and_path_to_a_remote_file>__/che-editor.yaml
 inline:
   schemaVersion: 2.1.0
   metadata:
-    name: IntelliJ IDEA Community Edition
+    name: JetBrains IntelliJ IDEA Community IDE
   components:
     - name: intellij
       container:

--- a/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
+++ b/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
@@ -32,7 +32,8 @@ inline:
   components:
     - name: intellij
       container:
-        image: 'quay.io/che-incubator/che-idea@sha256:b02663b2aea521bcbcafdbec7eba27b6d804e3885dc54bb7d5c771ed77d4a97f'
+```suggestion
+        image: 'quay.io/che-incubator/che-idea:next'
         volumeMounts:
           - name: projector-user
             path: /home/projector-user

--- a/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
+++ b/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
@@ -32,7 +32,6 @@ inline:
   components:
     - name: intellij
       container:
-```suggestion
         image: 'quay.io/che-incubator/che-idea:next'
         volumeMounts:
           - name: projector-user

--- a/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
+++ b/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
@@ -78,7 +78,7 @@ registryUrl: __<url_of_custom_plug-in_registry>__
 ... # <1>
 override:
   containers:
-    - name: intellij-ide
+    - name: che-idea
       memoryLimit: 1280Mi
       cpuLimit: 1510m
       cpuRequest: 102m

--- a/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
+++ b/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
@@ -78,7 +78,7 @@ registryUrl: __<url_of_custom_plug-in_registry>__
 ... # <1>
 override:
   containers:
-    - name: theia-ide
+    - name: intellij-ide
       memoryLimit: 1280Mi
       cpuLimit: 1510m
       cpuRequest: 102m

--- a/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
+++ b/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
@@ -7,7 +7,7 @@ The simplest way to select an IDE in the `che-editor.yaml` is to specify the `id
 ====
 [source,yaml]
 ----
-id: che-incubator/che-code/insiders
+id: che-incubator/che-idea/latest
 ----
 ====
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR updates the page https://www.eclipse.org/che/docs/stable/end-user-guide/selecting-an-in-browser-ide-for-all-workspaces-that-clone-the-same-git-repository/#parameters-for-che-editor-yaml, where Eclipse Theia is replaced by another editor.

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-4578

## Specify the version of the product this pull request applies to
`main` and `7.56.x`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
