### PR TITLE
Update the using-a-git-provider-access-token.adoc to omit scm-userid

### DIFF
--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -80,7 +80,8 @@ type: Opaque
 <1> Your {prod-short} user ID.
 <2> The Git provider name: `github` or `gitlab` or `bitbucket-server` or `azure-devops`.
 <3> The Git provider URL.
-<4> The Git provider username, user email in case you are using `azure-devops`.
+<4> The Git provider username or user's email address for `azure-devops`.
+<4> The Git provider username. For `azure-devops`, the user's email address.
 <5> This line is only applicable to `azure-devops`: your Git provider user organization.
 
 . Visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.

--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -81,7 +81,6 @@ type: Opaque
 <2> The Git provider name: `github` or `gitlab` or `bitbucket-server` or `azure-devops`.
 <3> The Git provider URL.
 <4> The Git provider username or user's email address for `azure-devops`.
-<4> The Git provider username. For `azure-devops`, the user's email address.
 <5> This line is only applicable to `azure-devops`: your Git provider user organization.
 
 . Visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.

--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -55,12 +55,6 @@ If you have the link:https://www.gnu.org/software/coreutils/base64[base64] comma
 
 . Go to `pass:c,a,q[{prod-url}]/api/user/id` in the web browser to get your {prod-short} user ID.
 
-. Get your Git provider user ID by following the Git provider's API documentation:
-+
-* GitHub: link:https://docs.github.com/en/rest/users/users#get-a-user[Get a user]. See the `id` value in the response.
-* GitLab: link:https://docs.gitlab.com/ee/api/users.html#for-normal-users[List users: For normal users], use the `username` filter: `/users?username=:username`. See the `id` value in the response.
-* Bitbucket Server: Get the `id` by running `curl -D- -u username:password -X GET -H "Content-Type: application/json" https://__<baseurl>__/rest/api/latest/users/__<userSlug>__`. See the Bitbucket API documentation about link:https://developer.atlassian.com/server/bitbucket/rest/v802/api-group-api/#api-api-latest-users-userslug-get[using the user slug] and link:https://developer.atlassian.com/server/bitbucket/how-tos/example-basic-authentication/[authentication].
-
 . Prepare a new {orch-name} Secret.
 +
 [source,yaml,subs="+quotes,+attributes,+macros"]
@@ -76,8 +70,7 @@ metadata:
     che.eclipse.org/che-userid: __<{prod-id-short}_user_id>__# <1>
     che.eclipse.org/scm-personal-access-token-name: _<git_provider_name>_# <2>
     che.eclipse.org/scm-url: __<git_provider_endpoint>__# <3>
-    che.eclipse.org/scm-userid: '__<git_provider_user_id>__'# <4>
-    che.eclipse.org/scm-username: __<git_provider_username>__
+    che.eclipse.org/scm-username: __<git_provider_username>__# <4>
     che.eclipse.org/scm-organization: __<git_provider_organization>__# <5>
 data:
   token: __<Base64_encoded_access_token>__
@@ -87,7 +80,7 @@ type: Opaque
 <1> Your {prod-short} user ID.
 <2> The Git provider name: `github` or `gitlab` or `bitbucket-server` or `azure-devops`.
 <3> The Git provider URL.
-<4> Your Git provider user ID wrapped in `' '` or `" "`.
+<4> The Git provider username, user email in case you are using `azure-devops`.
 <5> This line is only applicable to `azure-devops`: your Git provider user organization.
 
 . Visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.

--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -80,7 +80,7 @@ type: Opaque
 <1> Your {prod-short} user ID.
 <2> The Git provider name: `github` or `gitlab` or `bitbucket-server` or `azure-devops`.
 <3> The Git provider URL.
-<4> The Git provider username or user's email address for `azure-devops`.
+<4> The Git provider username. For `azure-devops`, the user's email address.
 <5> This line is only applicable to `azure-devops`: your Git provider user organization.
 
 . Visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Align the using-a-git-provider-access-token.adoc with the PAT flow simplification: `che.eclipse.org/scm-userid` annotation is omitted.

**Do NOT MERGE** until https://github.com/eclipse-che/che-server/pull/496 is merged.

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-4182

## Specify the version of the product this pull request applies to
7.64
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
