### PR TITLE
docs: updated glossary page with che-code (rhdevdocs-4580)

### DIFF
--- a/modules/glossary/partials/con_glossary.adoc
+++ b/modules/glossary/partials/con_glossary.adoc
@@ -9,23 +9,23 @@
 This section provides an overview of the main terms and expressions used throughout {prod} documentation.
 
 == Naming
-{prod}:: A developer platform for the cloud that provides an in-browser IDE. {prod-short} tools can be extended by adding development services, such as language servers, debug adapters, or editors (IDEs) packaged as containers. 
+{prod}:: A developer platform for the cloud that provides an in-browser editor (IDE). You can extend {prod-short} tools by adding development services, such as language servers, debug adapters, or IDEs packaged as containers.
 
-Che-Theia:: The default editor component of a {prod-short} workspace. It is a {prod-short}-specific customization of the Eclipse Theia editor. Che-Theia can be extended using Che-Theia plug-ins, which are packaged as containers for ease of deployment and use. Che-Theia plug-ins are usually compatible with Visual Studio extensions.
+Che-Code:: The default editor component of a {prod-short} workspace. It is a {prod-short}-specific customization of the Visual Studio Code editor. You can extend Che-Code with link:https://marketplace.visualstudio.com/VSCode[Visual Studio Code extensions].
 
-{prod-short} Workspace:: A container-based development environment managed by {prod}. Every {prod-short} workspace is defined by a devfile. A {prod-short} workspace is composed of an editor, runtime and build containers and other development tools running inside containers.
+{prod-short} Workspace:: A container-based development environment managed by {prod}. Every {prod-short} workspace is defined by a devfile. A {prod-short} workspace consists of an editor, runtime and build containers, and other development tools running inside containers.
 
 == Terminology
 
-`Editor`:: A web application that is used as an editor in a workspace.
+`Editor`:: A web application used as an editor in a workspace.
 
-`Plugin`:: Plug-ins are services that extend {prod-short} workspace capabilities. {prod-short} plug-ins are packaged as containers. plug-ins are extensions of an editor or a service running in the container. For example, the Che-Theia editor is compatible with Visual Studio Code extensions. 
+`Plugin`:: Plugins are services that extend {prod-short} workspace capabilities. {prod-short} plugins are packaged as containers. Plugins are extensions of an editor or a service running in the container.
 //TODO See for a diagram of {prod-short} extensibility architecture. 
-Both {prod-short} plug-ins and editors are distributed through the {prod-short} plug-ins registry. 
+Both {prod-short} plugins and editors are distributed through the {prod-short} plugins registry.
  
-Workspace:: A container-based development environment managed by {prod}. Every  {prod-short} workspace is defined by a devfile. A  {prod-short} workspace can be composed by an editor, some plug-ins and runtime containers. Workspace runtime containers can be defined as simple container images or as {platforms-name} resources. A {prod-short} Workspace can be associated with source code projects hosted on a remote CVS server. A {prod-short} Workspace can contain the definition of one or more commands such as `run`, `build`, or `debug`.
+Workspace:: A container-based development environment managed by {prod}. Every  {prod-short} workspace is defined by a devfile. A  {prod-short} workspace consists of an editor, plugins and runtime containers. Workspace runtime containers can be defined as simple container images or as {platforms-name} resources. A {prod-short} workspace can be associated with source code projects hosted on a remote CVS server. A {prod-short} workspace can contain the definition of one or more commands such as `run`, `build`, or `debug`.
 
-Devfile:: A workspace configuration template. Devfiles are used to create workspaces in the Dashboard. A devfile includes metadata such as scope, tags, components, description, name, and identification. Visual Studio Code API is one of the plug-in APIs that can be used in Theia.
+Devfile:: A workspace configuration template. Use devfiles to create workspaces in the Dashboard. A devfile includes metadata such as scope, tags, components, description, name, and identification.
 
 Factory:: A template that contains the configuration to automate the generation of a new workspace using a factory identifier or a devfile added to the URL of the IDE. Use factories to create replicas of existing workspaces or to automate the provisioning of statically or dynamically defined workspaces.
 

--- a/modules/glossary/partials/con_glossary.adoc
+++ b/modules/glossary/partials/con_glossary.adoc
@@ -9,9 +9,9 @@
 This section provides an overview of the main terms and expressions used throughout {prod} documentation.
 
 == Naming
-{prod}:: A developer platform for the cloud that provides an in-browser editor (IDE). You can extend {prod-short} tools by adding development services, such as language servers, debug adapters, or IDEs packaged as containers.
+{prod}:: A developer platform for the cloud that provides an in-browser editor (IDE). You can enhance {prod-short} tools by adding development services, such as language servers, debug adapters, or IDEs packaged as containers.
 
-Che-Code:: The default editor component of a {prod-short} workspace. It is a {prod-short}-specific customization of the Visual Studio Code editor. You can extend Che-Code with link:https://marketplace.visualstudio.com/VSCode[Visual Studio Code extensions].
+Che-Code:: The default editor component of a {prod-short} workspace. It is a {prod-short}-specific customization of the Visual Studio Code editor. You can enhance Che-Code with link:https://marketplace.visualstudio.com/VSCode[Visual Studio Code extensions].
 
 {prod-short} Workspace:: A container-based development environment managed by {prod}. Every {prod-short} workspace is defined by a devfile. A {prod-short} workspace consists of an editor, runtime and build containers, and other development tools running inside containers.
 

--- a/modules/glossary/partials/con_glossary.adoc
+++ b/modules/glossary/partials/con_glossary.adoc
@@ -11,7 +11,7 @@ This section provides an overview of the main terms and expressions used through
 == Naming
 {prod}:: A developer platform for the cloud that provides an in-browser editor (IDE). You can enhance {prod-short} tools by adding development services, such as language servers, debug adapters, or IDEs packaged as containers.
 
-Che-Code:: The default editor component of a {prod-short} workspace. It is a {prod-short}-specific customization of the Visual Studio Code editor. You can enhance Che-Code with link:https://marketplace.visualstudio.com/VSCode[Visual Studio Code extensions].
+Che-Code:: The default editor component of a {prod-short} workspace. It is a {prod-short}-specific customization of the Visual Studio Code editor. You can enhance Che-Code with link:https://open-vsx.org[Visual Studio Code extensions].
 
 {prod-short} Workspace:: A container-based development environment managed by {prod}. Every {prod-short} workspace is defined by a devfile. A {prod-short} workspace consists of an editor, runtime and build containers, and other development tools running inside containers.
 

--- a/modules/glossary/partials/con_glossary.adoc
+++ b/modules/glossary/partials/con_glossary.adoc
@@ -23,7 +23,7 @@ Che-Code:: The default editor component of a {prod-short} workspace. It is a {pr
 //TODO See for a diagram of {prod-short} extensibility architecture. 
 Both {prod-short} plugins and editors are distributed through the {prod-short} plugins registry.
  
-Workspace:: A container-based development environment managed by {prod}. Every  {prod-short} workspace is defined by a devfile. A  {prod-short} workspace consists of an editor, plugins and runtime containers. Workspace runtime containers can be defined as simple container images or as {platforms-name} resources. A {prod-short} workspace can be associated with source code projects hosted on a remote CVS server. A {prod-short} workspace can contain the definition of one or more commands such as `run`, `build`, or `debug`.
+Workspace:: A container-based development environment managed by {prod}. Every  {prod-short} workspace is defined by a devfile. A  {prod-short} workspace consists of an editor, plugins, and runtime containers. Workspace runtime containers can be defined as simple container images or as {platforms-name} resources. A {prod-short} workspace can be associated with source code projects hosted on a remote CVS server. A {prod-short} workspace can contain the definition of one or more commands such as `run`, `build`, or `debug`.
 
 Devfile:: A workspace configuration template. Use devfiles to create workspaces in the Dashboard. A devfile includes metadata such as scope, tags, components, description, name, and identification.
 

--- a/modules/glossary/partials/con_glossary.adoc
+++ b/modules/glossary/partials/con_glossary.adoc
@@ -11,7 +11,7 @@ This section provides an overview of the main terms and expressions used through
 == Naming
 {prod}:: A developer platform for the cloud that provides an in-browser editor (IDE). You can enhance {prod-short} tools by adding development services, such as language servers, debug adapters, or IDEs packaged as containers.
 
-Che-Code:: The default editor component of a {prod-short} workspace. It is a {prod-short}-specific customization of the Visual Studio Code editor. You can enhance Che-Code with link:https://open-vsx.org[Visual Studio Code extensions].
+Visual Studio Code - Open Source:: The default editor component of a {prod-short} workspace. It is a {prod-short}-specific customization of the Visual Studio Code editor. You can enhance Visual Studio Code - Open Source with link:https://open-vsx.org[Visual Studio Code extensions].
 
 {prod-short} Workspace:: A container-based development environment managed by {prod}. Every {prod-short} workspace is defined by a devfile. A {prod-short} workspace consists of an editor, runtime and build containers, and other development tools running inside containers.
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
updated glossary page with che-code

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-4568

## Specify the version of the product this pull request applies to
3.3

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
