### PR TITLE
docs: update of defining the list of images to pull (rhdevdocs-4580)

### DIFF
--- a/modules/administration-guide/pages/defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/pages/defining-the-list-of-images-to-pull.adoc
@@ -13,7 +13,7 @@ The {image-puller-name-short} can pre-pull most images, including scratch images
 
 . Gather a list of relevant container images to pull by navigating to the `pass:c,a,q[{prod-url}]/plugin-registry/v3/external_images.txt` URL.
 
-. Determine images from the list for pre-pulling. For faster workspace startup times, consider pulling workspace related images such as `universal-developer-image`, che-code`, `che-gateway`, and plug-in sidecar images.
+. Determine images from the list for pre-pulling. For faster workspace startup times, consider pulling workspace related images such as `universal-developer-image`, che-code`, and `che-gateway`.
 
 .Additional resources
 * xref:installing-image-puller-on-openshift-using-the-web-console.adoc[]

--- a/modules/administration-guide/pages/defining-the-list-of-images-to-pull.adoc
+++ b/modules/administration-guide/pages/defining-the-list-of-images-to-pull.adoc
@@ -13,7 +13,7 @@ The {image-puller-name-short} can pre-pull most images, including scratch images
 
 . Gather a list of relevant container images to pull by navigating to the `pass:c,a,q[{prod-url}]/plugin-registry/v3/external_images.txt` URL.
 
-. Determine images from the list for pre-pulling. For faster workspace startup times, consider pulling workspace related images such as `che-theia`, `che-machine-exec`, `che-theia-endpoint-runtime-binary`, and plug-in sidecar images.
+. Determine images from the list for pre-pulling. For faster workspace startup times, consider pulling workspace related images such as `universal-developer-image`, che-code`, `che-gateway`, and plug-in sidecar images.
 
 .Additional resources
 * xref:installing-image-puller-on-openshift-using-the-web-console.adoc[]


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
update of defining the list of images to pull to feature: universal-developer-image, che-code, che-gateway

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-4580

## Specify the version of the product this pull request applies to
3.3

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
