### PR TITLE
fix: splitting the Collecting Dev Workspace Operator metrics procedure into upstream and downstream versions

### DIFF
--- a/modules/administration-guide/examples/snip_che-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc
+++ b/modules/administration-guide/examples/snip_che-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc
@@ -32,7 +32,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: view-openshift-monitoring-prometheus-k8s
+  name: view-che-openshift-monitoring-prometheus-k8s
   namespace: openshift-operators
 subjects:
   - kind: ServiceAccount

--- a/modules/administration-guide/examples/snip_che-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc
+++ b/modules/administration-guide/examples/snip_che-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc
@@ -1,0 +1,46 @@
+. Create a Role and RoleBinding to allow Prometheus to view the metrics.
+
++
+.Role
+====
+[source,yaml,subs="+quotes,+attributes,+macros"]
+----
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-operators
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+----
+====
+
++
+.RoleBinding
+====
+[source,yaml,subs="+quotes,+attributes,+macros"]
+----
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: view-openshift-monitoring-prometheus-k8s
+  namespace: openshift-operators
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+----
+====

--- a/modules/administration-guide/pages/architecture-overview.adoc
+++ b/modules/administration-guide/pages/architecture-overview.adoc
@@ -16,7 +16,7 @@ image::architecture/{project-context}-interacting-with-devworkspace.png[]
 Manage User {orch-namespace} and workspaces. The main component is the User dashboard, from which users control their workspaces.
 
 {devworkspace} operator::
-Creates and controls the necessary {orch-name} objects to run User workspaces. Including `Pods`, `Services`, and `PersistentVolumes`.
+Creates and controls the necessary {orch-name} objects to run User workspaces. Including `Pods`, `Services`, and `PeristentVolumes`.
 
 User workspaces:: 
 Container-based development environments, the IDE included.

--- a/modules/administration-guide/pages/architecture-overview.adoc
+++ b/modules/administration-guide/pages/architecture-overview.adoc
@@ -16,7 +16,7 @@ image::architecture/{project-context}-interacting-with-devworkspace.png[]
 Manage User {orch-namespace} and workspaces. The main component is the User dashboard, from which users control their workspaces.
 
 {devworkspace} operator::
-Creates and controls the necessary {orch-name} objects to run User workspaces. Including `Pods`, `Services`, and `PeristentVolumes`.
+Creates and controls the necessary {orch-name} objects to run User workspaces. Including `Pods`, `Services`, and `PersistentVolumes`.
 
 User workspaces:: 
 Container-based development environments, the IDE included.

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -77,7 +77,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: view-openshift-monitoring-prometheus-k8s
+  name: view-{prod-id-short}-openshift-monitoring-prometheus-k8s
   namespace: {prod-namespace} <1>
 subjects:
   - kind: ServiceAccount

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -44,52 +44,7 @@ spec:
 <2> The rate at which a target is scraped.
 ====
 
-. Create a Role and RoleBinding to allow Prometheus to view the metrics.
-
-+
-.Role
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: prometheus-k8s
-  namespace: openshift-operators
-rules:
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - services
-      - endpoints
-      - pods
-----
-====
-
-+
-.RoleBinding
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: view-openshift-monitoring-prometheus-k8s
-  namespace: openshift-operators
-subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-----
-====
+include::example$snip_{project-context}-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc[]
 
 . Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
 +


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Step 2 of the procedure is kept in the Che docs but removed from the Dev Spaces docs:
https://www.eclipse.org/che/docs/stable/administration-guide/monitoring-the-dev-workspace-operator/#proc_collecting-dev-workspace-operator-metrics-with-prometheus

## What issues does this pull request fix or reference?
This is a follow-up to https://github.com/eclipse-che/che-docs/pull/2586 as requested by @dkwon17 

## Specify the version of the product this pull request applies to
Merge to `main`
Cherry-pick to `7.62.x`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
