### PR TITLE
docs: adding the token verification note to the 'Using a Git-provider access token' section

### DIFF
--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -44,6 +44,22 @@ On OpenShift, you can use the `oc` command-line tool to log in to the cluster:
 +
 [IMPORTANT]
 ====
+Personal access tokens are sensitive information and should be kept confidential. Treat them like passwords. If you are having trouble with authentication, ensure you are using the correct token and have the appropriate permissions for cloning repositories:
+
+. Open a terminal locally on your computer
+. Use the `git` command to clone the repository using your personal access token. The format of the `git` command vary based on the Git Provider. As an example, GitHub personal access token verification can be done using the following command:
+
+----
+git clone https://<PAT>@github.com/username/repo.git
+----
+
+Replace `<PAT>` with your personal access token, and `username/repo` with the appropriate repository path.
+If the token is valid and has the necessary permissions, the cloning process should be successful. Otherwise, this is an indicator of incorrect personal access token, insufficient permissions, or other issues.
+====
+
++
+[IMPORTANT]
+====
 For GitHub Enterprise Cloud, verify that the token is link:https://docs.github.com/en/enterprise-cloud@latest/authentication/authenticating-with-saml-single-sign-on/authorizing-a-personal-access-token-for-use-with-saml-single-sign-on[authorized for use within the organization].
 ====
 


### PR DESCRIPTION
<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Adding the token verification note to the 'Using a Git-provider access token' section - https://64ef2edfa59a110c459b58af--eclipse-che-docs-pr.netlify.app/docs/next/end-user-guide/using-a-git-provider-access-token/

![image](https://github.com/eclipse-che/che-docs/assets/1461122/21883e0f-9b28-444b-b3ac-ef32285c3d08)


## What issues does this pull request fix or reference?

https://github.com/eclipse/che/issues/22359

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
