### PR TITLE
fix: replace namespace and app name with placeholders for #2586

### DIFF
--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -33,10 +33,10 @@ spec:
       scheme: http
   namespaceSelector:
     matchNames:
-      - openshift-devspaces
+      - {prod-namespace} <1>
   selector:
     matchLabels:
-      app.kubernetes.io/name: devspaces
+      app.kubernetes.io/name: {prod-deployment}
 ----
 <1> The {prod-short} namespace. The default is `{prod-namespace}`.
 <2> The rate at which a target is scraped.

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -42,7 +42,7 @@ spec:
 <2> The rate at which a target is scraped.
 ====
 
-. Create a Role and RoleBinding to allow Prometheus view the metrics.
+. Create a Role and RoleBinding to allow Prometheus to view the metrics.
 
 +
 .Role

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -44,6 +44,53 @@ spec:
 <2> The rate at which a target is scraped.
 ====
 
+. Create a Role and RoleBinding to allow Prometheus to view the metrics.
+
++
+.Role
+====
+[source,yaml,subs="+quotes,+attributes,+macros"]
+----
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-operators
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+----
+====
+
++
+.RoleBinding
+====
+[source,yaml,subs="+quotes,+attributes,+macros"]
+----
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: view-openshift-monitoring-prometheus-k8s
+  namespace: openshift-operators
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+----
+====
+
 . Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
 +
 [source,subs="+attributes"]


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

Updates the service monitor for Che Server:

Before:
<img width="789" alt="image" src="https://user-images.githubusercontent.com/83611742/234406502-b7be7df0-1498-4bdb-a317-ff563eff88a8.png">

After: 
## What does this pull request change?
<img width="716" alt="image" src="https://user-images.githubusercontent.com/83611742/234406346-539a46a4-00e7-46a3-b729-0db22edd877a.png">

The second commit adds a role and rolebinding similar step 2 of the [che server monitoring docs](https://www.eclipse.org/che/docs/stable/administration-guide/monitoring-che/)

## What issues does this pull request fix or reference?
Small fix and something I realize could be helpful (role & rolebinding) for https://github.com/eclipse-che/che-docs/pull/2586

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
