### PR TITLE
Update remaining references to "Visual Studio Code" with addition of "- Open Source"

### DIFF
--- a/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
+++ b/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
@@ -7,7 +7,7 @@
 [id="configuring-the-open-vsx-registry-url"]
 = Configuring the Open VSX registry URL
 
-To search and install extensions, the Visual Studio Code - Open Source editor uses an embedded Open VSX registry instance.
+To search and install extensions, the Microsoft Visual Studio Code - Open Source editor uses an embedded Open VSX registry instance.
 You can also configure {prod-short} to use another Open VSX registry instance rather than the embedded one.
 
 .Procedure

--- a/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
+++ b/modules/administration-guide/pages/configuring-the-open-vsx-registry-url.adoc
@@ -7,7 +7,7 @@
 [id="configuring-the-open-vsx-registry-url"]
 = Configuring the Open VSX registry URL
 
-To search and install extensions, the Visual Studio Code editor uses an embedded Open VSX registry instance.
+To search and install extensions, the Visual Studio Code - Open Source editor uses an embedded Open VSX registry instance.
 You can also configure {prod-short} to use another Open VSX registry instance rather than the embedded one.
 
 .Procedure

--- a/modules/end-user-guide/pages/viewing-language-servers-and-debug-adapters-logs-in-visual-studio-code.adoc
+++ b/modules/end-user-guide/pages/viewing-language-servers-and-debug-adapters-logs-in-visual-studio-code.adoc
@@ -7,7 +7,7 @@
 [id="viewing-language-servers-and-debug-adapters-logs-in-visual-studio-code"]
 = Viewing language server and debug adapter logs in Visual Studio Code - Open Source
 
-In the Visual Studio Code - Open Source editor running in your workspace,
+In the Microsoft Visual Studio Code - Open Source editor running in your workspace,
 you can configure the installed language server and debug adapter extensions to view their logs.
 
 .Procedure

--- a/modules/end-user-guide/pages/viewing-language-servers-and-debug-adapters-logs-in-visual-studio-code.adoc
+++ b/modules/end-user-guide/pages/viewing-language-servers-and-debug-adapters-logs-in-visual-studio-code.adoc
@@ -5,7 +5,7 @@
 :page-aliases:
 
 [id="viewing-language-servers-and-debug-adapters-logs-in-visual-studio-code"]
-= Viewing language server and debug adapter logs in Visual Studio Code - Open Source
+= Viewing language server and debug adapter logs in Microsoft Visual Studio Code - Open Source
 
 In the Microsoft Visual Studio Code - Open Source editor running in your workspace,
 you can configure the installed language server and debug adapter extensions to view their logs.

--- a/modules/end-user-guide/pages/viewing-language-servers-and-debug-adapters-logs-in-visual-studio-code.adoc
+++ b/modules/end-user-guide/pages/viewing-language-servers-and-debug-adapters-logs-in-visual-studio-code.adoc
@@ -5,9 +5,9 @@
 :page-aliases:
 
 [id="viewing-language-servers-and-debug-adapters-logs-in-visual-studio-code"]
-= Viewing language server and debug adapter logs in Visual Studio Code
+= Viewing language server and debug adapter logs in Visual Studio Code - Open Source
 
-In the Visual Studio Code editor running in your workspace,
+In the Visual Studio Code - Open Source editor running in your workspace,
 you can configure the installed language server and debug adapter extensions to view their logs.
 
 .Procedure


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

Updates two references to "Visual Studio Code" to conform with new naming rules. There are still mentions of simply "Visual Studio Code" in the docs, but in the context they appear, it does not make sense to append "- Open Source" after them.

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
