### PR TITLE
docs: manage workspaces with kubectl

### DIFF
--- a/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
+++ b/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
@@ -14,8 +14,6 @@ Because each `DevWorkspace` custom resource on the cluster represents a {prod-sh
 
 Each `DevWorkspace` contains details derived from the devfile of the Git repository cloned for the workspace. For example, a devfile might provide devfile commands and workspace container configurations.
 
-Each `DevWorkspace` custom resource can reference a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which provides details about the IDE for the workspace.
-
 include::partial$proc_listing-workspaces.adoc[leveloffset=+1]
 
 include::partial$proc_creating-workspaces.adoc[leveloffset=+1]

--- a/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
+++ b/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
@@ -14,7 +14,7 @@ Because each `DevWorkspace` custom resource on the cluster represents a {prod-sh
 
 Each `DevWorkspace` contains details derived from the devfile of the Git repository cloned for the workspace. For example, a devfile might provide devfile commands and workspace container configurations.
 
-Each `DevWorkspace` custom resource also references a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which provides details about the IDE for the workspace.
+Each `DevWorkspace` custom resource can reference a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which provides details about the IDE for the workspace.
 
 include::partial$proc_listing-workspaces.adoc[leveloffset=+1]
 

--- a/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
+++ b/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
@@ -7,14 +7,14 @@
 [id="managing-workspaces-with-apis"]
 = Managing workspaces with {orch-name} APIs
 
-On a {platforms-name} cluster, {prod-short} workspaces are represented as `DevWorkspace` custom resources of the same name.
-As a result, if there is a workspace named `my-workspace` in the {prod-short} dashboard, there is a `DevWorkspace` named `my-workspace` in the user's {orch-namespace} on the {orch-name} cluster.
+On the {platforms-name} cluster, {prod-short} workspaces are represented as `DevWorkspace` custom resources of the same name.
+As a result, if there is a workspace named `my-workspace` in the {prod-short} dashboard, there is a corresponding `DevWorkspace` named `my-workspace` in the user's {orch-namespace} on the cluster.
 
-Since `DevWorkspaces` on the cluster represent {prod-short} workspaces, this allows managing {prod-short} workspaces using {orch-name} APIs with clients such as {orch-cli}.
+Because each `DevWorkspace` custom resource on the cluster represents a {prod-short} workspace, you can manage {prod-short} workspaces by using {orch-name} APIs with clients such as the command-line {orch-cli}.
 
-Each `DevWorkspace` contains details derived from the workspace project's devfile, such as workspace container configurations and devfile commands.
+Each `DevWorkspace` contains details derived from the devfile of the Git repository cloned in the workspace. For example, a devfile might provide devfile commands and workspace container configurations.
 
-Each `DevWorkspace` also references a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which contains details about the editor for the workspace.
+Each `DevWorkspace` also references a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which contains details about the editor to be loaded in the workspace.
 
 To manage a workspace with {orch-name} APIs, you must determine the workspace `NAME` and the `NAMESPACE` it is located in.
 

--- a/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
+++ b/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
@@ -7,16 +7,14 @@
 [id="managing-workspaces-with-apis"]
 = Managing workspaces with {orch-name} APIs
 
-On the {platforms-name} cluster, {prod-short} workspaces are represented as `DevWorkspace` custom resources of the same name.
-As a result, if there is a workspace named `my-workspace` in the {prod-short} dashboard, there is a corresponding `DevWorkspace` named `my-workspace` in the user's {orch-namespace} on the cluster.
+On your organization's {orch-name} cluster, {prod-short} workspaces are represented as `DevWorkspace` custom resources of the same name.
+As a result, if there is a workspace named `my-workspace` in the {prod-short} dashboard, there is a corresponding `DevWorkspace` custom resource named `my-workspace` in the user's {orch-namespace} on the cluster.
 
-Because each `DevWorkspace` custom resource on the cluster represents a {prod-short} workspace, you can manage {prod-short} workspaces by using {orch-name} APIs with clients such as the command-line {orch-cli}.
+Because each `DevWorkspace` custom resource on the cluster represents a {prod-short} workspace, you can manage {prod-short} workspaces by using {orch-name} APIs with clients such as the command-line `{orch-cli}`.
 
-Each `DevWorkspace` contains details derived from the devfile of the Git repository cloned in the workspace. For example, a devfile might provide devfile commands and workspace container configurations.
+Each `DevWorkspace` contains details derived from the devfile of the Git repository cloned for the workspace. For example, a devfile might provide devfile commands and workspace container configurations.
 
-Each `DevWorkspace` also references a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which contains details about the editor to be loaded in the workspace.
-
-To manage a workspace with {orch-name} APIs, you must determine the workspace `NAME` and the `NAMESPACE` it is located in.
+Each `DevWorkspace` custom resource also references a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which provides details about the IDE for the workspace.
 
 include::partial$proc_listing-workspaces.adoc[leveloffset=+1]
 

--- a/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
+++ b/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
@@ -12,7 +12,7 @@ As a result, if there is a workspace named `my-workspace` in the {prod-short} da
 
 Because each `DevWorkspace` custom resource on the cluster represents a {prod-short} workspace, you can manage {prod-short} workspaces by using {orch-name} APIs with clients such as the command-line `{orch-cli}`.
 
-Each `DevWorkspace` contains details derived from the devfile of the Git repository cloned for the workspace. For example, a devfile might provide devfile commands and workspace container configurations.
+Each `DevWorkspace` custom resource contains details derived from the devfile of the Git repository cloned for the workspace. For example, a devfile might provide devfile commands and workspace container configurations.
 
 include::partial$proc_listing-workspaces.adoc[leveloffset=+1]
 

--- a/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
+++ b/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
@@ -1,21 +1,26 @@
 :_content-type: ASSEMBLY
-:navtitle: Managing workspaces with OpenShift APIs
-:description: Managing workspaces with OpenShift APIs
+:navtitle: Managing workspaces with {orch-name} APIs
+:description: Managing workspaces with {orch-name} APIs
 :keywords: api, list workspaces, create workspace, restart workspace, stop workspace, start workspace, remove workspace
 // :page-aliases:
 
 [id="managing-workspaces-with-apis"]
-= Managing workspaces with OpenShift APIs
+= Managing workspaces with {orch-name} APIs
 
-...
+On a {platforms-name} cluster, {prod-short} workspaces are represented as `DevWorkspace` custom resources of the same name.
+As a result, if there is a workspace named `my-workspace` in the {prod-short} dashboard, there is a `DevWorkspace` named `my-workspace` in the user's {orch-namespace} on the {orch-name} cluster.
 
-Consider writing this entire page as a reference. (If so, then rename all the files in `/partials/` and in the `include::` statements below from `proc_` to `ref_`.)
+Since `DevWorkspaces` on the cluster represent {prod-short} workspaces, this allows managing {prod-short} workspaces using {orch-name} APIs with clients such as {orch-cli}.
+
+Each `DevWorkspace` contains details derived from the workspace project's devfile, such as workspace container configurations and devfile commands.
+
+Each `DevWorkspace` also references a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which contains details about the editor for the workspace.
+
+To manage a workspace with {orch-name} APIs, you must determine the workspace `NAME` and the `NAMESPACE` it is located in.
 
 include::partial$proc_listing-workspaces.adoc[leveloffset=+1]
 
 include::partial$proc_creating-workspaces.adoc[leveloffset=+1]
-
-include::partial$proc_restarting-workspaces.adoc[leveloffset=+1]
 
 include::partial$proc_stopping-workspaces.adoc[leveloffset=+1]
 

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -2,4 +2,218 @@
 [id="creating-workspaces"]
 = Creating workspaces
 
-Rough technical info to be dumped here by the assigned SME.
+It is recommended to create workspaces using the {prod-short} Dashboard instead of using {orch-name} APIs to directly create the `DevWorkspace` and `DevWorkspaceTemplate` custom resources.
+
+This is because creating workspaces using the {prod-short} Dashboard helps {prod-short} and its components convert the workspace project's devfile to `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
+
+Creating workspaces using the {prod-short} dashboard allows {prod-short} to make the following additions to the newly created `DevWorkspaces`:
+
+* Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
+** persistent storage strategy specified with `devEnvironments.storage`
+** default editor specified with `devEnvironments.defaultEditor`
+** default plugins specified with `devEnvironments.defaultPlugins`
+** container build configuration specified with `devEnvironments.containerBuildConfiguration`
+* Recognition of the `DevWorkspaceOperatorConfig` configuration managed by {prod-short}
+
+.Prerequisites
+
+* An active `{orch-cli}` session with permissions to create `DevWorkspace` and `DevWorkspaceTemplate` resources in your {orch-namespace} on the {orch-name} cluster. See {orch-cli-link}.
+
+.Procedure
+
+. Create a `DevWorkspaceTemplate` for the editor. The example below creates a `DevWorkspaceTemplate` named `che-code` for the Che-Code Visual Studio Code editor.
++
+[subs="+quotes,attributes"]
+----
+$ cat <<EOF | {orch-cli} apply -f - -n __<user_namespace>__
+apiVersion: workspace.devfile.io/v1alpha2
+kind: DevWorkspaceTemplate
+metadata:
+  name: che-code
+spec:
+  commands:
+    - apply:
+        component: vscode-injector
+      id: init-container-command
+  components:
+    - container:
+        command:
+          - /entrypoint-init-container.sh
+        cpuLimit: 500m
+        cpuRequest: 30m
+        image: 'quay.io/che-incubator/che-code:insiders'
+        memoryLimit: 128Mi
+        memoryRequest: 32Mi
+        sourceMapping: /projects
+        volumeMounts:
+          - name: checode
+            path: /checode
+      name: vscode-injector
+    - attributes:
+        app.kubernetes.io/component: vscode-runtime
+        app.kubernetes.io/part-of: vscode.eclipse.org
+        controller.devfile.io/container-contribution: true
+      container:
+        cpuRequest: 30m
+        command:
+          - /checode/entrypoint-volume.sh
+        env:
+          - name: CODE_HOST
+            value: 0.0.0.0
+        memoryRequest: 256Mi
+        sourceMapping: /projects
+        cpuLimit: 500m
+        volumeMounts:
+          - name: checode
+            path: /checode
+        memoryLimit: 1024Mi
+        image: 'quay.io/che-incubator/che-code:insiders' # no-op ignored image
+        endpoints:
+          - attributes:
+              cookiesAuthEnabled: true
+              discoverable: false
+              type: main
+              urlRewriteSupported: true
+            exposure: public
+            name: che-code
+            protocol: https
+            secure: false
+            targetPort: 3100
+          - attributes:
+              discoverable: false
+              urlRewriteSupported: true
+            exposure: public
+            name: code-redirect-1
+            protocol: http
+            targetPort: 13131
+          - attributes:
+              discoverable: false
+              urlRewriteSupported: true
+            exposure: public
+            name: code-redirect-2
+            protocol: http
+            targetPort: 13132
+          - attributes:
+              discoverable: false
+              urlRewriteSupported: true
+            exposure: public
+            name: code-redirect-3
+            protocol: http
+            targetPort: 13133
+      name: vscode-runtime-description
+    - name: checode
+      volume:
+        ephemeral: true
+  events:
+    preStart:
+      - init-container-command
+EOF
+----
+. To prepare the `DevWorkspace` custom resource, copy the contents of a project Devfile. The example used for this procedure is the following Devfile:
++
+[subs="+quotes,attributes"]
+----
+schemaVersion: 2.1.0    
+components:
+  - name: tooling-container
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
+----
+. Use the devfile to create a `DevWorkspace` definition by adding its contents to the `spec.template` field of the `DevWorkspace`. In the following example, `spec.started` is set to `true`, meaning that the workspace will start automatically when the `DevWorkspace` is applied on the {orch-name} cluster.
++
+[subs="+quotes,attributes"]
+----
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-devworkspace
+spec:
+  started: true
+  template:
+    components:
+      - name: tooling-container
+        container:
+          image: quay.io/devfile/universal-developer-image:ubi8-latest
+----
+. Add details about the project using the `spec.template.projects` field.
++
+[subs="+quotes,attributes"]
+----
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-devworkspace
+spec:
+  started: true
+  template:
+    projects:
+      - name: my-project-name
+        git:
+          remotes:
+            origin: __<git_project_URL>__
+    components:
+      - name: tooling-container
+        container:
+          image: quay.io/devfile/universal-developer-image:ubi8-latest
+----
+. Reference the editor using the `DevWorkspaceTemplate` created from step 1 using the `spec.contributions` field.
++
+[subs="+quotes,attributes"]
+----
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-devworkspace
+spec:
+  started: true
+  contributions:
+    - name: editor
+      kubernetes:
+        name: che-code
+  template:
+    projects:
+      - name: my-project-name
+        git:
+          remotes:
+            origin: __<git_project_URL>__
+    components:
+      - name: tooling-container
+        container:
+          image: quay.io/devfile/universal-developer-image:ubi8-latest
+----
+. Apply the `DevWorkspace` from the previous step onto the {orch-name} cluster.
++
+[subs="+quotes,attributes"]
+----
+$ cat <<EOF | {orch-cli} apply -f - -n __<user_namespace>__
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-devworkspace
+spec:
+  started: true
+  contributions:
+    - name: editor
+      kubernetes:
+        name: che-code
+  template:
+    projects:
+      - name: my-project-name
+        git:
+          remotes:
+            origin: __<git_project_URL>__
+    components:
+      - name: tooling-container
+        container:
+          image: quay.io/devfile/universal-developer-image:ubi8-latest
+EOF
+----
+. Confirm that the workspace is starting.
++
+[subs="+quotes,attributes"]
+----
+$ {orch-cli} get devworkspaces __<user_namespace>__
+
+NAMESPACE          NAME                  DEVWORKSPACE ID             PHASE      INFO
+__<user_namespace>__   my-devworkspace       workspacedf64e4a492cd4701   Starting   Waiting for workspace deployment
+----

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -14,7 +14,7 @@ Creating new workspaces through the {prod-short} dashboard provides better user 
 * {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
 * Access to the workspace is secured by default with the `routingClass: che` in the `DevWorkspace` of the workspace.
 * Recognition of the `DevWorkspaceOperatorConfig` configuration is managed by {prod-short}.
-* Recognition of configurations in `spec.devEnvironments`is specified in the `CheCluster` custom resource including:
+* Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
 ** Persistent storage strategy is specified with `devEnvironments.storage`
 ** Default IDE is specified with `devEnvironments.defaultEditor`
 ** Default plugins are specified with `devEnvironments.defaultPlugins`
@@ -24,7 +24,7 @@ Creating new workspaces through the {prod-short} dashboard provides better user 
 
 .Prerequisites
 
-* An active `{orch-cli}` session with permissions to create `DevWorkspace` and `DevWorkspaceTemplate` resources in your {orch-namespace} on the cluster. See {orch-cli-link}.
+* An active `{orch-cli}` session with permissions to create `DevWorkspace` resources in your {orch-namespace} on the cluster. See {orch-cli-link}.
 
 * You know the relevant {prod-short} user namespace on the cluster.
 +
@@ -32,102 +32,9 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 
 * You are on the {prod-short} user namespace on the cluster.
 +
-NOTE: {prod-short} administrators who intend to create workspaces for other users must create the `DevWorkspace` and `DevWorkspaceTemplate` custom resources in a user namespace that is provisioned by {prod-short} or by the administrator. See xref:administration-guide:configuring-namespace-provisioning.adoc[].
+NOTE: {prod-short} administrators who intend to create workspaces for other users must create the `DevWorkspace` custom resource in a user namespace that is provisioned by {prod-short} or by the administrator. See xref:administration-guide:configuring-namespace-provisioning.adoc[].
 
 .Procedure
-
-. Create a `DevWorkspaceTemplate` custom resource for the selected IDE. The `DevWorkspaceTemplate` is based on the IDE's devfile.
-+
-.Creating a `DevWorkspaceTemplate` named `che-code` for the link:https://github.com/microsoft/vscode[Microsoft Visual Studio Code - Open Source] IDE
-====
-[source,yaml,subs="+quotes,+attributes"]
-----
-apiVersion: workspace.devfile.io/v1alpha2
-kind: DevWorkspaceTemplate
-metadata:
-  name: che-code#<1>
-  namespace: user1-dev#<2>
-spec:#<3>
-  commands:
-    - apply:
-        component: vscode-injector
-      id: init-container-command
-  components:
-    - container:
-        command:
-          - /entrypoint-init-container.sh
-        cpuLimit: 500m
-        cpuRequest: 30m
-        image: 'quay.io/che-incubator/che-code:insiders'
-        memoryLimit: 128Mi
-        memoryRequest: 32Mi
-        sourceMapping: /projects
-        volumeMounts:
-          - name: checode
-      name: vscode-injector
-    - attributes:
-        app.kubernetes.io/component: vscode-runtime
-        app.kubernetes.io/part-of: vscode.eclipse.org
-        controller.devfile.io/container-contribution: true
-      container:
-        cpuRequest: 30m
-        command:
-          - /checode/entrypoint-volume.sh
-        env:
-          - name: CODE_HOST
-            value: 0.0.0.0
-        memoryRequest: 256Mi
-        sourceMapping: /projects
-        cpuLimit: 500m
-        volumeMounts:
-          - name: checode
-            path: /checode
-        memoryLimit: 1024Mi
-        image: 'quay.io/che-incubator/che-code:insiders'
-        endpoints:
-          - attributes:
-              cookiesAuthEnabled: true
-              discoverable: false
-              type: main
-              urlRewriteSupported: true
-            exposure: public
-            name: che-code
-            protocol: https
-            secure: false
-            targetPort: 3100
-          - attributes:
-              discoverable: false
-              urlRewriteSupported: true
-            exposure: public
-            name: code-redirect-1
-            protocol: http
-            targetPort: 13131
-          - attributes:
-              discoverable: false
-              urlRewriteSupported: true
-            exposure: public
-            name: code-redirect-2
-            protocol: http
-            targetPort: 13132
-          - attributes:
-              discoverable: false
-              urlRewriteSupported: true
-            exposure: public
-            name: code-redirect-3
-            protocol: http
-            targetPort: 13133
-      name: vscode-runtime-description
-    - name: checode
-      volume:
-        ephemeral: true
-  events:
-    preStart:
-      - init-container-command
-----
-<1> Name of the `DevWorkspaceTemplate` custom resource. This name will be used to reference the `DevWorkspaceTemplate` custom resource within the `DevWorkspace` custom resource.
-<2> User namespace, which is the target {orch-namespace} for the new workspace.
-<3> The `spec` is derived from the `che-code` editor devfile located in `pass:c,a,q[{prod-url}]/plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml`
-====
 
 . To prepare the `DevWorkspace` custom resource, copy the contents of the target Git repository's devfile.
 +
@@ -148,7 +55,7 @@ TIP: For more details, see the link:https://devfile.io/docs/2.2.0/what-is-a-devf
 +
 .A `DevWorkspace` custom resource
 ====
-[source,yaml,subs="+quotes,+attributes"]
+[source,yaml,subs="+quotes,+attributes,+macros"]
 ----
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
@@ -160,15 +67,14 @@ spec:
   started: true#<3>
   contributions:#<4>
     - name: ide
-      kubernetes:
-        name: che-code#<5>
+      uri: pass:c,a,q[{prod-url}]/plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
   template:
-    projects:#<6>
+    projects:#<5>
       - name: my-project-name
         git:
           remotes:
             origin: https://github.com/eclipse-che/che-docs
-    components:#<7>
+    components:#<6>
       - name: tooling-container
         container:
           image: quay.io/devfile/universal-developer-image:ubi8-latest
@@ -176,27 +82,9 @@ spec:
 <1> Name of the `DevWorkspace` custom resource. This will be the name of the new workspace.
 <2> User namespace, which is the target {orch-namespace} for the new workspace.
 <3> Determines whether the workspace must be started when the `DevWorkspace` custom resource is created.
-<4> Reference to the `DevWorkspaceTemplate` custom resource of the selected IDE.
-<5> Name of the `DevWorkspaceTemplate` custom resource from the previous step.
-<6> Details about the Git repository to clone into the workspace when it starts.
-<7> List of components such as workspace containers and volume components.
-====
-+
-[TIP]
-====
-Multiple `DevWorkspace` resources can reference the same `DevWorkspaceTemplate` resource.
-====
-+
-[TIP]
-====
-Instead of creating a `DevWorkspaceTemplate` and referencing it in the `spec.contributions` field of the `DevWorkspace`, you can reference the IDE devfile in the `DevWorkspace` using a URL.
-[source,subs="+quotes,+attributes,+macros"]
-----
-  contributions:
-    - name: ide
-      uri: pass:c,a,q[{prod-url}]/plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
-----
-Referencing the IDE using the `pass:c,a,q[{prod-url}]/*` URL automatically updates the IDE when {prod} is updated to a newer version.
+<4> URL reference to the link:https://github.com/microsoft/vscode[Microsoft Visual Studio Code - Open Source] IDE devfile from the plugin registry.
+<5> Details about the Git repository to clone into the workspace when it starts.
+<6> List of components such as workspace containers and volume components.
 ====
 
 . Apply the `DevWorkspace` custom resource to the cluster.

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -9,7 +9,9 @@ If your use case does not permit use of the {prod-short} dashboard, you can crea
 
 Creating new workspaces through the {prod-short} dashboard provides better user experience and configuration benefits compared to using the command line:
 
-* The developer is automatically logged into the {orch-name} cluster
+* As a user, you are automatically logged in to the {orch-name} cluster.
+* {platforms-name} clients work automatically.
+* {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
 * Secures workspace access by default, using the `routingClass: che` in the workspace's `DevWorkspace`
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
 ** Persistent storage strategy specified with `devEnvironments.storage`

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -2,11 +2,13 @@
 [id="creating-workspaces"]
 = Creating workspaces
 
-It is recommended to create workspaces using the {prod-short} Dashboard instead of using {orch-name} APIs to directly create the `DevWorkspace` and `DevWorkspaceTemplate` custom resources.
+Since workspaces on the {orch-name} cluster are represented by custom resources, it is possible to create workspaces with {orch-name} APIs by applying custom resources to the cluster.
+
+It is recommended however, for users to create workspaces using the {prod-short} Dashboard instead of using {orch-name} APIs to manually create `DevWorkspace` and `DevWorkspaceTemplate` custom resources.
 
 This is because creating workspaces using the {prod-short} Dashboard helps {prod-short} and its components convert the workspace project's devfile to `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
 
-Creating workspaces using the {prod-short} dashboard allows {prod-short} to make the following additions to the newly created `DevWorkspaces`:
+Creating workspaces using the {prod-short} Dashboard allows {prod-short} to make the following additions to the newly created `DevWorkspaces`:
 
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
 ** persistent storage strategy specified with `devEnvironments.storage`
@@ -19,17 +21,19 @@ Creating workspaces using the {prod-short} dashboard allows {prod-short} to make
 
 * An active `{orch-cli}` session with permissions to create `DevWorkspace` and `DevWorkspaceTemplate` resources in your {orch-namespace} on the {orch-name} cluster. See {orch-cli-link}.
 
+NOTE: For admins creating workspaces for users, the `DevWorkspace` and `DevWorkspaceTemplate` custom resources should be created in a user namespace that is provisioned by {prod-short} or provisioned by the admin. See xref:administration-guide:configuring-namespace-provisioning.adoc[].
+
 .Procedure
 
 . Create a `DevWorkspaceTemplate` for the editor. The example below creates a `DevWorkspaceTemplate` named `che-code` for the Che-Code Visual Studio Code editor.
 +
-[subs="+quotes,attributes"]
+[source,yaml,subs="+quotes,+attributes"]
 ----
-$ cat <<EOF | {orch-cli} apply -f - -n __<user_namespace>__
 apiVersion: workspace.devfile.io/v1alpha2
 kind: DevWorkspaceTemplate
 metadata:
-  name: che-code
+  name: che-code <1>
+  namespace: __<user_{orch-namespace}>__ <2>
 spec:
   commands:
     - apply:
@@ -47,7 +51,6 @@ spec:
         sourceMapping: /projects
         volumeMounts:
           - name: checode
-            path: /checode
       name: vscode-injector
     - attributes:
         app.kubernetes.io/component: vscode-runtime
@@ -107,11 +110,12 @@ spec:
   events:
     preStart:
       - init-container-command
-EOF
 ----
+<1> Name of the `DevWorkspaceTemplate`. This name will be used to reference the `DevWorkspaceTemplate` within the `DevWorkspace`.
+<2> Target {orch-namespace} for the new workspace.
 . To prepare the `DevWorkspace` custom resource, copy the contents of a project Devfile. The example used for this procedure is the following Devfile:
 +
-[subs="+quotes,attributes"]
+[source,yaml,subs="+quotes,+attributes"]
 ----
 schemaVersion: 2.1.0    
 components:
@@ -119,101 +123,56 @@ components:
     container:
       image: quay.io/devfile/universal-developer-image:ubi8-latest
 ----
-. Use the devfile to create a `DevWorkspace` definition by adding its contents to the `spec.template` field of the `DevWorkspace`. In the following example, `spec.started` is set to `true`, meaning that the workspace will start automatically when the `DevWorkspace` is applied on the {orch-name} cluster.
 +
-[subs="+quotes,attributes"]
-----
-kind: DevWorkspace
-apiVersion: workspace.devfile.io/v1alpha2
-metadata:
-  name: my-devworkspace
-spec:
-  started: true
-  template:
-    components:
-      - name: tooling-container
-        container:
-          image: quay.io/devfile/universal-developer-image:ubi8-latest
-----
-. Add details about the project using the `spec.template.projects` field.
-+
-[subs="+quotes,attributes"]
-----
-kind: DevWorkspace
-apiVersion: workspace.devfile.io/v1alpha2
-metadata:
-  name: my-devworkspace
-spec:
-  started: true
-  template:
-    projects:
-      - name: my-project-name
-        git:
-          remotes:
-            origin: __<git_project_URL>__
-    components:
-      - name: tooling-container
-        container:
-          image: quay.io/devfile/universal-developer-image:ubi8-latest
-----
-. Reference the editor using the `DevWorkspaceTemplate` created from step 1 using the `spec.contributions` field.
-+
-[subs="+quotes,attributes"]
-----
-kind: DevWorkspace
-apiVersion: workspace.devfile.io/v1alpha2
-metadata:
-  name: my-devworkspace
-spec:
-  started: true
-  contributions:
-    - name: editor
-      kubernetes:
-        name: che-code
-  template:
-    projects:
-      - name: my-project-name
-        git:
-          remotes:
-            origin: __<git_project_URL>__
-    components:
-      - name: tooling-container
-        container:
-          image: quay.io/devfile/universal-developer-image:ubi8-latest
-----
-. Apply the `DevWorkspace` from the previous step onto the {orch-name} cluster.
-+
-[subs="+quotes,attributes"]
-----
-$ cat <<EOF | {orch-cli} apply -f - -n __<user_namespace>__
-kind: DevWorkspace
-apiVersion: workspace.devfile.io/v1alpha2
-metadata:
-  name: my-devworkspace
-spec:
-  started: true
-  contributions:
-    - name: editor
-      kubernetes:
-        name: che-code
-  template:
-    projects:
-      - name: my-project-name
-        git:
-          remotes:
-            origin: __<git_project_URL>__
-    components:
-      - name: tooling-container
-        container:
-          image: quay.io/devfile/universal-developer-image:ubi8-latest
-EOF
-----
-. Confirm that the workspace is starting.
-+
-[subs="+quotes,attributes"]
-----
-$ {orch-cli} get devworkspaces __<user_namespace>__
+For more details about Devfiles, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[Devfile v2 documentation].
 
-NAMESPACE          NAME                  DEVWORKSPACE ID             PHASE      INFO
-__<user_namespace>__   my-devworkspace       workspacedf64e4a492cd4701   Starting   Waiting for workspace deployment
+. Use the Devfile to create a `DevWorkspace` definition.
++
+[source,yaml,subs="+quotes,+attributes"]
+----
+kind: DevWorkspace
+apiVersion: workspace.devfile.io/v1alpha2
+metadata:
+  name: my-devworkspace <1>
+  namespace: __<user_{orch-namespace}>__ <2>
+spec:
+  started: true <3>
+  contributions: <4>
+    - name: editor
+      kubernetes:
+        name: che-code <5>
+  template:
+    projects: <6>
+      - name: my-project-name
+        git:
+          remotes:
+            origin: https://github.com/eclipse-che/che-docs
+    components: <7>
+      - name: tooling-container
+        container:
+          image: quay.io/devfile/universal-developer-image:ubi8-latest
+----
+<1> Name of `DevWorkspace` resource. This is will be the name of the new workspace.
+<2> Target {orch-namespace} for the new workspace.
+<3> Determines whether the workspace should be started upon creating the `DevWorkspace` resource.
+<4> Reference to the editor's `DevWorkspaceTemplate`.
+<5> Name of the editor's `DevWorkspaceTemplate` from the previous step.
+<6> Details about the Git project to clone upon workspace startup. The Git project that will be cloned for this example is https://github.com/eclipse-che/che-docs.
+<7> List of components such as workspace containers and volume components.
+. Apply the `DevWorkspace` to the cluster. 
+. Confirm that the workspace is starting by referring to the `PHASE` status of the `DevWorkspace`.
++
+[subs="+quotes,attributes"]
+----
+$ {orch-cli} get devworkspaces -n __<user_{orch-namespace}>__  --watch
+
+NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE      INFO
+__<user_{orch-namespace}>__   my-devworkspace       workspacedf64e4a492cd4701   Starting   Waiting for workspace deployment
+----
+. Once the workspace starts, the workspace can be opened by accessing the URL provided in the `INFO` section of the output from `{orch-cli} get devworkspaces`, or by accessing the workspace from the {prod-short} Dashboard.
++
+[subs="+quotes,attributes"]
+----
+NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE      INFO
+__<user_{orch-namespace}>__   my-devworkspace       workspacedf64e4a492cd4701   Running    https://url-to-workspace.com
 ----

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -28,19 +28,6 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 
 * You are on the {prod-short} user namespace on the cluster.
 +
-[TIP]
-====
-On OpenShift:
-
-* You can use the `oc` command-line tool to check your current namespace:
-+
-`$ oc project`
-
-* You can switch to your {prod-short} user namespace on a command line if needed:
-+
-`$ oc project __<user_namespace>__`
-====
-+
 NOTE: {prod-short} administrators who intend to create workspaces for other users must create the `DevWorkspace` and `DevWorkspaceTemplate` custom resources in a user namespace that is provisioned by {prod-short} or by the administrator. See xref:administration-guide:configuring-namespace-provisioning.adoc[].
 
 .Procedure

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -118,5 +118,5 @@ user1-dev            my-devworkspace       workspacedf64e4a492cd4701   Running  
 +
 You can then open the workspace by using one of these options:
 +
-** Visit the URL provided in the `INFO` section of the output of the `{orch-cli} get devworkspaces` command.
+** Visit the URL provided in the *INFO* section of the output of the `{orch-cli} get devworkspaces` command.
 ** Open the workspace from the {prod-short} dashboard.

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -173,7 +173,7 @@ spec:
         container:
           image: quay.io/devfile/universal-developer-image:ubi8-latest
 ----
-<1> Name of the `DevWorkspace` custom resource. This is will be the name of the new workspace.
+<1> Name of the `DevWorkspace` custom resource. This will be the name of the new workspace.
 <2> User namespace, which is the target {orch-namespace} for the new workspace.
 <3> Determines whether the workspace must be started when the `DevWorkspace` custom resource is created.
 <4> Reference to the `DevWorkspaceTemplate` custom resource of the selected IDE.

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -32,6 +32,11 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 
 * You are in the {prod-short} user namespace on the cluster.
 +
+[TIP]
+====
+On OpenShift, you can use the command-line `oc` tool to link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[display your current namespace or switch to a namespace].
+====
++
 NOTE: {prod-short} administrators who intend to create workspaces for other users must create the `DevWorkspace` custom resource in a user namespace that is provisioned by {prod-short} or by the administrator. See xref:administration-guide:configuring-namespace-provisioning.adoc[].
 
 .Procedure

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -7,7 +7,7 @@ If your use case does not permit use of the {prod-short} dashboard, you can crea
 [NOTE]
 ====
 
-Using the {prod-short} dashboard is the default way to create workspaces because {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster with the following configuration benefits:
+Creating new workspaces through the {prod-short} dashboard provides better user experience and configuration benefits compared to using the command line:
 
 * The developer is automatically logged into the {orch-name} cluster
 * Secures workspace access by default, using the `routingClass: che` in the workspace's `DevWorkspace`

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -155,7 +155,7 @@ metadata:
 spec:
   started: true#<3>
   contributions:#<4>
-    - name: IDE
+    - name: ide
       kubernetes:
         name: che-code#<5>
   template:

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -10,13 +10,13 @@ If your use case does not permit use of the {prod-short} dashboard, you can crea
 Using the {prod-short} dashboard is the default way to create workspaces because {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster with the following configuration benefits:
 
 * The developer is automatically logged into the {orch-name} cluster
+* Secures workspace access by default, using the `routingClass: che` in the workspace's `DevWorkspace`.
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
 ** Persistent storage strategy specified with `devEnvironments.storage`
 ** Default IDE specified with `devEnvironments.defaultEditor`
 ** Default plugins specified with `devEnvironments.defaultPlugins`
 ** Container build configuration specified with `devEnvironments.containerBuildConfiguration`
 * Recognition of the `DevWorkspaceOperatorConfig` configuration managed by {prod-short}
-* Secures workspace access by default, using the `routingClass: che` in the workspace's `DevWorkspace`.
 
 ====
 

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -152,7 +152,7 @@ components:
 +
 TIP: For more details, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[devfile v2 documentation].
 
-. Create a `DevWorkspace` custom resource definition that incorporates the copied devfile contents from the previous step.
+. Create a `DevWorkspace` custom resource definition, pasting the devfile contents from the previous step under the `spec.template` field.
 +
 .A `DevWorkspace` custom resource definition
 ====

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -12,7 +12,7 @@ Creating new workspaces through the {prod-short} dashboard provides better user 
 * As a user, you are automatically logged in to the {orch-name} cluster.
 * {platforms-name} clients work automatically.
 * {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
-* Secures workspace access by default, using the `routingClass: che` in the workspace's `DevWorkspace`
+* Access to the workspace is secured by default with the `routingClass: che` in the `DevWorkspace` of the workspace.
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
 ** Persistent storage strategy specified with `devEnvironments.storage`
 ** Default IDE specified with `devEnvironments.defaultEditor`

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -141,7 +141,7 @@ TIP: For more details, see the link:https://devfile.io/docs/2.1.0/what-is-a-devf
 
 . Create a `DevWorkspace` custom resource, pasting the devfile contents from the previous step under the `spec.template` field.
 +
-.A `DevWorkspace` custom resource definition
+.A `DevWorkspace` custom resource
 ====
 [source,yaml,subs="+quotes,+attributes"]
 ----

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -10,7 +10,7 @@ If your use case does not permit use of the {prod-short} dashboard, you can crea
 Using the {prod-short} dashboard is the default way to create workspaces because {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster with the following configuration benefits:
 
 * The developer is automatically logged into the {orch-name} cluster
-* Secures workspace access by default, using the `routingClass: che` in the workspace's `DevWorkspace`.
+* Secures workspace access by default, using the `routingClass: che` in the workspace's `DevWorkspace`
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
 ** Persistent storage strategy specified with `devEnvironments.storage`
 ** Default IDE specified with `devEnvironments.defaultEditor`

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -13,12 +13,12 @@ Creating new workspaces through the {prod-short} dashboard provides better user 
 * {platforms-name} clients work automatically.
 * {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
 * Access to the workspace is secured by default with the `routingClass: che` in the `DevWorkspace` of the workspace.
-* Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
-** Persistent storage strategy specified with `devEnvironments.storage`
-** Default IDE specified with `devEnvironments.defaultEditor`
-** Default plugins specified with `devEnvironments.defaultPlugins`
-** Container build configuration specified with `devEnvironments.containerBuildConfiguration`
-* Recognition of the `DevWorkspaceOperatorConfig` configuration managed by {prod-short}
+* Recognition of the `DevWorkspaceOperatorConfig` configuration is managed by {prod-short}.
+* Recognition of configurations in `spec.devEnvironments`is specified in the `CheCluster` custom resource including:
+** Persistent storage strategy is specified with `devEnvironments.storage`
+** Default IDE is specified with `devEnvironments.defaultEditor`
+** Default plugins are specified with `devEnvironments.defaultPlugins`
+** Container build configuration is specified with `devEnvironments.containerBuildConfiguration`
 
 ====
 

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -9,7 +9,7 @@ If your use case does not permit use of the {prod-short} dashboard, you can crea
 
 Using the {prod-short} dashboard is the default way to create workspaces because {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster with the following configuration benefits:
 
-* User is already logged into the cluster when accessing the {prod-short} dashboard, allowing workspace resources to be created and accessed in the user's {orch-namespace}
+* The developer is automatically logged into the {orch-name} cluster
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
 ** Persistent storage strategy specified with `devEnvironments.storage`
 ** Default IDE specified with `devEnvironments.defaultEditor`

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -9,7 +9,7 @@ If your use case does not permit use of the {prod-short} dashboard, you can crea
 
 Creating workspaces through the {prod-short} dashboard provides better user experience and configuration benefits compared to using the command line:
 
-* As a user, you are automatically logged in to the {orch-name} cluster.
+* As a user, you are automatically logged in to the cluster.
 * {platforms-name} clients work automatically.
 * {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
 * Access to the workspace is secured by default with the `routingClass: che` in the `DevWorkspace` of the workspace.

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -9,12 +9,14 @@ If your use case does not permit use of the {prod-short} dashboard, you can crea
 
 Using the {prod-short} dashboard is the default way to create workspaces because {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster with the following configuration benefits:
 
+* User is already logged into the cluster when accessing the {prod-short} dashboard, allowing workspace resources to be created and accessed in the user's {orch-namespace}
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
 ** Persistent storage strategy specified with `devEnvironments.storage`
 ** Default IDE specified with `devEnvironments.defaultEditor`
 ** Default plugins specified with `devEnvironments.defaultPlugins`
 ** Container build configuration specified with `devEnvironments.containerBuildConfiguration`
 * Recognition of the `DevWorkspaceOperatorConfig` configuration managed by {prod-short}
+* Secures workspace access by default, using the `routingClass: che` in the workspace's `DevWorkspace`.
 
 ====
 
@@ -176,7 +178,7 @@ spec:
 <7> List of components such as workspace containers and volume components.
 ====
 
-. Apply the `DevWorkspace` custom resource to the cluster. 
+. Apply the `DevWorkspace` custom resource to the cluster.
 
 . Verify that the workspace is starting by checking the *PHASE* status of the `DevWorkspace`.
 +

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -36,7 +36,7 @@ NOTE: {prod-short} administrators who intend to create workspaces for other user
 
 .Procedure
 
-. Create a `DevWorkspaceTemplate` custom resource for the selected IDE.
+. Create a `DevWorkspaceTemplate` custom resource for the selected IDE. The `DevWorkspaceTemplate` is based on the IDE's devfile.
 +
 .Creating a `DevWorkspaceTemplate` named `che-code` for the link:https://github.com/microsoft/vscode[Microsoft Visual Studio Code - Open Source] IDE
 ====
@@ -47,7 +47,7 @@ kind: DevWorkspaceTemplate
 metadata:
   name: che-code#<1>
   namespace: user1-dev#<2>
-spec:
+spec:#<3>
   commands:
     - apply:
         component: vscode-injector
@@ -126,6 +126,7 @@ spec:
 ----
 <1> Name of the `DevWorkspaceTemplate` custom resource. This name will be used to reference the `DevWorkspaceTemplate` custom resource within the `DevWorkspace` custom resource.
 <2> User namespace, which is the target {orch-namespace} for the new workspace.
+<3> The `spec` is derived from the `che-code` editor devfile located in `pass:c,a,q[{prod-url}]/plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml`
 ====
 
 . To prepare the `DevWorkspace` custom resource, copy the contents of the target Git repository's devfile.
@@ -183,12 +184,12 @@ spec:
 +
 [TIP]
 ====
-Instead of creating a `DevWorkspaceTemplate` and referencing it in the `spec.contributions` field of the `DevWorkspace`, if the `DevWorkspaceTemplate` is hosted online, you can reference it using a URL.
+Instead of creating a `DevWorkspaceTemplate` and referencing it in the `spec.contributions` field of the `DevWorkspace`, you can reference the IDE devfile in the `DevWorkspace` using a URL.
 [source,subs="+quotes,+attributes,+macros"]
 ----
   contributions:
     - name: ide
-      uri: __<url_to_devworkspace_template>__
+      uri: pass:c,a,q[{prod-url}]/plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
 ----
 ====
 

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -153,6 +153,7 @@ metadata:
   name: my-devworkspace#<1>
   namespace: user1-dev#<2>
 spec:
+  routingClass: che
   started: true#<3>
   contributions:#<4>
     - name: ide

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -89,6 +89,7 @@ spec:
 
 . Apply the `DevWorkspace` custom resource to the cluster.
 
+.Verification
 . Verify that the workspace is starting by checking the *PHASE* status of the `DevWorkspace`.
 +
 [subs="+quotes,attributes"]

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -206,7 +206,7 @@ user1-dev        my-devworkspace       workspacedf64e4a492cd4701   Starting   Wa
 [subs="+quotes,attributes"]
 ----
 NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE      INFO
-user1-dev	     my-devworkspace       workspacedf64e4a492cd4701   Running    https://url-to-workspace.com
+user1-dev            my-devworkspace       workspacedf64e4a492cd4701   Running    https://url-to-workspace.com
 ----
 ====
 +

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -2,30 +2,50 @@
 [id="creating-workspaces"]
 = Creating workspaces
 
-It is recommended however, for users to create workspaces using the {prod-short} Dashboard instead of using {orch-name} APIs to manually create `DevWorkspace` and `DevWorkspaceTemplate` custom resources.
+Because workspaces on the {orch-name} cluster are represented by custom resources, and if your use case does not permit use of the {prod-short} dashboard, you can instead create workspaces with {orch-name} APIs by applying custom resources to the cluster.
 
-This is because creating workspaces using the {prod-short} Dashboard helps {prod-short} and its components convert the workspace project's devfile to `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
+[NOTE]
+====
 
-Creating workspaces using the {prod-short} dashboard allows {prod-short} to make the following additions to the newly created `DevWorkspaces`:
+Using the {prod-short} dashboard is the default way to create workspaces because {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster with the following configuration benefits:
 
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
-** persistent storage strategy specified with `devEnvironments.storage`
-** default editor specified with `devEnvironments.defaultEditor`
-** default plugins specified with `devEnvironments.defaultPlugins`
-** container build configuration specified with `devEnvironments.containerBuildConfiguration`
+** Persistent storage strategy specified with `devEnvironments.storage`
+** Default IDE specified with `devEnvironments.defaultEditor`
+** Default plugins specified with `devEnvironments.defaultPlugins`
+** Container build configuration specified with `devEnvironments.containerBuildConfiguration`
 * Recognition of the `DevWorkspaceOperatorConfig` configuration managed by {prod-short}
 
-Because workspaces on the {orch-name} cluster are represented by custom resources, you can create workspaces with {orch-name} APIs by applying custom resources to the cluster.
+====
 
 .Prerequisites
 
-* An active `{orch-cli}` session with permissions to create `DevWorkspace` and `DevWorkspaceTemplate` resources in your {orch-namespace} on the {orch-name} cluster. See {orch-cli-link}.
+* An active `{orch-cli}` session with permissions to create `DevWorkspace` and `DevWorkspaceTemplate` resources in your {orch-namespace} on the cluster. See {orch-cli-link}.
 
-NOTE: For admins creating workspaces for users, the `DevWorkspace` and `DevWorkspaceTemplate` custom resources should be created in a user namespace that is provisioned by {prod-short} or provisioned by the admin. See xref:administration-guide:configuring-namespace-provisioning.adoc[].
+* You know the relevant {prod-short} user namespace on the cluster.
++
+TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
+
+* You are on the {prod-short} user namespace on the cluster.
++
+[TIP]
+====
+On OpenShift:
+
+* You can use the `oc` command-line tool to check your current namespace:
++
+`$ oc project`
+
+* You can switch to your {prod-short} user namespace on a command line if needed:
++
+`$ oc project __<user_namespace>__`
+====
++
+NOTE: {prod-short} administrators who intend to create workspaces for other users must create the `DevWorkspace` and `DevWorkspaceTemplate` custom resources in a user namespace that is provisioned by {prod-short} or by the administrator. See xref:administration-guide:configuring-namespace-provisioning.adoc[].
 
 .Procedure
 
-. Create a `DevWorkspaceTemplate` for the editor.
+. Create a `DevWorkspaceTemplate` custom resource for the selected IDE.
 +
 .Creating a `DevWorkspaceTemplate` named `che-code` for the link:https://github.com/microsoft/vscode[Microsoft Visual Studio Code - Open Source] IDE
 ====
@@ -35,7 +55,7 @@ apiVersion: workspace.devfile.io/v1alpha2
 kind: DevWorkspaceTemplate
 metadata:
   name: che-code#<1>
-  namespace: __<user_{orch-namespace}>__#<2>
+  namespace: user1-dev#<2>
 spec:
   commands:
     - apply:
@@ -72,7 +92,7 @@ spec:
           - name: checode
             path: /checode
         memoryLimit: 1024Mi
-        image: 'quay.io/che-incubator/che-code:insiders' # no-op ignored image
+        image: 'quay.io/che-incubator/che-code:insiders'
         endpoints:
           - attributes:
               cookiesAuthEnabled: true
@@ -113,17 +133,16 @@ spec:
     preStart:
       - init-container-command
 ----
-<1> Name of the `DevWorkspaceTemplate`. This name will be used to reference the `DevWorkspaceTemplate` within the `DevWorkspace`.
-<2> Target {orch-namespace} for the new workspace.
+<1> Name of the `DevWorkspaceTemplate` custom resource. This name will be used to reference the `DevWorkspaceTemplate` custom resource within the `DevWorkspace` custom resource.
+<2> User namespace, which is the target {orch-namespace} for the new workspace.
 ====
 
-. To prepare the `DevWorkspace` custom resource, copy the contents of a project Devfile.
+. To prepare the `DevWorkspace` custom resource, copy the contents of the target Git repository's devfile.
 +
-.Copied devfile contents
+.Copied devfile contents with `schemaVersion: 2.1.0`
 ====
 [source,yaml,subs="+quotes,+attributes"]
 ----
-schemaVersion: 2.1.0    
 components:
   - name: tooling-container
     container:
@@ -133,9 +152,9 @@ components:
 +
 TIP: For more details, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[devfile v2 documentation].
 
-. Use the devfile to create a `DevWorkspace` definition.
+. Create a `DevWorkspace` custom resource definition that incorporates the copied devfile contents from the previous step.
 +
-.Example title
+.A `DevWorkspace` custom resource definition
 ====
 [source,yaml,subs="+quotes,+attributes"]
 ----
@@ -143,11 +162,11 @@ kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
   name: my-devworkspace#<1>
-  namespace: __<user_{orch-namespace}>__#<2>
+  namespace: user1-dev#<2>
 spec:
   started: true#<3>
   contributions:#<4>
-    - name: editor
+    - name: IDE
       kubernetes:
         name: che-code#<5>
   template:
@@ -161,18 +180,18 @@ spec:
         container:
           image: quay.io/devfile/universal-developer-image:ubi8-latest
 ----
-<1> Name of `DevWorkspace` resource. This is will be the name of the new workspace.
-<2> Target {orch-namespace} for the new workspace.
-<3> Determines whether the workspace should be started upon creating the `DevWorkspace` resource.
-<4> Reference to the editor's `DevWorkspaceTemplate`.
-<5> Name of the editor's `DevWorkspaceTemplate` from the previous step.
-<6> Details about the Git project to clone upon workspace startup. The Git project that will be cloned for this example is https://github.com/eclipse-che/che-docs.
+<1> Name of the `DevWorkspace` custom resource. This is will be the name of the new workspace.
+<2> User namespace, which is the target {orch-namespace} for the new workspace.
+<3> Determines whether the workspace must be started when the `DevWorkspace` custom resource is created.
+<4> Reference to the `DevWorkspaceTemplate` custom resource of the selected IDE.
+<5> Name of the `DevWorkspaceTemplate` custom resource from the previous step.
+<6> Details about the Git repository to clone into the workspace when it starts.
 <7> List of components such as workspace containers and volume components.
 ====
 
 . Apply the `DevWorkspace` custom resource to the cluster. 
 
-. Verify that the workspace is starting by checking the `PHASE` status of the `DevWorkspace`.
+. Verify that the workspace is starting by checking the *PHASE* status of the `DevWorkspace`.
 +
 [subs="+quotes,attributes"]
 ----
@@ -188,9 +207,7 @@ user1-dev	     my-devworkspace       workspacedf64e4a492cd4701   Starting   Wait
 ----
 ====
 
-. When the workspace starts with the *PHASE* status *Running*, open the workspace by either way:
-** Visit the URL provided in the `INFO` section of the output from `{orch-cli} get devworkspaces`.
-** Open the workspace from the {prod-short} dashboard.
+. When the workspace has successfully started, its *PHASE* status changes to *Running* in the output of the `{orch-cli} get devworkspaces` command.
 +
 .Output
 ====
@@ -200,3 +217,8 @@ NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE    
 user1-dev	     my-devworkspace       workspacedf64e4a492cd4701   Running    https://url-to-workspace.com
 ----
 ====
++
+You can then open the workspace by using one of these options:
++
+** Visit the URL provided in the `INFO` section of the output of the `{orch-cli} get devworkspaces` command.
+** Open the workspace from the {prod-short} dashboard.

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -2,7 +2,7 @@
 [id="creating-workspaces"]
 = Creating workspaces
 
-Because workspaces on the {orch-name} cluster are represented by custom resources, and if your use case does not permit use of the {prod-short} dashboard, you can instead create workspaces with {orch-name} APIs by applying custom resources to the cluster.
+If your use case does not permit use of the {prod-short} dashboard, you can create workspaces with {orch-name} APIs by applying custom resources to the cluster.
 
 [NOTE]
 ====

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -180,6 +180,17 @@ spec:
 <6> Details about the Git repository to clone into the workspace when it starts.
 <7> List of components such as workspace containers and volume components.
 ====
++
+[TIP]
+====
+Instead of creating a `DevWorkspaceTemplate` and referencing it in the `spec.contributions` field of the `DevWorkspace`, if the `DevWorkspaceTemplate` is hosted online, you can reference it using a URL.
+[source,subs="+quotes,+attributes,+macros"]
+----
+  contributions:
+    - name: ide
+      uri: __<url_to_devworkspace_template>__
+----
+====
 
 . Apply the `DevWorkspace` custom resource to the cluster.
 

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -139,7 +139,7 @@ spec:
 
 . To prepare the `DevWorkspace` custom resource, copy the contents of the target Git repository's devfile.
 +
-.Copied devfile contents with `schemaVersion: 2.1.0`
+.Copied devfile contents with `schemaVersion: 2.2.0`
 ====
 [source,yaml,subs="+quotes,+attributes"]
 ----

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -15,10 +15,10 @@ Creating new workspaces through the {prod-short} dashboard provides better user 
 * Access to the workspace is secured by default with the `routingClass: che` in the `DevWorkspace` of the workspace.
 * Recognition of the `DevWorkspaceOperatorConfig` configuration is managed by {prod-short}.
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
-** Persistent storage strategy is specified with `devEnvironments.storage`
-** Default IDE is specified with `devEnvironments.defaultEditor`
-** Default plugins are specified with `devEnvironments.defaultPlugins`
-** Container build configuration is specified with `devEnvironments.containerBuildConfiguration`
+** Persistent storage strategy is specified with `devEnvironments.storage`.
+** Default IDE is specified with `devEnvironments.defaultEditor`.
+** Default plugins are specified with `devEnvironments.defaultPlugins`.
+** Container build configuration is specified with `devEnvironments.containerBuildConfiguration`.
 
 ====
 
@@ -30,7 +30,7 @@ Creating new workspaces through the {prod-short} dashboard provides better user 
 +
 TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
 
-* You are on the {prod-short} user namespace on the cluster.
+* You are in the {prod-short} user namespace on the cluster.
 +
 NOTE: {prod-short} administrators who intend to create workspaces for other users must create the `DevWorkspace` custom resource in a user namespace that is provisioned by {prod-short} or by the administrator. See xref:administration-guide:configuring-namespace-provisioning.adoc[].
 

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -72,7 +72,7 @@ spec:
   started: true#<3>
   contributions:#<4>
     - name: ide
-      uri: pass:c,a,q[{prod-url}]/plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
+      uri: pass:c,a,q[{prod-url}]/plugin-registry/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
   template:
     projects:#<5>
       - name: my-project-name

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -184,6 +184,11 @@ spec:
 +
 [TIP]
 ====
+Multiple `DevWorkspace` resources can reference the same `DevWorkspaceTemplate` resource.
+====
++
+[TIP]
+====
 Instead of creating a `DevWorkspaceTemplate` and referencing it in the `spec.contributions` field of the `DevWorkspace`, you can reference the IDE devfile in the `DevWorkspace` using a URL.
 [source,subs="+quotes,+attributes,+macros"]
 ----
@@ -191,6 +196,7 @@ Instead of creating a `DevWorkspaceTemplate` and referencing it in the `spec.con
     - name: ide
       uri: pass:c,a,q[{prod-url}]/plugin-registry/main/v3/plugins/che-incubator/che-code/insiders/devfile.yaml
 ----
+Referencing the IDE using the `pass:c,a,q[{prod-url}]/*` URL automatically updates the IDE when {prod} is updated to a newer version.
 ====
 
 . Apply the `DevWorkspace` custom resource to the cluster.

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -7,7 +7,7 @@ If your use case does not permit use of the {prod-short} dashboard, you can crea
 [NOTE]
 ====
 
-Creating new workspaces through the {prod-short} dashboard provides better user experience and configuration benefits compared to using the command line:
+Creating workspaces through the {prod-short} dashboard provides better user experience and configuration benefits compared to using the command line:
 
 * As a user, you are automatically logged in to the {orch-name} cluster.
 * {platforms-name} clients work automatically.

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -141,7 +141,7 @@ components:
 ----
 ====
 +
-TIP: For more details, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[devfile v2 documentation].
+TIP: For more details, see the link:https://devfile.io/docs/2.2.0/what-is-a-devfile[devfile v2 documentation].
 
 . Create a `DevWorkspace` custom resource, pasting the devfile contents from the previous step under the `spec.template` field.
 +

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -93,7 +93,7 @@ spec:
 +
 [subs="+quotes,attributes"]
 ----
-$ {orch-cli} get devworkspaces -n __<user_{orch-namespace}>__  --watch
+$ {orch-cli} get devworkspaces -n __<user_{orch-namespace}>__ --watch
 ----
 +
 .Output

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -139,7 +139,7 @@ components:
 +
 TIP: For more details, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[devfile v2 documentation].
 
-. Create a `DevWorkspace` custom resource definition, pasting the devfile contents from the previous step under the `spec.template` field.
+. Create a `DevWorkspace` custom resource, pasting the devfile contents from the previous step under the `spec.template` field.
 +
 .A `DevWorkspace` custom resource definition
 ====

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -2,13 +2,11 @@
 [id="creating-workspaces"]
 = Creating workspaces
 
-Since workspaces on the {orch-name} cluster are represented by custom resources, it is possible to create workspaces with {orch-name} APIs by applying custom resources to the cluster.
-
 It is recommended however, for users to create workspaces using the {prod-short} Dashboard instead of using {orch-name} APIs to manually create `DevWorkspace` and `DevWorkspaceTemplate` custom resources.
 
 This is because creating workspaces using the {prod-short} Dashboard helps {prod-short} and its components convert the workspace project's devfile to `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
 
-Creating workspaces using the {prod-short} Dashboard allows {prod-short} to make the following additions to the newly created `DevWorkspaces`:
+Creating workspaces using the {prod-short} dashboard allows {prod-short} to make the following additions to the newly created `DevWorkspaces`:
 
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
 ** persistent storage strategy specified with `devEnvironments.storage`
@@ -16,6 +14,8 @@ Creating workspaces using the {prod-short} Dashboard allows {prod-short} to make
 ** default plugins specified with `devEnvironments.defaultPlugins`
 ** container build configuration specified with `devEnvironments.containerBuildConfiguration`
 * Recognition of the `DevWorkspaceOperatorConfig` configuration managed by {prod-short}
+
+Because workspaces on the {orch-name} cluster are represented by custom resources, you can create workspaces with {orch-name} APIs by applying custom resources to the cluster.
 
 .Prerequisites
 
@@ -25,15 +25,17 @@ NOTE: For admins creating workspaces for users, the `DevWorkspace` and `DevWorks
 
 .Procedure
 
-. Create a `DevWorkspaceTemplate` for the editor. The example below creates a `DevWorkspaceTemplate` named `che-code` for the Che-Code Visual Studio Code editor.
+. Create a `DevWorkspaceTemplate` for the editor.
 +
+.Creating a `DevWorkspaceTemplate` named `che-code` for the link:https://github.com/microsoft/vscode[Microsoft Visual Studio Code - Open Source] IDE
+====
 [source,yaml,subs="+quotes,+attributes"]
 ----
 apiVersion: workspace.devfile.io/v1alpha2
 kind: DevWorkspaceTemplate
 metadata:
-  name: che-code <1>
-  namespace: __<user_{orch-namespace}>__ <2>
+  name: che-code#<1>
+  namespace: __<user_{orch-namespace}>__#<2>
 spec:
   commands:
     - apply:
@@ -113,8 +115,12 @@ spec:
 ----
 <1> Name of the `DevWorkspaceTemplate`. This name will be used to reference the `DevWorkspaceTemplate` within the `DevWorkspace`.
 <2> Target {orch-namespace} for the new workspace.
-. To prepare the `DevWorkspace` custom resource, copy the contents of a project Devfile. The example used for this procedure is the following Devfile:
+====
+
+. To prepare the `DevWorkspace` custom resource, copy the contents of a project Devfile.
 +
+.Copied devfile contents
+====
 [source,yaml,subs="+quotes,+attributes"]
 ----
 schemaVersion: 2.1.0    
@@ -123,31 +129,34 @@ components:
     container:
       image: quay.io/devfile/universal-developer-image:ubi8-latest
 ----
+====
 +
-For more details about Devfiles, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[Devfile v2 documentation].
+TIP: For more details, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[devfile v2 documentation].
 
-. Use the Devfile to create a `DevWorkspace` definition.
+. Use the devfile to create a `DevWorkspace` definition.
 +
+.Example title
+====
 [source,yaml,subs="+quotes,+attributes"]
 ----
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: my-devworkspace <1>
-  namespace: __<user_{orch-namespace}>__ <2>
+  name: my-devworkspace#<1>
+  namespace: __<user_{orch-namespace}>__#<2>
 spec:
-  started: true <3>
-  contributions: <4>
+  started: true#<3>
+  contributions:#<4>
     - name: editor
       kubernetes:
-        name: che-code <5>
+        name: che-code#<5>
   template:
-    projects: <6>
+    projects:#<6>
       - name: my-project-name
         git:
           remotes:
             origin: https://github.com/eclipse-che/che-docs
-    components: <7>
+    components:#<7>
       - name: tooling-container
         container:
           image: quay.io/devfile/universal-developer-image:ubi8-latest
@@ -159,20 +168,35 @@ spec:
 <5> Name of the editor's `DevWorkspaceTemplate` from the previous step.
 <6> Details about the Git project to clone upon workspace startup. The Git project that will be cloned for this example is https://github.com/eclipse-che/che-docs.
 <7> List of components such as workspace containers and volume components.
-. Apply the `DevWorkspace` to the cluster. 
-. Confirm that the workspace is starting by referring to the `PHASE` status of the `DevWorkspace`.
+====
+
+. Apply the `DevWorkspace` custom resource to the cluster. 
+
+. Verify that the workspace is starting by checking the `PHASE` status of the `DevWorkspace`.
 +
 [subs="+quotes,attributes"]
 ----
 $ {orch-cli} get devworkspaces -n __<user_{orch-namespace}>__  --watch
-
-NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE      INFO
-__<user_{orch-namespace}>__   my-devworkspace       workspacedf64e4a492cd4701   Starting   Waiting for workspace deployment
 ----
-. Once the workspace starts, the workspace can be opened by accessing the URL provided in the `INFO` section of the output from `{orch-cli} get devworkspaces`, or by accessing the workspace from the {prod-short} Dashboard.
 +
+.Output
+====
 [subs="+quotes,attributes"]
 ----
 NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE      INFO
-__<user_{orch-namespace}>__   my-devworkspace       workspacedf64e4a492cd4701   Running    https://url-to-workspace.com
+user1-dev	     my-devworkspace       workspacedf64e4a492cd4701   Starting   Waiting for workspace deployment
 ----
+====
+
+. When the workspace starts with the *PHASE* status *Running*, open the workspace by either way:
+** Visit the URL provided in the `INFO` section of the output from `{orch-cli} get devworkspaces`.
+** Open the workspace from the {prod-short} dashboard.
++
+.Output
+====
+[subs="+quotes,attributes"]
+----
+NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE      INFO
+user1-dev	     my-devworkspace       workspacedf64e4a492cd4701   Running    https://url-to-workspace.com
+----
+====

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -194,8 +194,8 @@ $ {orch-cli} get devworkspaces -n __<user_{orch-namespace}>__  --watch
 ====
 [subs="+quotes,attributes"]
 ----
-NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE      INFO
-user1-dev	     my-devworkspace       workspacedf64e4a492cd4701   Starting   Waiting for workspace deployment
+NAMESPACE        NAME                  DEVWORKSPACE ID             PHASE      INFO
+user1-dev        my-devworkspace       workspacedf64e4a492cd4701   Starting   Waiting for workspace deployment
 ----
 ====
 

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -16,7 +16,7 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 +
 [TIP]
 ====
-On OpenShift, you can use link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[the `oc` command-line tool] to display your current namespace or switch to a namespace.
+On OpenShift, you can use the command-line `oc` tool to link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[display your current namespace or switch to a namespace].
 ====
 
 .Procedure

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -12,7 +12,7 @@ As a user, you can list your workspaces by using the command line.
 +
 TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
 
-* You are on the {prod-short} user namespace on the cluster.
+* You are in the {prod-short} user namespace on the cluster.
 +
 [TIP]
 ====

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -2,28 +2,33 @@
 [id="listing-workspaces"]
 = Listing all workspaces
 
-Run the following command to list all workspaces for all users.
+You can list your workspaces on a command line.
 
+.Procedure
+
+* To list your workspaces, enter the following on a command line:
++
 [source,subs="+attributes"]
 ----
 $ {orch-cli} get devworkspaces
-
+----
++
+.Output
+====
+----
 NAMESPACE   NAME                 DEVWORKSPACE ID             PHASE     INFO
+user1-dev   spring-petclinic     workspace6d99e9ffb9784491   Running   https://url-to-workspace.com
 user1-dev   golang-example       workspacedf64e4a492cd4701   Stopped   Stopped
-user1-dev   php-symfony          workspace5a8f37a0a0d94ea3   Stopped   Stopped
+user1-dev   python-hello-world   workspace69c26884bbc141f2   Failed    Container tooling has state CrashLoopBackOff
 ----
+====
 
-TIP: You can add the `--watch` flag to view updates when the workspace's `PHASE` changes.
+[TIP]
+====
+You can view `PHASE` changes live by adding the `--watch` flag to this command.
+====
 
-Admins can add the `--all-namespaces` flag to list all workspaces from all users.
-
-[source,subs="+attributes"]
-----
-$ {orch-cli} get devworkspaces --all-namespaces
-
-NAMESPACE   NAME                 DEVWORKSPACE ID             PHASE     INFO
-user1-dev   golang-example       workspacedf64e4a492cd4701   Stopped   Stopped
-user1-dev   php-symfony          workspace5a8f37a0a0d94ea3   Stopped   Stopped
-user2-dev   python-hello-world   workspace69c26884bbc141f2   Failed    Container tooling has state CrashLoopBackOff
-user3-dev   spring-petclinic     workspace6d99e9ffb9784491   Running   https://url-to-workspace.com
-----
+[NOTE]
+====
+Users with administrative permissions on the cluster can list all workspaces from all {prod-short} users by including the `--all-namespaces` flag.
+====

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -1,15 +1,29 @@
 
 [id="listing-workspaces"]
-= Listing workspaces
+= Listing all workspaces
 
-Explain why `--all-namespaces`.
+Run the following command to list all workspaces for all users.
 
 [source,subs="+attributes"]
 ----
-$ {orch-cli} get devworkspace --all-namespaces
+$ {orch-cli} get devworkspaces
+
+NAMESPACE   NAME                 DEVWORKSPACE ID             PHASE     INFO
+user1-dev   golang-example       workspacedf64e4a492cd4701   Stopped   Stopped
+user1-dev   php-symfony          workspace5a8f37a0a0d94ea3   Stopped   Stopped
 ----
 
-TIP: You can add the `--watch` flag.
+TIP: You can add the `--watch` flag to view updates when the workspace's `PHASE` changes.
 
-To be confirmed by the assigned SME.
+Admins can add the `--all-namespaces` flag to list all workspaces from all users.
 
+[source,subs="+attributes"]
+----
+$ {orch-cli} get devworkspaces --all-namespaces
+
+NAMESPACE   NAME                 DEVWORKSPACE ID             PHASE     INFO
+user1-dev   golang-example       workspacedf64e4a492cd4701   Stopped   Stopped
+user1-dev   php-symfony          workspace5a8f37a0a0d94ea3   Stopped   Stopped
+user2-dev   python-hello-world   workspace69c26884bbc141f2   Failed    Container tooling has state CrashLoopBackOff
+user3-dev   spring-petclinic     workspace6d99e9ffb9784491   Running   https://url-to-workspace.com
+----

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -2,7 +2,7 @@
 [id="listing-workspaces"]
 = Listing all workspaces
 
-You can list your workspaces by using the command line.
+As a user, you can list your workspaces by using the command line.
 
 .Prerequisites
 

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -16,15 +16,7 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 +
 [TIP]
 ====
-On OpenShift:
-
-* You can use the `oc` command-line tool to check your current namespace:
-+
-`$ oc project`
-
-* You can switch to your {prod-short} user namespace on a command line if needed:
-+
-`$ oc project __<user_namespace>__`
+On OpenShift, you can use link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[the `oc` command-line tool] to display your current namespace or switch to a namespace.
 ====
 
 .Procedure

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -6,7 +6,7 @@ You can list your workspaces by using the command line.
 
 .Prerequisites
 
-* An active `{orch-cli}` session with permissions to `get` and `list` `DevWorkspace` resources in your {orch-namespace} on the cluster. See {orch-cli-link}.
+* An active `{orch-cli}` session with permissions to `get` the `DevWorkspace` resources in your {orch-namespace} on the cluster. See {orch-cli-link}.
 
 * You know the relevant {prod-short} user namespace on the cluster.
 +

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -2,7 +2,7 @@
 [id="listing-workspaces"]
 = Listing all workspaces
 
-You can list your workspaces on a command line.
+You can list your workspaces by using the command line.
 
 .Prerequisites
 

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -4,6 +4,29 @@
 
 You can list your workspaces on a command line.
 
+.Prerequisites
+
+* An active `{orch-cli}` session on the cluster. See {orch-cli-link}.
+
+* You know the relevant {prod-short} user namespace on the cluster.
++
+TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
+
+* You are on the {prod-short} user namespace on the cluster.
++
+[TIP]
+====
+On OpenShift:
+
+* You can use the `oc` command-line tool to check your current namespace:
++
+`$ oc project`
+
+* You can switch to your {prod-short} user namespace on a command line if needed:
++
+`$ oc project __<user_namespace>__`
+====
+
 .Procedure
 
 * To list your workspaces, enter the following on a command line:
@@ -25,7 +48,7 @@ user1-dev   python-hello-world   workspace69c26884bbc141f2   Failed    Container
 
 [TIP]
 ====
-You can view `PHASE` changes live by adding the `--watch` flag to this command.
+You can view *PHASE* changes live by adding the `--watch` flag to this command.
 ====
 
 [NOTE]

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -6,7 +6,7 @@ You can list your workspaces on a command line.
 
 .Prerequisites
 
-* An active `{orch-cli}` session with permissions to `get` and `list` `DevWorkspace` and `DevWorkspaceTemplate` resources in your {orch-namespace} on the cluster. See {orch-cli-link}.
+* An active `{orch-cli}` session with permissions to `get` and `list` `DevWorkspace` resources in your {orch-namespace} on the cluster. See {orch-cli-link}.
 
 * You know the relevant {prod-short} user namespace on the cluster.
 +

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -6,7 +6,7 @@ You can list your workspaces on a command line.
 
 .Prerequisites
 
-* An active `{orch-cli}` session on the cluster. See {orch-cli-link}.
+* An active `{orch-cli}` session with permissions to `get` and `list` `DevWorkspace` and `DevWorkspaceTemplate` resources in your {orch-namespace} on the cluster. See {orch-cli-link}.
 
 * You know the relevant {prod-short} user namespace on the cluster.
 +

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -2,4 +2,11 @@
 [id="removing-workspaces"]
 = Removing workspaces
 
-Rough technical info to be dumped here by the assigned SME.
+Removing a workspace only requires deleting the `DevWorkspace` custom resource.
+
+Deleting the `DevWorkspace` custom resource will also delete other workspace resources if they were created by {prod-short} such as the referenced `DevWorkspaceTemplate` and per-workspace `PersistentVolumeClaims`.
+
+[source,subs="+attributes"]
+----
+$ {orch-cli} delete devworkspace NAME -n NAMESPACE
+----

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -23,7 +23,7 @@ You can find the relevant workspace name in the output of `$ {orch-cli} get devw
 +
 TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
 
-* You are on the {prod-short} user namespace on the cluster.
+* You are in the {prod-short} user namespace on the cluster.
 +
 [TIP]
 ====

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -4,9 +4,14 @@
 
 Removing a workspace only requires deleting the `DevWorkspace` custom resource.
 
-Deleting the `DevWorkspace` custom resource will also delete other workspace resources if they were created by {prod-short} such as the referenced `DevWorkspaceTemplate` and per-workspace `PersistentVolumeClaims`.
+TIP: Remove workspaces by using the {prod-short} dashboard whenever possible.
 
+WARNING: Deleting the `DevWorkspace` custom resource will also delete other workspace resources if they were created by {prod-short} such as the referenced `DevWorkspaceTemplate` and per-workspace `PersistentVolumeClaims`.
+
+.Procedure
+
+* To remove a workspace, run the following command
 [source,subs="+attributes"]
 ----
-$ {orch-cli} delete devworkspace NAME -n NAMESPACE
+$ {orch-cli} delete devworkspace __<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -27,7 +27,7 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 +
 [TIP]
 ====
-On OpenShift, you can use link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[the `oc` command-line tool] to display your current namespace or switch to a namespace.
+On OpenShift, you can use the command-line `oc` tool to link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[display your current namespace or switch to a namespace].
 ====
 
 .Procedure

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -2,16 +2,19 @@
 [id="removing-workspaces"]
 = Removing workspaces
 
-Removing a workspace only requires deleting the `DevWorkspace` custom resource.
+You can remove a workspace by simply deleting the `DevWorkspace` custom resource.
+
+WARNING: Deleting the `DevWorkspace` custom resource will also delete other workspace resources if they were created by {prod-short}: for example, the referenced `DevWorkspaceTemplate` and per-workspace `PersistentVolumeClaims`.
 
 TIP: Remove workspaces by using the {prod-short} dashboard whenever possible.
 
-WARNING: Deleting the `DevWorkspace` custom resource will also delete other workspace resources if they were created by {prod-short} such as the referenced `DevWorkspaceTemplate` and per-workspace `PersistentVolumeClaims`.
-
 .Procedure
 
-* To remove a workspace, run the following command
-[source,subs="+attributes"]
+. Get the `__<workspace_name>__` of the workspace to remove and the `__<user_namespace>__`.
+
+* Run the following command to remove the workspace:
++
+[subs="+quotes,attributes"]
 ----
 $ {orch-cli} delete devworkspace __<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -29,15 +29,7 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 +
 [TIP]
 ====
-On OpenShift:
-
-* You can use the `oc` command-line tool to check your current namespace:
-+
-`$ oc project`
-
-* You can switch to your {prod-short} user namespace on a command line if needed:
-+
-`$ oc project __<user_namespace>__`
+On OpenShift, you can use link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[the `oc` command-line tool] to display your current namespace or switch to a namespace.
 ====
 
 .Procedure

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -16,9 +16,7 @@ TIP: Remove workspaces by using the {prod-short} dashboard whenever possible.
 +
 [TIP]
 ====
-You can find the relevant workspace name in the output of the following command:
-
-`$ {orch-cli} get devworkspaces`
+You can find the relevant workspace name in the output of `$ {orch-cli} get devworkspaces`.
 ====
 
 * You know the relevant {prod-short} user namespace on the cluster.

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -8,9 +8,39 @@ WARNING: Deleting the `DevWorkspace` custom resource will also delete other work
 
 TIP: Remove workspaces by using the {prod-short} dashboard whenever possible.
 
-.Procedure
+.Prerequisites
 
-. Get the `__<workspace_name>__` of the workspace to remove and the `__<user_namespace>__`.
+* An active `{orch-cli}` session on the cluster. See {orch-cli-link}.
+
+* You know the workspace name.
++
+[TIP]
+====
+You can find the relevant workspace name in the output of the following command:
+
+`$ {orch-cli} get devworkspaces`
+====
+
+* You know the relevant {prod-short} user namespace on the cluster.
++
+TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
+
+* You are on the {prod-short} user namespace on the cluster.
++
+[TIP]
+====
+On OpenShift:
+
+* You can use the `oc` command-line tool to check your current namespace:
++
+`$ oc project`
+
+* You can switch to your {prod-short} user namespace on a command line if needed:
++
+`$ oc project __<user_namespace>__`
+====
+
+.Procedure
 
 * Run the following command to remove the workspace:
 +

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -32,7 +32,7 @@ On OpenShift, you can use the command-line `oc` tool to link:https://docs.opensh
 
 .Procedure
 
-* Run the following command to remove the workspace:
+* Run the following command to remove a workspace:
 +
 [subs="+quotes,attributes"]
 ----

--- a/modules/end-user-guide/partials/proc_restarting-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_restarting-workspaces.adoc
@@ -1,5 +1,0 @@
-
-[id="restarting-workspaces"]
-= Restarting workspaces
-
-Rough technical info to be dumped here by the assigned SME.

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -2,4 +2,14 @@
 [id="starting-stopped-workspaces"]
 = Starting stopped workspaces
 
-Rough technical info to be dumped here by the assigned SME.
+A stopped workspace can be started by setting the `Devworkspace` 's `spec.started` field to `true`.
+
+To use the `wait` command to wait for the status change, a minimum version of `1.23` for `kubectl`, or a minimum version of `4.10` for `oc` is required.
+
+After determining the `NAME` and `NAMESPACE` of the workspace to start, run:
+
+[source,subs="+attributes"]
+----
+$ {orch-cli} patch devworkspace NAME -p '{"spec":{"started":true}}' --type=merge -n NAMESPACE && \
+        {orch-cli} wait --for=jsonpath='{.status.phase}'=Running dw/NAME -n NAMESPACE
+----

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -2,15 +2,45 @@
 [id="starting-stopped-workspaces"]
 = Starting stopped workspaces
 
-You can start a stopped workspace by setting the `spec.started` field in the `Devworkspace` to `true`.
+You can start a stopped workspace by setting the `spec.started` field in the `Devworkspace` custom resource to `true`.
+
+.Prerequisites
+
+* An active `{orch-cli}` session on the cluster. See {orch-cli-link}.
+
+* You know the workspace name.
++
+[TIP]
+====
+You can find the relevant workspace name in the output of the following command:
+
+`$ {orch-cli} get devworkspaces`
+====
+
+* You know the relevant {prod-short} user namespace on the cluster.
++
+TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
+
+* You are on the {prod-short} user namespace on the cluster.
++
+[TIP]
+====
+On OpenShift:
+
+* You can use the `oc` command-line tool to check your current namespace:
++
+`$ oc project`
+
+* You can switch to your {prod-short} user namespace on a command line if needed:
++
+`$ oc project __<user_namespace>__`
+====
 
 .Procedure
 
-. Get the `__<workspace_name>__` of the stopped workspace and the `__<user_namespace>__`.
-
-. Run the following command to start the stopped workspace:
+* Run the following command to start the stopped workspace:
 +
-[source,subs="+attributes"]
+[subs="+quotes,attributes"]
 ----
 $ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":true}}' --type=merge -n __<user_namespace>__ && \
         {orch-cli} wait --for=jsonpath='{.status.phase}'=Running dw/__<workspace_name>__ -n __<user_namespace>__

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -28,7 +28,7 @@ On OpenShift, you can use the command-line `oc` tool to link:https://docs.opensh
 
 .Procedure
 
-* Run the following command to start the stopped workspace:
+* Run the following command to start a stopped workspace:
 +
 [subs="+quotes,attributes"]
 ----

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -32,6 +32,9 @@ On OpenShift, you can use link:https://docs.openshift.com/container-platform/lat
 +
 [subs="+quotes,attributes"]
 ----
-$ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":true}}' --type=merge -n __<user_namespace>__ && \
-        {orch-cli} wait --for=jsonpath='{.status.phase}'=Running dw/__<workspace_name>__ -n __<user_namespace>__
+$ {orch-cli} patch devworkspace __<workspace_name>__ \
+-p '{"spec":{"started":true}}' \
+--type=merge -n __<user_namespace>__ && \
+{orch-cli} wait --for=jsonpath='{.status.phase}'=Running \
+dw/__<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -12,9 +12,7 @@ You can start a stopped workspace by setting the `spec.started` field in the `De
 +
 [TIP]
 ====
-You can find the relevant workspace name in the output of the following command:
-
-`$ {orch-cli} get devworkspaces`
+You can find the relevant workspace name in the output of `$ {orch-cli} get devworkspaces`.
 ====
 
 * You know the relevant {prod-short} user namespace on the cluster.

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -19,7 +19,7 @@ You can find the relevant workspace name in the output of `$ {orch-cli} get devw
 +
 TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
 
-* You are on the {prod-short} user namespace on the cluster.
+* You are in the {prod-short} user namespace on the cluster.
 +
 [TIP]
 ====

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -23,7 +23,7 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 +
 [TIP]
 ====
-On OpenShift, you can use link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[the `oc` command-line tool] to display your current namespace or switch to a namespace.
+On OpenShift, you can use the command-line `oc` tool to link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[display your current namespace or switch to a namespace].
 ====
 
 .Procedure

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -25,15 +25,7 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 +
 [TIP]
 ====
-On OpenShift:
-
-* You can use the `oc` command-line tool to check your current namespace:
-+
-`$ oc project`
-
-* You can switch to your {prod-short} user namespace on a command line if needed:
-+
-`$ oc project __<user_namespace>__`
+On OpenShift, you can use link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[the `oc` command-line tool] to display your current namespace or switch to a namespace.
 ====
 
 .Procedure

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -2,14 +2,16 @@
 [id="starting-stopped-workspaces"]
 = Starting stopped workspaces
 
-A stopped workspace can be started by setting the `Devworkspace` 's `spec.started` field to `true`.
+You can start a stopped workspace by setting the `spec.started` field in the `Devworkspace` to `true`.
 
-To use the `wait` command to wait for the status change, a minimum version of `1.23` for `kubectl`, or a minimum version of `4.10` for `oc` is required.
+.Procedure
 
-After determining the `NAME` and `NAMESPACE` of the workspace to start, run:
+. Get the `__<workspace_name>__` of the stopped workspace and the `__<user_namespace>__`.
 
+. Run the following command to start the stopped workspace:
++
 [source,subs="+attributes"]
 ----
-$ {orch-cli} patch devworkspace NAME -p '{"spec":{"started":true}}' --type=merge -n NAMESPACE && \
-        {orch-cli} wait --for=jsonpath='{.status.phase}'=Running dw/NAME -n NAMESPACE
+$ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":true}}' --type=merge -n __<user_namespace>__ && \
+        {orch-cli} wait --for=jsonpath='{.status.phase}'=Running dw/__<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -2,4 +2,14 @@
 [id="stopping-workspaces"]
 = Stopping workspaces
 
-Rough technical info to be dumped here by the assigned SME.
+A workspace can be stopped by setting the `Devworkspace` 's `spec.started` field to `false`.
+
+To use the `wait` command to wait for the status change, a minimum version of `1.23` for `kubectl`, or a minimum version of `4.10` for `oc` is required.
+
+After determining the `NAME` and `NAMESPACE` of the workspace to stop, run:
+
+[source,subs="+attributes"]
+----
+$ {orch-cli} patch devworkspace NAME -p '{"spec":{"started":false}}' --type=merge -n NAMESPACE && \
+        {orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped dw/NAME -n NAMESPACE
+----

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -25,15 +25,6 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 +
 [TIP]
 ====
-On OpenShift:
-
-* You can use the `oc` command-line tool to check your current namespace:
-+
-`$ oc project`
-
-* You can switch to your {prod-short} user namespace on a command line if needed:
-+
-`$ oc project __<user_namespace>__`
 ====
 
 .Procedure

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -32,6 +32,9 @@ On OpenShift, you can use link:https://docs.openshift.com/container-platform/lat
 +
 [subs="+quotes,attributes"]
 ----
-$ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":false}}' --type=merge -n __<user_namespace>__ && \
-{orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped dw/__<workspace_name>__ -n __<user_namespace>__
+$ {orch-cli} patch devworkspace __<workspace_name>__ \
+-p '{"spec":{"started":false}}' \
+--type=merge -n __<user_namespace>__ && \
+{orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped \
+dw/__<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -35,5 +35,5 @@ On OpenShift, you can use link:https://docs.openshift.com/container-platform/lat
 [subs="+quotes,attributes"]
 ----
 $ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":false}}' --type=merge -n __<user_namespace>__ && \
-        {orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped dw/__<workspace_name>__ -n __<user_namespace>__
+{orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped dw/__<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -2,14 +2,16 @@
 [id="stopping-workspaces"]
 = Stopping workspaces
 
-A workspace can be stopped by setting the `Devworkspace` 's `spec.started` field to `false`.
+You can stop a workspace by setting the `spec.started` field in the `Devworkspace` to `false`.
 
-To use the `wait` command to wait for the status change, a minimum version of `1.23` for `kubectl`, or a minimum version of `4.10` for `oc` is required.
+.Procedure
 
-After determining the `NAME` and `NAMESPACE` of the workspace to stop, run:
+. Get the `__<workspace_name>__` of the workspace to stop and the `__<user_namespace>__`.
 
+. Run the following command to stop that workspace:
++
 [source,subs="+attributes"]
 ----
-$ {orch-cli} patch devworkspace NAME -p '{"spec":{"started":false}}' --type=merge -n NAMESPACE && \
-        {orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped dw/NAME -n NAMESPACE
+$ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":false}}' --type=merge -n __<user_namespace>__ && \
+        {orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped dw/__<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -12,9 +12,7 @@ You can stop a workspace by setting the `spec.started` field in the `Devworkspac
 +
 [TIP]
 ====
-You can find the relevant workspace name in the output of the following command:
-
-`$ {orch-cli} get devworkspaces`
+You can find the relevant workspace name in the output of `$ {orch-cli} get devworkspaces`.
 ====
 
 * You know the relevant {prod-short} user namespace on the cluster.

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -28,7 +28,7 @@ On OpenShift, you can use the command-line `oc` tool to link:https://docs.opensh
 
 .Procedure
 
-* Run the following command to stop that workspace:
+* Run the following command to stop a workspace:
 +
 [subs="+quotes,attributes"]
 ----

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -2,15 +2,45 @@
 [id="stopping-workspaces"]
 = Stopping workspaces
 
-You can stop a workspace by setting the `spec.started` field in the `Devworkspace` to `false`.
+You can stop a workspace by setting the `spec.started` field in the `Devworkspace` custom resource to `false`.
+
+.Prerequisites
+
+* An active `{orch-cli}` session on the cluster. See {orch-cli-link}.
+
+* You know the workspace name.
++
+[TIP]
+====
+You can find the relevant workspace name in the output of the following command:
+
+`$ {orch-cli} get devworkspaces`
+====
+
+* You know the relevant {prod-short} user namespace on the cluster.
++
+TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
+
+* You are on the {prod-short} user namespace on the cluster.
++
+[TIP]
+====
+On OpenShift:
+
+* You can use the `oc` command-line tool to check your current namespace:
++
+`$ oc project`
+
+* You can switch to your {prod-short} user namespace on a command line if needed:
++
+`$ oc project __<user_namespace>__`
+====
 
 .Procedure
 
-. Get the `__<workspace_name>__` of the workspace to stop and the `__<user_namespace>__`.
-
-. Run the following command to stop that workspace:
+* Run the following command to stop that workspace:
 +
-[source,subs="+attributes"]
+[subs="+quotes,attributes"]
 ----
 $ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":false}}' --type=merge -n __<user_namespace>__ && \
         {orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped dw/__<workspace_name>__ -n __<user_namespace>__

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -19,7 +19,7 @@ You can find the relevant workspace name in the output of `$ {orch-cli} get devw
 +
 TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
 
-* You are on the {prod-short} user namespace on the cluster.
+* You are in the {prod-short} user namespace on the cluster.
 +
 [TIP]
 ====

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -23,7 +23,7 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 +
 [TIP]
 ====
-On OpenShift, you can use link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[the `oc` command-line tool] to display your current namespace or switch to a namespace.
+On OpenShift, you can use the command-line `oc` tool to link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[display your current namespace or switch to a namespace].
 ====
 
 .Procedure

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -25,6 +25,7 @@ TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your
 +
 [TIP]
 ====
+On OpenShift, you can use link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/developer-cli-commands.html#oc-project[the `oc` command-line tool] to display your current namespace or switch to a namespace.
 ====
 
 .Procedure


### PR DESCRIPTION
Signed-off-by: dkwon17 <dakwon@redhat.com>

Adds the steps for:
* `Listing all workspaces`
* `Creating workspaces`
* `Stopping workspaces`
* `Starting stopped workspaces`
* `Removing workspaces`

The `Restarting workpsaces` section was removed, as it can be done by following the `Stopping workspaces` and then the `Starting stopped workspaces` sections

<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

## What issues does this pull request fix or reference?
https://github.com/eclipse/che/issues/21808

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
