### PR TITLE
fix: remove reference to "supported browsers"

### DIFF
--- a/modules/end-user-guide/pages/benefits-of-pull-requests-review-in-che.adoc
+++ b/modules/end-user-guide/pages/benefits-of-pull-requests-review-in-che.adoc
@@ -12,7 +12,6 @@
 
 .Prerequisites
 * You have access to the repository hosted by your Git provider.
-* You use a {prod}-supported browser: Google Chrome or Mozilla Firefox.
 * You have access to a {prod-short} instance.
 
 .Procedure

--- a/modules/end-user-guide/pages/troubleshooting-network-problems.adoc
+++ b/modules/end-user-guide/pages/troubleshooting-network-problems.adoc
@@ -14,9 +14,6 @@ Secure WebSocket connections improve confidentiality and also reliability becaus
 .Prerequisites
 
 * The WebSocket Secure (WSS) connections on port 443 must be available on the network. Firewall and proxy may need additional configuration.
-* Use a supported web browser:
-** Google Chrome
-** Mozilla Firefox
 
 .Procedure
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

Removes references to specific browsers as "supported" (Chrome and Firefox).

## What issues does this pull request fix or reference?

* https://issues.redhat.com/browse/RHDEVDOCS-4754

## Specify the version of the product this pull request applies to
7.58

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
