### PR TITLE
fix: attributes usage in generated docs

### DIFF
--- a/tools/checluster_docs_gen.sh
+++ b/tools/checluster_docs_gen.sh
@@ -111,6 +111,7 @@ parse_section() {
     DESCR_BUFF="${DESCR_BUFF//\"/}"
     DESCR_BUFF="${DESCR_BUFF//:/\\:}"
     DESCR_BUFF="$(sed 's|Eclipse Che|{prod-short}|g' <<<$DESCR_BUFF)"
+    DESCR_BUFF="$(sed 's|Che |{prod-short} |g' <<<$DESCR_BUFF)"
     BUFF="$BUFF${PROP}: ${DESCR_BUFF}$NEWLINE"
   done
   BUFF="$BUFF$TABLE_FOOTER"


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

Use the `{prod-short}` attribute in single-sourced content.

## What issues does this pull request fix or reference?

fixes https://issues.redhat.com/browse/RHDEVDOCS-4814

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
