### PR TITLE
fix: removed eclipse theia from table of supported editors (rhdevdocs-4580)

### DIFF
--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -24,6 +24,3 @@
 * `latest` is the stable version.
 * `next` is the development version.
 
-| link:https://github.com/eclipse-che/che-theia[Eclipse Theia]
-| `eclipse/che-theia/latest`
-| *Deprecated and will be removed in a future release.*


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
removed eclipse theia from table of supported editors 

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-4570

## Specify the version of the product this pull request applies to
devspaces 3.6, eclipse che 7.63

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
