### PR TITLE
fix: Remove https://mattermost.eclipse.org/eclipse/channels/eclipse-c…

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -330,6 +330,3 @@ $ ./tools/runnerpreview.sh
 * https://github.com/eclipse/che/issues/new?labels=area/doc,kind/question[image:https://img.shields.io/badge/New-question-blue.svg?style=flat-curved[Ask a question]]
 
 * https://github.com/eclipse/che/issues/new?labels=area/doc,kind/bug[image:https://img.shields.io/badge/New-bug-red.svg?style=flat-curved[Open a bug]]
-
-.Public Chat
-* Join the public https://mattermost.eclipse.org/eclipse/channels/eclipse-che[eclipse-che Mattermost channel] to talk to the community and contributors.

--- a/RELEASE.adoc
+++ b/RELEASE.adoc
@@ -13,7 +13,7 @@ The publication is decoupled. See link:https://github.com/eclipse-che/che-docs/t
 
 .Prerequisites
 
-* The new release is published on https://github.com/eclipse/che/releases and https://mattermost.eclipse.org/eclipse/channels/eclipse-che-releases.
+* The new release is published on https://github.com/eclipse/che/releases.
 
 .Procedure
 

--- a/modules/overview/pages/introduction-to-eclipse-che.adoc
+++ b/modules/overview/pages/introduction-to-eclipse-che.adoc
@@ -32,10 +32,6 @@
 
 Interested in joining the community? Join us on the following channels:
 
-Public chat::
-
-Join the public link:https://mattermost.eclipse.org/eclipse/channels/eclipse-che[{prod} Mattermost] channel to chat with the developers.
-
 GitHub project repositories::
 
 Report bugs, request features, and contribute in the main link:https://github.com/eclipse/che[{prod} repository].


### PR DESCRIPTION
…he to unblock PR checks


<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Eclipse mattermost channel is not available anymore. 
Remove https://mattermost.eclipse.org/eclipse/channels/eclipse-che to unblock PR checks

## What issues does this pull request fix or reference?
N/A

## Specify the version of the product this pull request applies to
N/A

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [x] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
