### PR TITLE
docs: Remove Che-Theia from Selecting a workspace IDE

### DIFF
--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -3,21 +3,13 @@
 | This is the default IDE that loads in a new workspace when the URL parameter or `che-editor.yaml` is not used.
 
 | link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community Edition]
-|
-* `che-incubator/che-idea/latest`
+| * `che-incubator/che-idea/latest`
 * `che-incubator/che-idea/next`
-|
-* `latest` is the stable version.
+| * `latest` is the stable version.
 * `next` is the development version.
 
 | link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains PyCharm Community Edition]
-|
-* `che-incubator/che-pycharm/latest`
+| * `che-incubator/che-pycharm/latest`
 * `che-incubator/che-pycharm/next`
-|
-* `latest` is the stable version.
+| * `latest` is the stable version.
 * `next` is the development version.
-
-| link:https://github.com/eclipse-che/che-theia[Eclipse Theia]
-| `eclipse/che-theia/latest`
-| Stable and planned for deprecation and removal in future releases.


### PR DESCRIPTION




## What does this pull request change?

docs: Remove Che-Theia from Selecting a workspace IDE

## What issues does this pull request fix or reference?

fixes https://issues.redhat.com/browse/RHDEVDOCS-4577

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
