### PR TITLE
fix: Installing Eclipse Che in disconnected cluster

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -24,7 +24,7 @@ asciidoc:
     ocp4-ver: "4.12"
     # for the project
     che-plugin-registry-directory: che-plugin-registry
-    devworkspace-operator-index: registry.redhat.io/redhat/redhat-operator-index:v{ocp4-ver}
+    devworkspace-operator-index: quay.io/devfile/devworkspace-operator-index:release
     devworkspace-operator-version-patch: "0.20.0"
     devworkspace: Dev Workspace
     devworkspace-id: devworkspace

--- a/antora.yml
+++ b/antora.yml
@@ -25,7 +25,7 @@ asciidoc:
     # for the project
     che-plugin-registry-directory: che-plugin-registry
     devworkspace-operator-index-disconnected-install: quay.io/devfile/devworkspace-operator-index:release-digest
-    devworkspace-operator-version-patch: "0.21.2"
+    devworkspace-operator-version-patch: "0.21.1"
     devworkspace: Dev Workspace
     devworkspace-id: devworkspace
     docker-cli: docker

--- a/antora.yml
+++ b/antora.yml
@@ -100,8 +100,8 @@ asciidoc:
     prod-upstream: Eclipse&#160;Che
     prod-url: "https://__&lt;che_fqdn&gt;__"
     prod-ver-major: "7"
-    prod-ver-patch: "7.70.0"
-    prod-ver: "7.70"
+    prod-ver-patch: "7.71.0"
+    prod-ver: "7.71"
     prod-workspace: che-ws
     prod: Eclipse&#160;Che
     prod2: Eclipse&#160;Che

--- a/antora.yml
+++ b/antora.yml
@@ -24,8 +24,8 @@ asciidoc:
     ocp4-ver: "4.12"
     # for the project
     che-plugin-registry-directory: che-plugin-registry
-    devworkspace-operator-index: quay.io/devfile/devworkspace-operator-index:release
-    devworkspace-operator-version-patch: "0.20.0"
+    devworkspace-operator-index-disconnected-install: quay.io/devfile/devworkspace-operator-index:release-digest
+    devworkspace-operator-version-patch: "0.21.2"
     devworkspace: Dev Workspace
     devworkspace-id: devworkspace
     docker-cli: docker
@@ -100,8 +100,8 @@ asciidoc:
     prod-upstream: Eclipse&#160;Che
     prod-url: "https://__&lt;che_fqdn&gt;__"
     prod-ver-major: "7"
-    prod-ver-patch: "7.67.0"
-    prod-ver: "7.67"
+    prod-ver-patch: "7.70.0"
+    prod-ver: "7.70"
     prod-workspace: che-ws
     prod: Eclipse&#160;Che
     prod2: Eclipse&#160;Che

--- a/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
+++ b/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
@@ -33,10 +33,11 @@ declare prod_operator_version="${prod_operator_version:?Define the variable}"
 
 # Destination registry
 declare my_registry="${my_registry:?Define the variable}"
-declare my_catalog=${prod_operator_package_name}-disconnected-install
-declare k8s_resource_name=${my_catalog}
 declare my_operator_index_image_name_and_tag=${prod_operator_package_name}-index:${prod_operator_version}
 declare my_operator_index="${my_registry}/${prod_operator_package_name}/${my_operator_index_image_name_and_tag}"
+
+declare my_catalog=${prod_operator_package_name}-disconnected-install
+declare k8s_resource_name=${my_catalog}
 
 # Create local directories
 mkdir -p "${my_catalog}/${devworkspace_operator_package_name}" "${my_catalog}/${prod_operator_package_name}"
@@ -106,7 +107,8 @@ while IFS= read -r line
 do
   public_image=$(echo "${line}" | cut -d '=' -f1)
   private_image=$(echo "${line}" | cut -d '=' -f2)
-  skopeo copy --preserve-digests --all "docker://$public_image" "docker://$private_image"
+  echo "Mirroring ${public_image}"
+  skopeo copy --dest-tls-verify=false --preserve-digests --all "docker://$public_image" "docker://$private_image"
 done < "${MANIFESTS_FOLDER}/mapping.txt"
 
 echo "Creating CatalogSource and ImageContentSourcePolicy"

--- a/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
+++ b/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
@@ -42,7 +42,7 @@ declare k8s_resource_name=${my_catalog}
 # Create local directories
 mkdir -p "${my_catalog}/${devworkspace_operator_package_name}" "${my_catalog}/${prod_operator_package_name}"
 
-echo "Fetching metadata for the ${devworkspace_operator_package_name} operator catalog channel, packages, and bundles."
+echo "[INFO] Fetching metadata for the ${devworkspace_operator_package_name} operator catalog channel, packages, and bundles."
 opm render "${devworkspace_operator_index}" \
   | jq "select \
     (\
@@ -55,7 +55,7 @@ opm render "${devworkspace_operator_index}" \
       |= [{name: \"${devworkspace_operator_package_name}.${devworkspace_operator_version}\"}]" \
   > "${my_catalog}/${devworkspace_operator_package_name}/render.json"
 
-echo "Fetching metadata for the ${prod_operator_package_name} operator catalog channel, packages, and bundles."
+echo "[INFO] Fetching metadata for the ${prod_operator_package_name} operator catalog channel, packages, and bundles."
 opm render "${prod_operator_index}" \
   | jq "select \
     (\
@@ -68,20 +68,20 @@ opm render "${prod_operator_index}" \
       |= [{name: \"${prod_operator_package_name}.${prod_operator_version}\"}]" \
   > "${my_catalog}/${prod_operator_package_name}/render.json"
 
-echo "Creating the catalog dockerfile."
+echo "[INFO] Creating the catalog dockerfile."
 if [ -f "${my_catalog}.Dockerfile" ]; then
   rm -f "${my_catalog}.Dockerfile"
 fi
 opm alpha generate dockerfile "./${my_catalog}"
 
-echo "Building the catalog image locally."
+echo "[INFO] Building the catalog image locally."
 podman build -t "${my_operator_index}" -f "./${my_catalog}.Dockerfile" --no-cache .
 
-echo "Disabling the default Red Hat Ecosystem Catalog."
+echo "[INFO] Disabling the default Red Hat Ecosystem Catalog."
 oc patch OperatorHub cluster --type json \
     --patch '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
 
-echo "Deploying your catalog image to the $my_operator_index registry."
+echo "[INFO] Deploying your catalog image to the $my_operator_index registry."
 # See: https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-installation-images.html#olm-mirroring-catalog_installing-mirroring-installation-images
 skopeo copy --dest-tls-verify=false --all "containers-storage:$my_operator_index" "docker://$my_operator_index"
 
@@ -95,24 +95,24 @@ spec:
       openVSXURL: ""
 EOF
 
-echo "Removing index image from mappings.txt to prepare mirroring."
+echo "[INFO] Removing index image from mappings.txt to prepare mirroring."
 oc adm catalog mirror "$my_operator_index" "$my_registry" --insecure --manifests-only | tee catalog_mirror.log
 MANIFESTS_FOLDER=$(sed -n -e 's/^wrote mirroring manifests to \(.*\)$/\1/p' catalog_mirror.log |xargs) # The xargs here is to trim whitespaces
 sed -i -e "/${my_operator_index_image_name_and_tag}/d" "${MANIFESTS_FOLDER}/mapping.txt"
 cat "${MANIFESTS_FOLDER}/mapping.txt"
 
-echo "Mirroring related images to the $my_registry registry."
+echo "[INFO] Mirroring related images to the $my_registry registry."
 # oc image mirror --insecure=true -f "${MANIFESTS_FOLDER}/mapping.txt"
 while IFS= read -r line
 do
   public_image=$(echo "${line}" | cut -d '=' -f1)
   private_image=$(echo "${line}" | cut -d '=' -f2)
-  echo "Mirroring ${public_image}"
+  echo "[INFO] Mirroring ${public_image}"
   skopeo copy --dest-tls-verify=false --preserve-digests --all "docker://$public_image" "docker://$private_image"
 done < "${MANIFESTS_FOLDER}/mapping.txt"
 
-echo "Creating CatalogSource and ImageContentSourcePolicy"
+echo "[INFO] Creating CatalogSource and ImageContentSourcePolicy"
 cat ${MANIFESTS_FOLDER}/catalogSource.yaml | sed 's|name: .*|name: '${k8s_resource_name}'|' | oc apply -f -
 cat ${MANIFESTS_FOLDER}/imageContentSourcePolicy.yaml | sed 's|name: .*|name: '${k8s_resource_name}'|' | oc apply -f -
 
-echo "INFO: Catalog $my_operator_index deployed to the $my_registry registry."
+echo "[INFO] Catalog $my_operator_index deployed to the $my_registry registry."

--- a/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
+++ b/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
@@ -101,22 +101,12 @@ sed -i -e "/${my_operator_index_image_name_and_tag}/d" "${MANIFESTS_FOLDER}/mapp
 cat "${MANIFESTS_FOLDER}/mapping.txt"
 
 echo "Mirroring related images to the $my_registry registry."
-oc image mirror --insecure=true -f "${MANIFESTS_FOLDER}/mapping.txt"
-
-# Use skopeo for non Red Hat registries to preserve the original digest
+# oc image mirror --insecure=true -f "${MANIFESTS_FOLDER}/mapping.txt"
 while IFS= read -r line
 do
-  images=(
-    $(echo $line | tr "=" "\n")
-  )
-
-  public_image=${images[1]}
-  private_image=${images[2]}
-
-  if [[ ! $public_image =~ ^quay.io ]] && [[ ! $public_image =~ ^registry.redhat.io ]]; then
-    echo "Preserving digest for $public_image"
-    skopeo copy --preserve-digests --all "docker://$public_image" "docker://$private_image"
-  fi
+  public_image=$(echo "${line}" | cut -d '=' -f1)
+  private_image=$(echo "${line}" | cut -d '=' -f2)
+  skopeo copy --preserve-digests --all "docker://$public_image" "docker://$private_image"
 done < "${MANIFESTS_FOLDER}/mapping.txt"
 
 echo "Creating CatalogSource and ImageContentSourcePolicy"

--- a/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
+++ b/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
@@ -29,6 +29,7 @@ declare devworkspace_operator_package_name="devworkspace-operator"
 declare devworkspace_operator_version="${devworkspace_operator_version:?Define the variable}"
 declare prod_operator_index="${prod_operator_index:?Define the variable}"
 declare prod_operator_package_name="${prod_operator_package_name:?Define the variable}"
+declare prod_operator_bundle_name="${prod_operator_bundle_name:?Define the variable}"
 declare prod_operator_version="${prod_operator_version:?Define the variable}"
 
 # Destination registry
@@ -59,13 +60,13 @@ echo "[INFO] Fetching metadata for the ${prod_operator_package_name} operator ca
 opm render "${prod_operator_index}" \
   | jq "select \
     (\
-      (.schema == \"olm.bundle\" and .name == \"${prod_operator_package_name}.${prod_operator_version}\") or \
+      (.schema == \"olm.bundle\" and .name == \"${prod_operator_bundle_name}.${prod_operator_version}\") or \
       (.schema == \"olm.package\" and .name == \"${prod_operator_package_name}\") or \
       (.schema == \"olm.channel\" and .package == \"${prod_operator_package_name}\") \
     )" \
   | jq "select \
      (.schema == \"olm.channel\" and .package == \"${prod_operator_package_name}\").entries \
-      |= [{name: \"${prod_operator_package_name}.${prod_operator_version}\"}]" \
+      |= [{name: \"${prod_operator_bundle_name}.${prod_operator_version}\"}]" \
   > "${my_catalog}/${prod_operator_package_name}/render.json"
 
 echo "[INFO] Creating the catalog dockerfile."

--- a/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
+++ b/modules/administration-guide/attachments/restricted-environment/prepare-restricted-environment.sh
@@ -23,9 +23,6 @@ done
 # Display commands
 # set -x
 
-# OpenShift cluster version
-declare ocp_ver="${ocp_ver:?Define the variable}"
-
 # Operators
 declare devworkspace_operator_index="${devworkspace_operator_index:?Define the variable}"
 declare devworkspace_operator_package_name="devworkspace-operator"
@@ -36,26 +33,36 @@ declare prod_operator_version="${prod_operator_version:?Define the variable}"
 
 # Destination registry
 declare my_registry="${my_registry:?Define the variable}"
-declare my_catalog="${my_catalog:-restricted-environment-install}"
-declare my_operator_index="$my_registry/$my_catalog/my-operator-index:v${ocp_ver}"
+declare my_catalog=restricted-environment-install
+declare my_operator_index="$my_registry/$my_catalog/my-operator-index:latest"
 
 # Create local directories
 mkdir -p "${my_catalog}/${devworkspace_operator_package_name}" "${my_catalog}/${prod_operator_package_name}"
 
 echo "Fetching metadata for the ${devworkspace_operator_package_name} operator catalog channel, packages, and bundles."
 opm render "${devworkspace_operator_index}" \
-  | jq "select(\
-    .name == \"${devworkspace_operator_package_name}.${devworkspace_operator_version}\" \
-    and .schema == \"olm.bundle\" \
+  | jq "select \
+    (\
+      (.schema == \"olm.bundle\" and .name == \"${devworkspace_operator_package_name}.${devworkspace_operator_version}\") or \
+      (.schema == \"olm.package\" and .name == \"${devworkspace_operator_package_name}\") or \
+      (.schema == \"olm.channel\" and .package == \"${devworkspace_operator_package_name}\") \
     )" \
+  | jq "select \
+     (.schema == \"olm.channel\" and .package == \"${devworkspace_operator_package_name}\").entries \
+      |= [{name: \"${devworkspace_operator_package_name}.${devworkspace_operator_version}\"}]" \
   > "${my_catalog}/${devworkspace_operator_package_name}/render.json"
 
 echo "Fetching metadata for the ${prod_operator_package_name} operator catalog channel, packages, and bundles."
 opm render "${prod_operator_index}" \
-  | jq "select(\
-    .name == \"${prod_operator_package_name}.${prod_operator_version}\" \
-    and .schema == \"olm.bundle\" \
+  | jq "select \
+    (\
+      (.schema == \"olm.bundle\" and .name == \"${prod_operator_package_name}.${prod_operator_version}\") or \
+      (.schema == \"olm.package\" and .name == \"${prod_operator_package_name}\") or \
+      (.schema == \"olm.channel\" and .package == \"${prod_operator_package_name}\") \
     )" \
+  | jq "select \
+     (.schema == \"olm.channel\" and .package == \"${prod_operator_package_name}\").entries \
+      |= [{name: \"${prod_operator_package_name}.${prod_operator_version}\"}]" \
   > "${my_catalog}/${prod_operator_package_name}/render.json"
 
 echo "Creating the catalog dockerfile."
@@ -73,42 +80,45 @@ oc patch OperatorHub cluster --type json \
 
 echo "Deploying your catalog image to the $my_operator_index registry."
 # See: https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-installation-images.html#olm-mirroring-catalog_installing-mirroring-installation-images
-oc delete project "$my_catalog" --grace-period=1 --ignore-not-found=true
-oc wait --for=delete "project/$my_catalog"
-sleep 5
-oc new-project "$my_catalog"
 skopeo copy --dest-tls-verify=false --all "containers-storage:$my_operator_index" "docker://$my_operator_index"
-
-echo "Deploying your catalog source to the OpenShift cluster."
-# See: https://docs.openshift.com/container-platform/latest/operators/admin/olm-restricted-networks.html#olm-creating-catalog-from-index_olm-restricted-networks
-oc apply -f - << EOF
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: $my_catalog
-  namespace: openshift-marketplace
-spec:
-  sourceType: grpc
-  image: $my_operator_index
-EOF
 
 echo "Creating the 'che-operator-cr-patch.yaml' file locally."
 cat > che-operator-cr-patch.yaml << EOF
 kind: CheCluster
 apiVersion: org.eclipse.che/v2
 spec:
-  containerRegistry:
-    hostname: "$my_registry"
-    organization: "$my_catalog"
+  components:
+    pluginRegistry:
+      openVSXURL: ""
 EOF
 
 echo "Removing index image from mappings.txt to prepare mirroring."
 oc adm catalog mirror "$my_operator_index" "$my_registry" --insecure --manifests-only | tee catalog_mirror.log
 MANIFESTS_FOLDER=$(sed -n -e 's/^wrote mirroring manifests to \(.*\)$/\1/p' catalog_mirror.log |xargs) # The xargs here is to trim whitespaces
-sed -i -e "/my-operator-index:v${ocp_ver}/d" "${MANIFESTS_FOLDER}/mapping.txt"
+sed -i -e "/my-operator-index:latest/d" "${MANIFESTS_FOLDER}/mapping.txt"
 cat "${MANIFESTS_FOLDER}/mapping.txt"
 
 echo "Mirroring related images to the $my_registry registry."
 oc image mirror --insecure=true -f "${MANIFESTS_FOLDER}/mapping.txt"
+
+# Use skopeo for non Red Hat registries to preserve the original digest
+while IFS= read -r line
+do
+  images=(
+    $(echo $line | tr "=" "\n")
+  )
+
+  public_image=${images[1]}
+  private_image=${images[2]}
+
+  if [[ ! $public_image =~ ^quay.io ]] && [[ ! $public_image =~ ^registry.redhat.io ]]; then
+    echo "Preserving digest for $public_image"
+    skopeo copy --preserve-digests --all "docker://$public_image" "docker://$private_image"
+  fi
+done < "${MANIFESTS_FOLDER}/mapping.txt"
+
+echo "Creating CatalogSource and ImageContentSourcePolicy"
+cat ${MANIFESTS_FOLDER}/catalogSource.yaml | oc apply -f -
+cat ${MANIFESTS_FOLDER}/imageContentSourcePolicy.yaml | oc apply -f -
 
 echo "INFO: Catalog $my_operator_index deployed to the $my_registry registry."

--- a/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
+++ b/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
@@ -27,6 +27,7 @@ include::partial$snip_preparing-images-for-a-restricted-environment.adoc[]
 ----
 $ {prod-cli} server:deploy \
   --platform=openshift \
+  --olm-channel stable \
   --catalog-source-name={prod-operator-package-name}-disconnected-install \
   --catalog-source-namespace=openshift-marketplace \
   --skip-devworkspace-operator \

--- a/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
+++ b/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
@@ -25,7 +25,11 @@ include::partial$snip_preparing-images-for-a-restricted-environment.adoc[]
 +
 [subs="+attributes,+quotes"]
 ----
-$ {prod-cli} server:deploy --platform=openshift \
+$ {prod-cli} server:deploy \
+  --platform=openshift \
+  --catalog-source-name=restricted-environment-install \
+  --catalog-source-namespace=openshift-marketplace \
+  --skip-devworkspace-operator \
   --che-operator-cr-patch-yaml=che-operator-cr-patch.yaml
 ----
 

--- a/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
+++ b/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
@@ -27,7 +27,7 @@ include::partial$snip_preparing-images-for-a-restricted-environment.adoc[]
 ----
 $ {prod-cli} server:deploy \
   --platform=openshift \
-  --catalog-source-name=restricted-environment-install \
+  --catalog-source-name={prod-operator-package-name}-disconnected-install \
   --catalog-source-namespace=openshift-marketplace \
   --skip-devworkspace-operator \
   --che-operator-cr-patch-yaml=che-operator-cr-patch.yaml

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -26,7 +26,7 @@
 
 * `skopeo` version 1.6 or higher. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo].
 
-* An active `skopeo` session with administrative access to the private docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.openshift.com/container-platform/{ocp4-ver}/installing/disconnected_install/installing-mirroring-installation-images.html[Mirroring images for a disconnected installation].
+* An active `skopeo` session with administrative access to the private Docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.openshift.com/container-platform/{ocp4-ver}/installing/disconnected_install/installing-mirroring-installation-images.html[Mirroring images for a disconnected installation].
 
 ----
 $ bash prepare-restricted-environment.sh \
@@ -37,5 +37,5 @@ $ bash prepare-restricted-environment.sh \
   --prod_operator_version "v{prod-ver-patch}" \
   --my_registry "__<my_registry>__" <1>
 ----
-<1> The private docker registry where the images will be mirrored
+<1> The private Docker registry where the images will be mirrored
 

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -35,7 +35,7 @@ $ bash prepare-restricted-environment.sh \
   --devworkspace_operator_version "v{devworkspace-operator-version-patch}" \
   --prod_operator_index "{prod-operator-index}" \
   --prod_operator_package_name "{prod-operator-package-name}" \
-  --prod_operator_bundle_name "{prod-operator-bundle-name} \
+  --prod_operator_bundle_name "{prod-operator-bundle-name}" \
   --prod_operator_version "v{prod-ver-patch}" \
   --my_registry "__<my_registry>__" <1>
 ----

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -24,22 +24,18 @@
 
 * `podman`. See link:https://podman.io/docs/installation[Podman Installation Instructions].
 
-* An active `skopeo` session with administrative access to the __<my_registry>__ registry. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo], link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.openshift.com/container-platform/{ocp4-ver}/installing/disconnected_install/installing-mirroring-installation-images.html[Mirroring images for a disconnected installation].
+* `skopeo` version 1.6 or higher. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo].
 
-* `{prod-cli}` for {prod-short} version {prod-ver}. See xref:installing-the-chectl-management-tool.adoc[].
+* An active `skopeo` session with administrative access to the private docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.openshift.com/container-platform/{ocp4-ver}/installing/disconnected_install/installing-mirroring-installation-images.html[Mirroring images for a disconnected installation].
 
-.Procedure
-
-. Download and execute the mirroring script to install a custom Operator catalog and mirror the related images: xref:attachment$restricted-environment/prepare-restricted-environment.sh[prepare-restricted-environment.sh].
-+
-[subs="+attributes,+quotes"]
 ----
 $ bash prepare-restricted-environment.sh \
-  --devworkspace_operator_index "{devworkspace-operator-index}" \
+  --devworkspace_operator_index {devworkspace-operator-index-disconnected-install}\
   --devworkspace_operator_version "v{devworkspace-operator-version-patch}" \
   --prod_operator_index "{prod-operator-index}" \
   --prod_operator_package_name "{prod-operator-package-name}" \
   --prod_operator_version "v{prod-ver-patch}" \
-  --my_registry "__<my_registry>__"
+  --my_registry "__<my_registry>__" <1>
 ----
+<1> The private docker registry where the images will be mirrored
 

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -27,7 +27,8 @@
 * `skopeo` version 1.6 or higher. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo].
 
 * An active `skopeo` session with administrative access to the private Docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.openshift.com/container-platform/{ocp4-ver}/installing/disconnected_install/installing-mirroring-installation-images.html[Mirroring images for a disconnected installation].
-
++
+[subs="+attributes,+quotes"]
 ----
 $ bash prepare-restricted-environment.sh \
   --devworkspace_operator_index {devworkspace-operator-index-disconnected-install}\

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -34,6 +34,7 @@ $ bash prepare-restricted-environment.sh \
   --devworkspace_operator_version "v{devworkspace-operator-version-patch}" \
   --prod_operator_index "{prod-operator-index}" \
   --prod_operator_package_name "{prod-operator-package-name}" \
+  --prod_operator_bundle_name "{prod-operator-bundle-name} \
   --prod_operator_version "v{prod-ver-patch}" \
   --my_registry "__<my_registry>__" <1>
 ----

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -35,13 +35,11 @@
 [subs="+attributes,+quotes"]
 ----
 $ bash prepare-restricted-environment.sh \
-  --ocp_ver "{ocp4-ver}" \
   --devworkspace_operator_index "{devworkspace-operator-index}" \
   --devworkspace_operator_version "v{devworkspace-operator-version-patch}" \
   --prod_operator_index "{prod-operator-index}" \
   --prod_operator_package_name "{prod-operator-package-name}" \
   --prod_operator_version "v{prod-ver-patch}" \
-  --my_registry "__<my_registry>__" \
-  --my_catalog "__<my_catalog>__"
+  --my_registry "__<my_registry>__"
 ----
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
fix: Installing Eclipse Che in disconnected cluster

## What issues does this pull request fix or reference?
https://github.com/eclipse/che/issues/21445

## Specify the version of the product this pull request applies to
7.71 and higher

## Downstreaming notes
`devworkspace-operator-index-disconnected-install: registry.redhat.io/redhat/redhat-operator-index:v{ocp4-ver}`
`prod-operator-bundle-name: devspacesoperator`
`prod-operator-package-name: devspaces`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
