### PR TITLE
docs: configuring the Open VSX registry URL

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -39,6 +39,7 @@
 *** xref:enabling-users-to-run-multiple-workspaces-simultaneously.adoc[]
 *** xref:deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc[]
 *** xref:configuring-workspaces-nodeselector.adoc[]
+*** xref:configuring-the-open-vsx-registry-url.adoc[]
 ** xref:caching-images-for-faster-workspace-start.adoc[]
 *** xref:defining-the-list-of-images-to-pull.adoc[]
 *** xref:defining-the-memory-parameters-for-the-image-puller.adoc[]

--- a/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
+++ b/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
@@ -1,0 +1,28 @@
+:_content-type: PROCEDURE
+:description: Open VSX registry URL
+:keywords: administration guide, configuring, openvsx, registry
+:navtitle: Configuring Open VSX registry URL
+:page-aliases:
+
+[id="configuring-the-open-vsx-registry-url"]
+= Configuring the Open VSX registry URL
+
+To search and install extensions, the Visual Studio Code editor is using an embedded Open VSX registry instance.
+You can configure {prod-short} to rather use your Open VSX registry instance.
+
+.Procedure
+* Set the URL of your Open VSX registry instance in the CheClustor Custom Resource `spec.components.pluginRegistry.openVSXURL` field.
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+spec:
+   components:
+# [...]
+     pluginRegistry:
+       openVSXRegistryURL: __<your_open_vsx_registy>__
+# [...]
+----
+
+.Additional resources
+* xref:using-the-cli-to-configure-the-checluster-custom-resource.adoc[]
+* link:https://open-vsx.org/[Open VSX registry]

--- a/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
+++ b/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
@@ -7,7 +7,7 @@
 [id="configuring-the-open-vsx-registry-url"]
 = Configuring the Open VSX registry URL
 
-To search and install extensions, the Visual Studio Code editor is using an embedded Open VSX registry instance.
+To search and install extensions, the Visual Studio Code editor uses an embedded Open VSX registry instance.
 You can configure {prod-short} to rather use your Open VSX registry instance.
 
 .Procedure

--- a/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
+++ b/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
@@ -8,7 +8,7 @@
 = Configuring the Open VSX registry URL
 
 To search and install extensions, the Visual Studio Code editor uses an embedded Open VSX registry instance.
-You can configure {prod-short} to rather use your Open VSX registry instance.
+You can also configure {prod-short} to use another Open VSX registry instance rather than the embedded one.
 
 .Procedure
 * Set the URL of your Open VSX registry instance in the CheCluster Custom Resource `spec.components.pluginRegistry.openVSXURL` field.

--- a/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
+++ b/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
@@ -11,7 +11,7 @@ To search and install extensions, the Visual Studio Code editor is using an embe
 You can configure {prod-short} to rather use your Open VSX registry instance.
 
 .Procedure
-* Set the URL of your Open VSX registry instance in the CheClustor Custom Resource `spec.components.pluginRegistry.openVSXURL` field.
+* Set the URL of your Open VSX registry instance in the CheCluster Custom Resource `spec.components.pluginRegistry.openVSXURL` field.
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----

--- a/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
+++ b/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
@@ -1,7 +1,7 @@
 :_content-type: PROCEDURE
-:description: Open VSX registry URL
+:description: Configuring the Open VSX registry URL for all {prod} workspaces
 :keywords: administration guide, configuring, openvsx, registry
-:navtitle: Configuring Open VSX registry URL
+:navtitle: Open VSX registry URL
 :page-aliases:
 
 [id="configuring-the-open-vsx-registry-url"]


### PR DESCRIPTION
## What does this pull request change?

New page: configuring the Open VSX registry URL

![Screenshot from 2022-11-22 10-12-25](https://user-images.githubusercontent.com/243761/203273529-25c70987-ba26-4575-aff7-6c89f6369e25.png)


## What issues does this pull request fix or reference?

fixes: https://issues.redhat.com/browse/RHDEVDOCS-4594
refs: https://github.com/eclipse/che/issues/20549
refs: https://github.com/eclipse/che/issues/21598

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
