### PR TITLE
procedures: Add caution against installing operators in separate namespaces

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -26,7 +26,7 @@ asciidoc:
     che-plugin-registry-directory: che-plugin-registry
     devworkspace-operator-index-disconnected-install: quay.io/devfile/devworkspace-operator-index:release-digest
     devworkspace-operator-version-patch: "0.21.1"
-    devworkspace: Dev Workspace
+    devworkspace: DevWorkspace
     devworkspace-id: devworkspace
     docker-cli: docker
     hosted-che-docs: xref:hosted-che:hosted-che.adoc[]

--- a/modules/administration-guide/pages/installing-che-on-openshift-using-the-web-console.adoc
+++ b/modules/administration-guide/pages/installing-che-on-openshift-using-the-web-console.adoc
@@ -24,6 +24,8 @@ If you have trouble xref:installing-che-on-openshift-using-cli.adoc[installing {
 . Install the {prod} Operator.
 +
 TIP: See link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admin/olm-adding-operators-to-cluster.html#olm-installing-from-operatorhub-using-web-console_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the web console].
++
+CAUTION: The {prod} Operator depends on the {devworkspace} Operator. If you install the {prod} Operator manually to a non-default namespace, ensure that the {devworkspace} Operator is also installed in the same namespace. This is required as the Operator Lifecycle Manager will attempt to install the {devworkspace} Operator as a dependency within the {prod} Operator namespace, potentially resulting in two conflicting installations of the {devworkspace} Operator if the latter is installed in a different namespace.
 
 . Create the `{prod-namespace}` project in OpenShift as follows:
 +


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Add a warning to the installation docs to warn against installing the {prod} Operator in a different namespace than the {devworkspace} Operator (operator and any operators it depends on must be in the same namespace).

In addition, update the {devworkspace} variable to reflect accurate name for DevWorkspace (no space between Dev Workspace).

![2023-07-05-15:37:37](https://github.com/eclipse-che/che-docs/assets/16168279/c1b07bec-eca8-460d-bb09-8280af4ae1d0)


## What issues does this pull request fix or reference?
[CRW-4522](https://issues.redhat.com/browse/CRW-4522)

## Specify the version of the product this pull request applies to
next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
