### PR TITLE
fix: fixed Vale warnings (rhdevdocs-4580)

### DIFF
--- a/modules/administration-guide/pages/configuring-workspaces-nodeselector.adoc
+++ b/modules/administration-guide/pages/configuring-workspaces-nodeselector.adoc
@@ -11,7 +11,7 @@ This section describes how to configure link:https://kubernetes.io/docs/concepts
 
 .Procedure
 
-{prod-short} uses the `CHE_WORKSPACE_POD_NODE__SELECTOR` environment variable to configure `nodeSelector`. This variable may contain a set of comma-separated `key=value` pairs to form the nodeSelector rule, or `NULL` to disable it.
+{prod-short} uses the `CHE_WORKSPACE_POD_NODE__SELECTOR` environment variable to configure `nodeSelector`. This variable can contain a set of comma-separated `key=value` pairs to form the nodeSelector rule, or `NULL` to disable it.
 
 ----
 CHE_WORKSPACE_POD_NODE__SELECTOR=disktype=ssd,cpu=xlarge,[key=value]

--- a/modules/administration-guide/pages/plugin-registry.adoc
+++ b/modules/administration-guide/pages/plugin-registry.adoc
@@ -5,7 +5,7 @@
 :page-aliases: plug-in-registry
 
 [id="plugin-registry"]
-= Plug-in registry
+= Plugin registry
 
 Each {prod-short} workspace starts with a specific editor and set of associated extensions.
 The {prod-short} plugin registry provides the list of available editors and editor extensions.
@@ -13,11 +13,11 @@ A Devfile v2 describes each editor or extension.
 
 The xref:dashboard.adoc[] is reading the content of the registry.
 
-.Plug-in registries interactions with other components
-image::architecture/{project-context}-plugin-registry-interactions.png[Plug-in registries interactions with other components]
+.Plugin registries interactions with other components
+image::architecture/{project-context}-plugin-registry-interactions.png[Plugin registries interactions with other components]
 
 .Additional resources
 
-* link:https://github.com/eclipse-che/che-plugin-registry/blob/main/che-editors.yaml[Editors definitions in the {prod-short} plugin registry repository]
-* link:https://github.com/eclipse-che/che-plugin-registry/blob/main/che-theia-plugins.yaml[Plug-ins definitions in the {prod-short} plugin registry repository]
-* link:https://eclipse-che.github.io/che-plugin-registry/main/index.json[Plug-in registry latest community version online instance]
+* link:https://github.com/eclipse-che/che-plugin-registry/blob/main/che-editors.yaml[Editor definitions in the {prod-short} plugin registry repository]
+* link:https://github.com/eclipse-che/che-plugin-registry/blob/main/che-theia-plugins.yaml[Plugin definitions in the {prod-short} plugin registry repository]
+* link:https://eclipse-che.github.io/che-plugin-registry/main/index.json[Plugin registry latest community version online instance]

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -14,7 +14,7 @@ To use Prometheus to collect, store, and query metrics about the {devworkspace} 
 
 .Procedure
 
-. Create a ClusterRoleBinding to bind the ServiceAccount associated with Prometheus to the link:https://github.com/devfile/devworkspace-operator/blob/main/deploy/deployment/kubernetes/objects/devworkspace-controller-metrics-reader.ClusterRole.yaml[devworkspace-controller-metrics-reader] ClusterRole. For the xref:installing-prometheus-and-grafana.adoc[example monitoring stack], the name of the ServiceAccount to be be used is `prometheus`.
+. Create a ClusterRoleBinding to bind the ServiceAccount associated with Prometheus to the link:https://github.com/devfile/devworkspace-operator/blob/main/deploy/deployment/kubernetes/objects/devworkspace-controller-metrics-reader.ClusterRole.yaml[devworkspace-controller-metrics-reader] ClusterRole. For the xref:installing-prometheus-and-grafana.adoc[example monitoring stack], the name of the ServiceAccount to be used is `prometheus`.
 +
 NOTE: Without the ClusterRoleBinding, you cannot access {devworkspace} metrics because access is protected with role-based access control (RBAC).
 +

--- a/modules/administration-guide/partials/proc_mounting-a-secret-or-a-configmap-as-a-file-into-a-container.adoc
+++ b/modules/administration-guide/partials/proc_mounting-a-secret-or-a-configmap-as-a-file-into-a-container.adoc
@@ -51,7 +51,7 @@ metadata:
 ----
 ====
 
-The {orch-name} object may contain several items whose names must match the desired file name mounted into the container.
+The {orch-name} object can contain several items whose names must match the desired file name mounted into the container.
 
 .Example:
 ====

--- a/modules/end-user-guide/pages/requesting-persistent-storage-for-workspaces.adoc
+++ b/modules/end-user-guide/pages/requesting-persistent-storage-for-workspaces.adoc
@@ -19,7 +19,7 @@ Persistent Volumes come at a cost: attaching a persistent volume slows workspace
 
 [WARNING]
 ====
-Starting another, concurrently running workspace with a link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes[`ReadWriteOnce` PV] may fail.
+Starting another, concurrently running workspace with a link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes[`ReadWriteOnce` PV] might fail.
 ====
 
 .Additional resources

--- a/modules/end-user-guide/pages/troubleshooting-network-problems.adoc
+++ b/modules/end-user-guide/pages/troubleshooting-network-problems.adoc
@@ -13,7 +13,7 @@ Secure WebSocket connections improve confidentiality and also reliability becaus
 
 .Prerequisites
 
-* The WebSocket Secure (WSS) connections on port 443 must be available on the network. Firewall and proxy may need additional configuration.
+* The WebSocket Secure (WSS) connections on port 443 must be available on the network. Firewall and proxy might need additional configuration.
 * Use a supported web browser:
 ** Google Chrome
 ** Mozilla Firefox


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
fixed Vale warnings

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-4799

## Specify the version of the product this pull request applies to
`main`
`7.56.x`
`7.58.x`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
