### PR TITLE
Add info about starting a workspace from raw devfile location

### DIFF
--- a/modules/end-user-guide/nav.adoc
+++ b/modules/end-user-guide/nav.adoc
@@ -7,6 +7,7 @@
 ** xref:benefits-of-pull-requests-review-in-che.adoc[]
 * xref:user-onboarding.adoc[]
 ** xref:starting-a-new-workspace-with-a-clone-of-a-git-repository.adoc[]
+** xref:starting-a-new-workspace-from-a-devfile-url.adoc[]
 ** xref:optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc[]
 *** xref:url-parameter-concatenation.adoc[]
 *** xref:url-parameter-for-the-workspace-ide.adoc[]

--- a/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
@@ -18,7 +18,7 @@ With {prod-short}, you can visit a *devfile* URL in your browser to start a new 
 
 pass:[<!-- vale RedHat.Spelling = NO -->]
 
-TIP: You can also use the *Git Repo URL** field on the *Create Workspace* page of your {prod-short} dashboard to enter the URL of a *devfile* to start a new workspace.
+TIP: You can also use the *Git Repo URL ** field on the *Create Workspace* page of your {prod-short} dashboard to enter the URL of a *devfile* to start a new workspace.
 
 pass:[<!-- vale RedHat.Spelling = YES -->]
 

--- a/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
@@ -14,7 +14,7 @@ Working with {prod-short} in your browser involves multiple URLs:
 * [.underline]#The URLs for starting a new workspace#
 * The URLs of your workspaces in use
 
-With {prod-short}, you can visit a *devfile* URL in your browser to start a new workspace.
+With {prod-short}, you can open a *devfile* URL in your browser to start a new workspace.
 
 pass:[<!-- vale RedHat.Spelling = NO -->]
 

--- a/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
@@ -1,0 +1,92 @@
+:_content-type: PROCEDURE
+:description: Starting a new workspace from a devfile URL
+:keywords: start-new-workspace, start-a-new-workspace, how-to-start-new-workspace, how-to-start-a-new-workspace, starting-a-new-workspace, how-to-start-workspace, how-to-start-a-workspace
+:navtitle: Starting a new workspace from a devfile URL
+:page-aliases:
+
+[id="starting-a-new-workspace-from-a-devfile-url"]
+= Starting a new workspace from a devfile URL
+
+Working with {prod-short} in your browser involves multiple URLs:
+
+* The URL of your organization's {prod-short} instance, used as part of all the following URLs
+* The URL of the *devfile*
+* [.underline]#The URLs for starting a new workspace#
+* The URLs of your workspaces in use
+
+With {prod-short}, you can visit a *devfile* URL in your browser to start a new workspace.
+
+TIP: You can also use the *Git Repo URL ** field on the *Create Workspace* page of your {prod-short} dashboard to enter the URL of a *devfile* to start a new workspace.
+
+.Prerequisites
+
+* Your organization has a running instance of {prod-short}.
+* You know the FQDN URL of your organization's {prod-short} instance: `pass:c,a,q[{prod-url}]`.
+
+.Procedure
+
+To start a new workspace from a devfile URL:
+
+. Optional: Visit your {prod-short} dashboard pages to authenticate to your organization's instance of {prod-short}.
+
+. Visit the URL to start a new workspace using the basic syntax:
+[source,subs="+quotes,+attributes,+macros"]
++
+----
+pass:c,a,q[{prod-url}]#__<devfile_url>__
+----
++
+[TIP]
+====
+You can extend this URL with optional parameters:
+[source,subs="+quotes,+attributes,+macros"]
+----
+pass:c,a,q[{prod-url}]#__<devfile_url>__?__<optional_parameters>__ <1>
+----
+<1> See xref:optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc[].
+====
++
+.A URL for starting a new workspace
+====
+
+`pass:c,a,q[{prod-url}#https://raw.githubusercontent.com/che-samples/cpp-hello-world/main/devfile.yaml]`
+
+====
++
+[TIP]
+====
+You can pass Personal Access Token to the URL to have access to private repositories:
+[source,subs="+quotes,+attributes,+macros"]
+----
+pass:c,a,q[{prod-url}]#__https://__<token>__@__<host>__/__<path> <1>
+----
+<1> See xref:using-a-git-provider-access-token.adoc[].
+
+This works for GitHub, GitLab, Bitbucket, Microsoft Azure, and other providers that support Personal Access Token.
+====
++
+After you enter the URL to start a new workspace in a browser tab, it renders the workspace-starting page.
++
+When the new workspace is ready, the workspace IDE loads in the browser tab.
++
+The workspace has a unique URL: `pass:c,a,q[{prod-url}]#workspace__<unique_url>__`.
+
+[TIP]
+====
+Although this is not possible in the address bar, you can add a URL for starting a new workspace as a bookmark by using the browser bookmark manager:
+
+* In Mozilla Firefox, go to *☰* *>* *Bookmarks* *>* *Manage bookmarks Ctrl+Shift+O* *>* *Bookmarks Toolbar* *>* *Organize* *>* *Add bookmark*.
+
+* In Google Chrome, go to *⋮* *>* *Bookmarks* *>* *Bookmark manager* *>* *Bookmarks bar* *>* *⋮* *>* *Add new bookmark*.
+====
+[IMPORTANT]
+====
+The devfile must contain a project info in its content, to initiate a clone of the Git repository in the filesystem of the new workspace.
+
+See https://devfile.io/docs/2.2.0/adding-projects.
+====
+
+.Additional resources
+
+* xref:optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc[]
+* xref:basic-actions-you-can-perform-on-a-workspace.adoc[]

--- a/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
@@ -16,7 +16,11 @@ Working with {prod-short} in your browser involves multiple URLs:
 
 With {prod-short}, you can visit a *devfile* URL in your browser to start a new workspace.
 
-TIP: You can also use the *Git Repo URL ** field on the *Create Workspace* page of your {prod-short} dashboard to enter the URL of a *devfile* to start a new workspace.
+pass:[<!-- vale RedHat.Spelling = NO -->]
+
+TIP: You can also use the *Git Repo URL** field on the *Create Workspace* page of your {prod-short} dashboard to enter the URL of a *devfile* to start a new workspace.
+
+pass:[<!-- vale RedHat.Spelling = YES -->]
 
 .Prerequisites
 

--- a/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
@@ -59,7 +59,7 @@ pass:c,a,q[{prod-url}]#__<devfile_url>__?__<optional_parameters>__ <1>
 +
 [TIP]
 ====
-You can pass Personal Access Token to the URL to have access to private repositories:
+You can pass your Personal Access Token to the URL to have access to private repositories:
 [source,subs="+quotes,+attributes,+macros"]
 ----
 pass:c,a,q[{prod-url}]#__https://__<token>__@__<host>__/__<path> <1>

--- a/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
@@ -64,7 +64,7 @@ You can pass Personal Access Token to the URL to have access to private reposito
 ----
 pass:c,a,q[{prod-url}]#__https://__<token>__@__<host>__/__<path> <1>
 ----
-<1> See xref:using-a-git-provider-access-token.adoc[].
+<1> Your Personal Access Token that you generated on the Git provider's website.
 
 This works for GitHub, GitLab, Bitbucket, Microsoft Azure, and other providers that support Personal Access Token.
 ====

--- a/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
@@ -77,7 +77,7 @@ The workspace has a unique URL: `pass:c,a,q[{prod-url}]#workspace__<unique_url>_
 
 [TIP]
 ====
-Although this is not possible in the address bar, you can add a URL for starting a new workspace as a bookmark by using the browser bookmark manager:
+You can not bookmark a URL for starting a new workspace in the address bar, but you can create the bookmark by using the browser bookmark manager instead:
 
 * In Mozilla Firefox, go to *☰* *>* *Bookmarks* *>* *Manage bookmarks Ctrl+Shift+O* *>* *Bookmarks Toolbar* *>* *Organize* *>* *Add bookmark*.
 

--- a/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
@@ -69,10 +69,10 @@ pass:c,a,q[{prod-url}]#__https://__<token>__@__<host>__/__<path> <1>
 This works for GitHub, GitLab, Bitbucket, Microsoft Azure, and other providers that support Personal Access Token.
 ====
 +
-After you enter the URL to start a new workspace in a browser tab, it renders the workspace-starting page.
-+
-When the new workspace is ready, the workspace IDE loads in the browser tab.
-+
+.Verification
+
+After you enter the URL to start a new workspace in a browser tab, it renders the workspace-starting page. When the new workspace is ready, the workspace IDE loads in the browser tab. 
+
 The workspace has a unique URL: `pass:c,a,q[{prod-url}]#workspace__<unique_url>__`.
 
 [TIP]

--- a/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-new-workspace-from-a-devfile-url.adoc
@@ -85,7 +85,7 @@ Although this is not possible in the address bar, you can add a URL for starting
 ====
 [IMPORTANT]
 ====
-The devfile must contain a project info in its content, to initiate a clone of the Git repository in the filesystem of the new workspace.
+To initiate a clone of the Git repository in the filesystem of the new workspace, the devfile must contain project info.
 
 See https://devfile.io/docs/2.2.0/adding-projects.
 ====

--- a/modules/end-user-guide/pages/user-onboarding.adoc
+++ b/modules/end-user-guide/pages/user-onboarding.adoc
@@ -10,6 +10,7 @@
 If your organization is already running a {prod-short} instance, you can get started as a new user by learning how to start a new workspace, manage your workspaces, and authenticate yourself to a Git server from a workspace:
 
 . xref:starting-a-new-workspace-with-a-clone-of-a-git-repository.adoc[]
+. xref:starting-a-new-workspace-from-a-devfile-url.adoc[]
 . xref:optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc[]
 . xref:basic-actions-you-can-perform-on-a-workspace.adoc[]
 . xref:authenticating-to-a-git-server-from-a-workspace.adoc[]


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Add info about starting a workspace from raw devfile location
## What issues does this pull request fix or reference?
https://github.com/eclipse/che/issues/21998
## Specify the version of the product this pull request applies to
7.60
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
