### PR TITLE
docs: VS Code as default editor in Introduction to Eclipse Che (rhdevdocs-4580)

### DIFF
--- a/modules/overview/pages/introduction-to-eclipse-che.adoc
+++ b/modules/overview/pages/introduction-to-eclipse-che.adoc
@@ -11,7 +11,7 @@
 * A multi-container workspace for each developer with the ability to replicate with a single click using {prod} factories.
 * Pre-built stacks with the ability to create custom stacks for any language or runtime.
 * An enterprise integration using OpenShift OAuth or Dex.
-* Browser-based IDEs; integration with link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code - Open Source IDE] and other web IDEs such as link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community IDE].
+* Browser-based IDEs; integration with link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code] and others such as link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community Edition].
 * Support of tools protocols, such as the Language Server Protocol or Debug Adapter Protocol.
 * A plugin mechanism compatible with Visual Studio Code extensions.
 * A software development kit (SDK) for creating custom cloud developer platforms.

--- a/modules/overview/pages/introduction-to-eclipse-che.adoc
+++ b/modules/overview/pages/introduction-to-eclipse-che.adoc
@@ -11,7 +11,7 @@
 * A multi-container workspace for each developer with the ability to replicate with a single click using {prod} factories.
 * Pre-built stacks with the ability to create custom stacks for any language or runtime.
 * An enterprise integration using OpenShift OAuth or Dex.
-* Browser-based IDEs; integration with Che-Theia or any other web IDE, such as Jupyter.
+* Browser-based IDEs; integration with link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code - Open Source IDE] and other web IDEs such as link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community IDE].
 * Support of tools protocols, such as the Language Server Protocol or Debug Adapter Protocol.
 * A plugin mechanism compatible with Visual Studio Code extensions.
 * A software development kit (SDK) for creating custom cloud developer platforms.

--- a/modules/overview/pages/introduction-to-eclipse-che.adoc
+++ b/modules/overview/pages/introduction-to-eclipse-che.adoc
@@ -16,6 +16,7 @@
 * A plugin mechanism compatible with Visual Studio Code extensions.
 * A software development kit (SDK) for creating custom cloud developer platforms.
 
+
 [id="getting-started-with-{prod-id-short}"]
 == Getting started with {prod-short}
 

--- a/modules/overview/pages/introduction-to-eclipse-che.adoc
+++ b/modules/overview/pages/introduction-to-eclipse-che.adoc
@@ -11,7 +11,7 @@
 * A multi-container workspace for each developer with the ability to replicate with a single click using {prod} factories.
 * Pre-built stacks with the ability to create custom stacks for any language or runtime.
 * An enterprise integration using OpenShift OAuth or Dex.
-* Browser-based IDEs; integration with link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code] and others such as link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community Edition].
+* Browser-based IDEs; integration with link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code - Open Source] and others such as link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community Edition].
 * Support of tools protocols, such as the Language Server Protocol or Debug Adapter Protocol.
 * A plugin mechanism compatible with Visual Studio Code extensions.
 * A software development kit (SDK) for creating custom cloud developer platforms.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
update of default ide info in introduction to eclipse che

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-4575

## Specify the version of the product this pull request applies to
3.3/7.6

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
