### PR TITLE
Exclude the `scm-username` annotation from the PAT instruction

### DIFF
--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -42,12 +42,10 @@ On OpenShift, you can use the `oc` command-line tool to log in to the cluster:
 . Generate your access token on your Git provider's website.
 
 +
-+
 [IMPORTANT]
 ====
 For GitHub Enterprise Cloud, verify that the token is link:https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on[authorized for use within the organization].
 ====
-+
 
 . Encode your access token to Base64.
 +
@@ -76,8 +74,7 @@ metadata:
     che.eclipse.org/che-userid: __<{prod-id-short}_user_id>__# <1>
     che.eclipse.org/scm-personal-access-token-name: _<git_provider_name>_# <2>
     che.eclipse.org/scm-url: __<git_provider_endpoint>__# <3>
-    che.eclipse.org/scm-username: __<git_provider_username>__# <4>
-    che.eclipse.org/scm-organization: __<git_provider_organization>__# <5>
+    che.eclipse.org/scm-organization: __<git_provider_organization>__# <4>
 data:
   token: __<Base64_encoded_access_token>__
 type: Opaque
@@ -86,8 +83,7 @@ type: Opaque
 <1> Your {prod-short} user ID.
 <2> The Git provider name: `github` or `gitlab` or `bitbucket-server` or `azure-devops`.
 <3> The Git provider URL.
-<4> The Git provider username. For `azure-devops`, the user's email address.
-<5> This line is only applicable to `azure-devops`: your Git provider user organization.
+<4> This line is only applicable to `azure-devops`: your Git provider user organization.
 
 . Visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
* Remove the `scm-username` annotation from the PAT instruction as a redundant, see https://github.com/eclipse-che/che-server/pull/533
* fix the `GitHub Enterprise Cloud` Important note:
![screenshot-0 0 0 0_4000-2023 07 21-13_14_45](https://github.com/eclipse-che/che-docs/assets/7668752/74fc9fdd-3169-4448-a527-8c59646e64ec)


**DO NOT MERGE** until the [dependant PR](https://github.com/eclipse-che/che-server/pull/533) is merged

## What issues does this pull request fix or reference?
https://github.com/eclipse/che/issues/22344

## Specify the version of the product this pull request applies to
next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
