### PR TITLE
feat: support stable release for minikube and kubectl

### DIFF
--- a/modules/administration-guide/pages/installing-che-on-minikube-keycloak-oidc.adoc
+++ b/modules/administration-guide/pages/installing-che-on-minikube-keycloak-oidc.adoc
@@ -14,9 +14,9 @@ WARNING: Single-node {kubernetes} clusters are suited only for testing or develo
 
 .Prerequisites
 
-* Minikube with {kubernetes} `{kube-ver-min}` or later. See link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Installing Minikube].
+* Minikube stable release. See link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Installing Minikube].
 
-* `{orch-cli}`. See {orch-cli-link}.
+* `{orch-cli}` stable release. See link:https://kubernetes.io/docs/tasks/tools/#kubectl[Installing `{orch-cli}`].
 
 * `{prod-cli}`. See xref:installing-the-chectl-management-tool.adoc[].
 

--- a/modules/administration-guide/pages/installing-che-on-minikube.adoc
+++ b/modules/administration-guide/pages/installing-che-on-minikube.adoc
@@ -13,9 +13,9 @@ WARNING: Remember that single-node {kubernetes} clusters are suited only for tes
 
 .Prerequisites
 
-* Minikube with {kubernetes} version `{kube-ver-min}` or higher. See link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Installing Minikube].
+* Minikube stable release. See link:https://kubernetes.io/docs/tasks/tools/install-minikube/[Installing Minikube].
 
-* `{orch-cli}`. See {orch-cli-link}.
+* `{orch-cli}` stable release. See link:https://kubernetes.io/docs/tasks/tools/#kubectl[Installing `{orch-cli}`].
 
 * `{prod-cli}`. See xref:installing-the-chectl-management-tool.adoc[].
 


### PR DESCRIPTION
For clarity, declare stable release in prerequisites for `minikube` and `kubectl`, in the installation on Minikube procedures.