### PR TITLE
chore: Set SHELL env var in devfile.yaml to allow terminal use

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -30,6 +30,9 @@ components:
           protocol: http
           targetPort: 4000
       image: "quay.io/eclipse/che-docs:next"
+      env:
+        - name: SHELL
+          value: /bin/bash
       memoryLimit: 2Gi
       memoryRequest: 256Mi
 commands:


### PR DESCRIPTION
## What does this pull request change?
The 'quay.io/eclipse/che-docs:next' image does not use the usual entrypoint (that adds an entry to /etc/passwd). As a result, the default shell for the current user on OpenShift is /sbin/nologin, which prevents opening terminal in the Code editor.

Since the image has Bash 5.2 installed, we can set the SHELL environment variable, which will cause Code to use that shell for terminals.

## What issues does this pull request fix or reference?
N/A, maintenance.

## Specify the version of the product this pull request applies to
N/A

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
