### PR TITLE
chore: use latest Podman container again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # Container to build and test Eclipse Che documentation
 
 # Require podman to run ccutil
-FROM quay.io/podman/stable:v4.2.1
+FROM quay.io/podman/stable:latest
 
 # Require superuser privileges to install packages
 USER root


### PR DESCRIPTION
## What does this pull request change?

Now there is a Vale package for Fedora 37, use latest Podman container again

## What issues does this pull request fix or reference?

fixes: https://issues.redhat.com/browse/RHDEVDOCS-4746

refs: https://github.com/eclipse-che/che-docs/pull/2497

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
