### PR TITLE
docs: Adding a note about GitHub Enterprise Cloud PAT requirement

### DIFF
--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -41,6 +41,14 @@ On OpenShift, you can use the `oc` command-line tool to log in to the cluster:
 
 . Generate your access token on your Git provider's website.
 
++
++
+[IMPORTANT]
+====
+For GitHub Enterprise Cloud, verify that the token is link:https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on[authorized for use within the organization].
+====
++
+
 . Encode your access token to Base64.
 +
 [TIP]
@@ -120,3 +128,4 @@ EOF
 .Additional resources
 
 * xref:administration-guide:deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc[Deploying Che with support for Git repositories with self-signed certificates]
+* link:https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on[Authorizing a personal access token for use with SAML single sign-on]


### PR DESCRIPTION
## What does this pull request change?
docs: Adding a note about GitHub Enterprise Cloud PAT requirement

![image](https://github.com/eclipse-che/che-docs/assets/1461122/d4401a6e-600a-44d7-9d3d-5002a02c9c37)


## What issues does this pull request fix or reference?
Related to https://issues.redhat.com/browse/CRW-4551

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/main/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
