### PR TITLE
fix: remove outdated link to removed che-theia-plugins.yaml

### DIFF
--- a/modules/administration-guide/pages/plugin-registry.adoc
+++ b/modules/administration-guide/pages/plugin-registry.adoc
@@ -19,5 +19,4 @@ image::architecture/{project-context}-plugin-registry-interactions.png[Plugin re
 .Additional resources
 
 * link:https://github.com/eclipse-che/che-plugin-registry/blob/main/che-editors.yaml[Editor definitions in the {prod-short} plugin registry repository]
-* link:https://github.com/eclipse-che/che-plugin-registry/blob/main/che-theia-plugins.yaml[Plugin definitions in the {prod-short} plugin registry repository]
 * link:https://eclipse-che.github.io/che-plugin-registry/main/index.json[Plugin registry latest community version online instance]


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
The page https://www.eclipse.org/che/docs/stable/administration-guide/plugin-registry/ currently has a link to https://github.com/eclipse-che/che-plugin-registry/blob/main/che-theia-plugins.yaml (under Additional resources), which makes the docs build fail. I've checked with @svor, who confirmed that the file has been removed and this link is outdated and has to be removed too.

## What issues does this pull request fix or reference?
[RHDEVDOCS-5085](https://issues.redhat.com/browse/RHDEVDOCS-5085)

## Specify the version of the product this pull request applies to
Merge to `main`
Cherry-pick to `7.60`, `7.61`, `7.62`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
