### PR TITLE
fix: remove user data page language update (rhdevdocs-4580)

### DIFF
--- a/modules/administration-guide/pages/removing-user-data.adoc
+++ b/modules/administration-guide/pages/removing-user-data.adoc
@@ -21,7 +21,10 @@ Following this procedure makes the service compliant to EU General Data Protecti
 
 .Procedure
 
-. Get the __<username>__ user __<id>__ `id`: navigate to pass:c,m,a,q[+https:+//__<{prod-host}>__]/swagger/#/user/find_1, click btn:[Try it out], set *name*: __<username>__, and click btn:[Execute]. Scroll down the *Response body* to find the `id` value.
+. Get the __<username>__ user __<id>__ `id`:
+.. Navigate to pass:c,m,a,q[+https:+//__<{prod-host}>__]/swagger/#/user/find_1.
+.. Click btn:[Try it out], set *name*: __<username>__, and click btn:[Execute].
+.. Scroll down the *Response body* to find the `id` value.
 // +
 // [subs="+quotes,macros,attributes"]
 // ----
@@ -30,7 +33,9 @@ Following this procedure makes the service compliant to EU General Data Protecti
 //   'pass:c,m,a,q[+https:+//__<{prod-host}>__]/api/user/find?name=__<username>__'
 // ----
 
-. Remove the __<id>__ user data that {prod-short} server manages, such as user preferences: navigate to pass:c,m,a,q[+https:+//__<{prod-host}>__]/swagger/#/user/remove, click btn:[Try it out], set *id*: __<id>__, and click btn:[Execute]. Expect a `204` response code:
+. Remove the __<id>__ user data that {prod-short} server manages, such as user preferences:
+.. Navigate to pass:c,m,a,q[+https:+//__<{prod-host}>__]/swagger/#/user/remove.
+.. Click btn:[Try it out], set *id*: __<id>__, and click btn:[Execute].
 // +
 // [subs="+quotes,macros,attributes"]
 // ----


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Language update of the Remove user data page.

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-4840

## Specify the version of the product this pull request applies to
7.58, 3.4

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
