### PR TITLE
[WIP] fix: render catalog source metadata for disconnected install

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -20,8 +20,8 @@ asciidoc:
     icons: font
     # for the project
     che-plugin-registry-directory: che-plugin-registry
-    devworkspace-operator-index: registry.redhat.io/redhat/redhat-operator-index:v4.10
-    devworkspace-operator-version-patch: "0.17.0"
+    devworkspace-operator-index: quay.io/devfile/devworkspace-operator-index:release
+    devworkspace-operator-version-patch: "0.18.1"
     devworkspace: Dev Workspace
     devworkspace-id: devworkspace
     docker-cli: docker

--- a/antora.yml
+++ b/antora.yml
@@ -21,7 +21,7 @@ asciidoc:
     # for the project
     che-plugin-registry-directory: che-plugin-registry
     devworkspace-operator-index: registry.redhat.io/redhat/redhat-operator-index:v4.10
-    devworkspace-operator-version-patch: "0.15.2"
+    devworkspace-operator-version-patch: "0.17.0"
     devworkspace: Dev Workspace
     devworkspace-id: devworkspace
     docker-cli: docker

--- a/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
+++ b/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
@@ -44,19 +44,30 @@ mkdir -p "${my_catalog}/${devworkspace_operator_package_name}" "${my_catalog}/${
 
 echo "Fetching metadata for the ${devworkspace_operator_package_name} operator catalog channel, packages, and bundles."
 opm render "${devworkspace_operator_index}" \
-  | jq "select(\
-    .name == \"${devworkspace_operator_package_name}.${devworkspace_operator_version}\" \
-    and .schema == \"olm.bundle\" \
+  | jq "select \
+    (\
+      (.schema == \"olm.bundle\" and .name == \"${devworkspace_operator_package_name}.${devworkspace_operator_version}\") or \
+      (.schema == \"olm.package\" and .name == \"${devworkspace_operator_package_name}\") or \
+      (.schema == \"olm.channel\" and .package == \"${devworkspace_operator_package_name}\") \
     )" \
+  | jq "select \
+     (.schema == \"olm.channel\" and .package == \"${devworkspace_operator_package_name}\").entries \
+      |= [{name: \"${devworkspace_operator_package_name}.${devworkspace_operator_version}\"}]"
   > "${my_catalog}/${devworkspace_operator_package_name}/render.json"
 
 echo "Fetching metadata for the ${prod_operator_package_name} operator catalog channel, packages, and bundles."
 opm render "${prod_operator_index}" \
-  | jq "select(\
-    .name == \"${prod_operator_package_name}.${prod_operator_version}\" \
-    and .schema == \"olm.bundle\" \
+  | jq "select \
+    (\
+      (.schema == \"olm.bundle\" and .name == \"${prod_operator_package_name}.${prod_operator_version}\") or \
+      (.schema == \"olm.package\" and .name == \"${prod_operator_package_name}\") or \
+      (.schema == \"olm.channel\" and .package == \"${prod_operator_package_name}\") \
     )" \
+  | jq "select \
+     (.schema == \"olm.channel\" and .package == \"${prod_operator_package_name}\").entries \
+      |= [{name: \"${prod_operator_package_name}.${prod_operator_version}\"}]"
   > "${my_catalog}/${prod_operator_package_name}/render.json"
+
 
 echo "Creating the catalog dockerfile."
 if [ -f "${my_catalog}.Dockerfile" ]; then

--- a/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
+++ b/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
@@ -36,7 +36,7 @@ declare prod_operator_version="${prod_operator_version:?Define the variable}"
 
 # Destination registry
 declare my_registry="${my_registry:?Define the variable}"
-declare my_catalog="${my_catalog:-restricted-environment-install}"
+declare my_catalog=restricted-environment-install
 declare my_operator_index="$my_registry/$my_catalog/my-operator-index:v${ocp_ver}"
 
 # Create local directories

--- a/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
+++ b/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
@@ -52,7 +52,7 @@ opm render "${devworkspace_operator_index}" \
     )" \
   | jq "select \
      (.schema == \"olm.channel\" and .package == \"${devworkspace_operator_package_name}\").entries \
-      |= [{name: \"${devworkspace_operator_package_name}.${devworkspace_operator_version}\"}]"
+      |= [{name: \"${devworkspace_operator_package_name}.${devworkspace_operator_version}\"}]" \
   > "${my_catalog}/${devworkspace_operator_package_name}/render.json"
 
 echo "Fetching metadata for the ${prod_operator_package_name} operator catalog channel, packages, and bundles."
@@ -65,9 +65,8 @@ opm render "${prod_operator_index}" \
     )" \
   | jq "select \
      (.schema == \"olm.channel\" and .package == \"${prod_operator_package_name}\").entries \
-      |= [{name: \"${prod_operator_package_name}.${prod_operator_version}\"}]"
+      |= [{name: \"${prod_operator_package_name}.${prod_operator_version}\"}]" \
   > "${my_catalog}/${prod_operator_package_name}/render.json"
-
 
 echo "Creating the catalog dockerfile."
 if [ -f "${my_catalog}.Dockerfile" ]; then
@@ -84,10 +83,6 @@ oc patch OperatorHub cluster --type json \
 
 echo "Deploying your catalog image to the $my_operator_index registry."
 # See: https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-installation-images.html#olm-mirroring-catalog_installing-mirroring-installation-images
-oc delete project "$my_catalog" --grace-period=1 --ignore-not-found=true
-oc wait --for=delete "project/$my_catalog"
-sleep 5
-oc new-project "$my_catalog"
 skopeo copy --dest-tls-verify=false --all "containers-storage:$my_operator_index" "docker://$my_operator_index"
 
 echo "Deploying your catalog source to the OpenShift cluster."

--- a/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
+++ b/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
@@ -26,6 +26,8 @@ include::partial$snip_preparing-images-for-a-restricted-environment.adoc[]
 [subs="+attributes,+quotes"]
 ----
 $ {prod-cli} server:deploy --platform=openshift \
+  --catalog-source-name=restricted-environment-install \
+  --catalog-source-namespace=openshift-marketplace \
   --che-operator-cr-patch-yaml=che-operator-cr-patch.yaml
 ----
 

--- a/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
+++ b/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
@@ -29,8 +29,8 @@ $ {prod-cli} server:deploy \
   --platform=openshift \
   --catalog-source-name=restricted-environment-install \
   --catalog-source-namespace=openshift-marketplace \
-  --skip-devworkspace-operator \ 
-  --che-operator-cr-patch-yaml=che-operator-cr-patch.yaml \
+  --skip-devworkspace-operator \
+  --che-operator-cr-patch-yaml=che-operator-cr-patch.yaml
 ----
 
 . Allow incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}s. See: xref:configuring-network-policies.adoc[].

--- a/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
+++ b/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
@@ -25,10 +25,12 @@ include::partial$snip_preparing-images-for-a-restricted-environment.adoc[]
 +
 [subs="+attributes,+quotes"]
 ----
-$ {prod-cli} server:deploy --platform=openshift \
+$ {prod-cli} server:deploy \
+  --platform=openshift \
   --catalog-source-name=restricted-environment-install \
   --catalog-source-namespace=openshift-marketplace \
-  --che-operator-cr-patch-yaml=che-operator-cr-patch.yaml
+  --skip-devworkspace-operator \ 
+  --che-operator-cr-patch-yaml=che-operator-cr-patch.yaml \
 ----
 
 . Allow incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}s. See: xref:configuring-network-policies.adoc[].

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -41,7 +41,6 @@ $ bash prepare-restricted-environment.sh \
   --prod_operator_index "{prod-operator-index}" \
   --prod_operator_package_name "{prod-operator-package-name}" \
   --prod_operator_version "v{prod-ver-patch}" \
-  --my_registry "__<my_registry>__" \
-  --my_catalog "__<my_catalog>__"
+  --my_registry "__<my_registry>__"
 ----
 


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>


<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
fix: render catalog source metadata for disconnected install

## What issues does this pull request fix or reference?
https://github.com/eclipse/che/issues/21445

## Specify the version of the product this pull request applies to
7.61.0

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
