### PR TITLE
chore: (workaround) keep the latest podman container built on Fedora 36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # Container to build and test Eclipse Che documentation
 
 # Require podman to run ccutil
-FROM quay.io/podman/stable:latest
+FROM quay.io/podman/stable:v4.2.1
 
 # Require superuser privileges to install packages
 USER root


### PR DESCRIPTION
chore: keep the latest podman container built on Fedora 36, waiting for Fedora 37 package in https://copr.fedorainfracloud.org/coprs/mczernek/vale/

