### PR TITLE
chore: remove +'s from url in Setting up the Microsoft Azure DevOps Services OAuth App

### DIFF
--- a/modules/administration-guide/partials/proc_setting-up-the-microsoft-azure-devops-services-oauth-app.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-the-microsoft-azure-devops-services-oauth-app.adoc
@@ -17,7 +17,7 @@ Set up a Microsoft Azure DevOps Services OAuth App using OAuth 2.0.
 
 .Procedure
 
-. Visit link:https://app.vsaex.visualstudio.com/app/register[].
+. Visit link:https://app.vsaex.visualstudio.com/app/register/[].
 
 . Enter the following values:
 

--- a/modules/administration-guide/partials/proc_setting-up-the-microsoft-azure-devops-services-oauth-app.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-the-microsoft-azure-devops-services-oauth-app.adoc
@@ -17,7 +17,7 @@ Set up a Microsoft Azure DevOps Services OAuth App using OAuth 2.0.
 
 .Procedure
 
-. Visit +https://app.vsaex.visualstudio.com/app/register+.
+. Visit https://app.vsaex.visualstudio.com/app/register.
 
 . Enter the following values:
 

--- a/modules/administration-guide/partials/proc_setting-up-the-microsoft-azure-devops-services-oauth-app.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-the-microsoft-azure-devops-services-oauth-app.adoc
@@ -17,7 +17,7 @@ Set up a Microsoft Azure DevOps Services OAuth App using OAuth 2.0.
 
 .Procedure
 
-. Visit https://app.vsaex.visualstudio.com/app/register.
+. Visit link:https://app.vsaex.visualstudio.com/app/register[].
 
 . Enter the following values:
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
remove +'s from the url https://app.vsaex.visualstudio.com/app/register  in Setting up the Microsoft Azure DevOps Services OAuth App because the htmltest failed the build of https://github.com/eclipse-che/che-docs/pull/2560 (the htmltest issue has since been fixed in https://github.com/eclipse-che/che-docs/pull/2570).

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-5018

## Specify the version of the product this pull request applies to
`main`, `7.60.x`, `7.61.x`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
