### PR TITLE
Add clarifications for the Bitbucket Server oAuth1 configuration

### DIFF
--- a/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
@@ -46,8 +46,8 @@ data:
 <1> The {prod-short} namespace. The default is `{prod-namespace}`.
 <2> The URL of the Bitbucket Server.
 <3> The content of the `privatepkcs8-stripped.pem` file, which was Base64-encoded when the file was generated.
-<4> The Base64-encoded content of the `bitbucket-consumer-key` file.
-<5> The Base64-encoded content of the `bitbucket-shared-secret` file.
+<4> The content of the `bitbucket-consumer-key` file, which you manually encoded to Base64.
+<5> The content of the `bitbucket-shared-secret` file, which you manually encoded to Base64.
 +
 [IMPORTANT]
 ====

--- a/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
@@ -13,7 +13,7 @@ Prepare and apply the application link Secret for the Bitbucket Server.
 
 * The application link is set up on the Bitbucket Server.
 
-* The following Base64-encoded files, which were created when setting up the application link, are prepared:
+* The following Base64-encoded values, which were generated when setting up the application link, are prepared:
 ** `privatepkcs8-stripped.pem`
 ** `bitbucket-consumer-key`
 ** `bitbucket-shared-secret`
@@ -45,9 +45,14 @@ data:
 ----
 <1> The {prod-short} namespace. The default is `{prod-namespace}`.
 <2> The URL of the Bitbucket Server.
-<3> The Base64-encoded content of the `privatepkcs8-stripped.pem` file.
+<3> The content of the `privatepkcs8-stripped.pem` file.
 <4> The Base64-encoded content of the `bitbucket-consumer-key` file.
 <5> The Base64-encoded content of the `bitbucket-shared-secret` file.
++
+[IMPORTANT]
+====
+The content of the `privatepkcs8-stripped.pem` file is already Base64 encoded, so no need to run the `echoo <file-content> | base64` command, like for the `consumer-key` and `shared-secret` files.
+====
 
 . Apply the Secret:
 +

--- a/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
@@ -45,7 +45,7 @@ data:
 ----
 <1> The {prod-short} namespace. The default is `{prod-namespace}`.
 <2> The URL of the Bitbucket Server.
-<3> The content of the `privatepkcs8-stripped.pem` file.
+<3> The content of the `privatepkcs8-stripped.pem` file, which was Base64-encoded when the file was generated.
 <4> The Base64-encoded content of the `bitbucket-consumer-key` file.
 <5> The Base64-encoded content of the `bitbucket-shared-secret` file.
 +

--- a/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
@@ -13,7 +13,10 @@ Prepare and apply the application link Secret for the Bitbucket Server.
 
 * The application link is set up on the Bitbucket Server.
 
-* The following Base64-encoded values, which were generated when setting up the application link, are prepared:
+* The following files, which were created when setting up the application link, are prepared:
+** `privatepkcs8-stripped.pem`
+** Base64-encoded `bitbucket-consumer-key`
+** Base64-encoded `bitbucket-shared-secret`
 ** `privatepkcs8-stripped.pem`
 ** `bitbucket-consumer-key`
 ** `bitbucket-shared-secret`

--- a/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
@@ -17,9 +17,6 @@ Prepare and apply the application link Secret for the Bitbucket Server.
 ** `privatepkcs8-stripped.pem`
 ** Base64-encoded `bitbucket-consumer-key`
 ** Base64-encoded `bitbucket-shared-secret`
-** `privatepkcs8-stripped.pem`
-** `bitbucket-consumer-key`
-** `bitbucket-shared-secret`
 
 * An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 

--- a/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
@@ -48,11 +48,6 @@ data:
 <3> The content of the `privatepkcs8-stripped.pem` file, which was Base64-encoded when the file was generated.
 <4> The content of the `bitbucket-consumer-key` file, which you manually encoded to Base64.
 <5> The content of the `bitbucket-shared-secret` file, which you manually encoded to Base64.
-+
-[IMPORTANT]
-====
-The content of the `privatepkcs8-stripped.pem` file is already Base64 encoded, so no need to run the `echoo <file-content> | base64` command, like for the `consumer-key` and `shared-secret` files.
-====
 
 . Apply the Secret:
 +

--- a/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
@@ -15,8 +15,8 @@ Prepare and apply the application link Secret for the Bitbucket Server.
 
 * The following files, which were created when setting up the application link, are prepared:
 ** `privatepkcs8-stripped.pem`
-** Base64-encoded `bitbucket-consumer-key`
-** Base64-encoded `bitbucket-shared-secret`
+** `bitbucket-consumer-key`
+** `bitbucket-shared-secret`
 
 * An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 

--- a/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_applying-an-application-link-secret-for-the-bitbucket-server.adoc
@@ -22,6 +22,20 @@ Prepare and apply the application link Secret for the Bitbucket Server.
 
 .Procedure
 
+. Encode the content of the `bitbucket-consumer-key` file to Base64 for use when applying the application link Secret for the Bitbucket Server:
++
+[subs="+quotes,+attributes,+macros"]
+----
+$ echo -n '__<bitbucket-consumer-key file content>__' | base64
+----
+
+. Encode the content of the `bitbucket-shared-secret` file to Base64 for use when applying the application link Secret for the Bitbucket Server:
++
+[subs="+quotes,+attributes,+macros"]
+----
+$ echo -n '__<bitbucket-shared-secret file content>__' | base64
+----
+
 . Prepare the Secret:
 +
 [source,yaml,subs="+quotes,+attributes,+macros"]

--- a/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
@@ -53,7 +53,7 @@ $ echo -n '__<bitbucket-consumer-key file content>__' | base64
 
 . Paste the content of the `bitbucket-shared-secret` file as the *Shared secret*.
 
-. Encode the content of the `bitbucket-shared-secret` file to Base64 for use when applying the Bitbucket Server OAuth Secret:
+. Encode the content of the `bitbucket-shared-secret` file to Base64 for use when applying the application link Secret for the Bitbucket Server:
 +
 [subs="+quotes,+attributes,+macros"]
 ----

--- a/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
@@ -44,7 +44,7 @@ openssl rand -base64 24 > bitbucket-shared-secret
 
 . Paste the content of the `bitbucket-consumer-key` file as the *Consumer key*.
 
-. Encode the content of the `bitbucket-consumer-key` file to Base64 for use when applying the Bitbucket Server OAuth Secret:
+. Encode the content of the `bitbucket-consumer-key` file to Base64 for use when applying the application link Secret for the Bitbucket Server:
 +
 [subs="+quotes,+attributes,+macros"]
 ----

--- a/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
@@ -17,7 +17,7 @@ Set up an application link for OAuth 1.0 on the Bitbucket Server.
 
 .Procedure
 
-. On a command line, run the commands to create the Base64-encoded files for the next steps and for use when applying the application link Secret:
+. On a command line, run the commands to create the necessary files for the next steps and for use when applying the application link Secret:
 +
 [subs="+quotes,+attributes,+macros"]
 ----

--- a/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
@@ -44,7 +44,21 @@ openssl rand -base64 24 > bitbucket-shared-secret
 
 . Paste the content of the `bitbucket-consumer-key` file as the *Consumer key*.
 
+. Encode the content of the `bitbucket-consumer-key` file to Base64 for use when applying the Bitbucket Server OAuth Secret:
++
+[subs="+quotes,+attributes,+macros"]
+----
+$ echo -n '__<bitbucket-consumer-key file content>__' | base64
+----
+
 . Paste the content of the `bitbucket-shared-secret` file as the *Shared secret*.
+
+. Encode the content of the `bitbucket-shared-secret` file to Base64 for use when applying the Bitbucket Server OAuth Secret:
++
+[subs="+quotes,+attributes,+macros"]
+----
+$ echo -n '__<bitbucket-shared-secret file content>__' | base64
+----
 
 . Enter `__<bitbucket_server_url>__/plugins/servlet/oauth/request-token` as the *Request Token URL*.
 

--- a/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
@@ -44,21 +44,7 @@ openssl rand -base64 24 > bitbucket-shared-secret
 
 . Paste the content of the `bitbucket-consumer-key` file as the *Consumer key*.
 
-. Encode the content of the `bitbucket-consumer-key` file to Base64 for use when applying the application link Secret for the Bitbucket Server:
-+
-[subs="+quotes,+attributes,+macros"]
-----
-$ echo -n '__<bitbucket-consumer-key file content>__' | base64
-----
-
 . Paste the content of the `bitbucket-shared-secret` file as the *Shared secret*.
-
-. Encode the content of the `bitbucket-shared-secret` file to Base64 for use when applying the application link Secret for the Bitbucket Server:
-+
-[subs="+quotes,+attributes,+macros"]
-----
-$ echo -n '__<bitbucket-shared-secret file content>__' | base64
-----
 
 . Enter `__<bitbucket_server_url>__/plugins/servlet/oauth/request-token` as the *Request Token URL*.
 

--- a/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
@@ -17,7 +17,7 @@ Set up an application link for OAuth 1.0 on the Bitbucket Server.
 
 .Procedure
 
-. On a command line, run the commands to create the necessary files for the next steps and for use when applying the application link Secret:
+. On a command line, run the commands to create the Base64-encoded files for the next steps and for use when applying the application link Secret:
 +
 [subs="+quotes,+attributes,+macros"]
 ----


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Fix the Bitbucket Server oAuth1 configuration instruction to be more accurate with Base64 encoding. The script generates `privatepkcs8-stripped.pem` file which content is already `Base64` encoded, but the `bitbucket-consumer-key` and `bitbucket-shared-secret` files need to be manually `Base64` encoded, because both original and encoded content is used.
![screenshot-0 0 0 0_4000-2023 05 30-12_25_25](https://github.com/eclipse-che/che-docs/assets/7668752/daed909e-b6ef-46bf-9999-9190aa4d5aaf)
![screenshot-0 0 0 0_4000-2023 05 30-12_26_14](https://github.com/eclipse-che/che-docs/assets/7668752/2a02a96c-f844-47ce-8ffa-fd8a8c385040)

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-4343
## Specify the version of the product this pull request applies to
next
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
