### PR TITLE
end-user-guide: add tip about VSCode config

### DIFF
--- a/modules/end-user-guide/pages/microsoft-visual-studio-code-open-source-ide.adoc
+++ b/modules/end-user-guide/pages/microsoft-visual-studio-code-open-source-ide.adoc
@@ -27,6 +27,11 @@ You can automate installation of Microsoft Visual Studio Code extensions from th
 
 ====
 
+[TIP]
+====
+Configure IDE preferences on a per-workspace basis by invoking the link:https://code.visualstudio.com/api/ux-guidelines/command-palette[Command Palette] and selecting *Preferences: Open Workspace Settings*.
+====
+
 NOTE: You might see your organization's branding in this IDE if your organization customized it through a branded build.
 
 include::partial$proc_automating-installation-of-microsoft-visual-studio-code-extensions-at-workspace-startup.adoc[leveloffset=+1]


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

Users can configure IDE preferences on a per-workspace basis. This commit adds a small tip showing users how to open the config.

## What issues does this pull request fix or reference?

https://issues.redhat.com/browse/RHDEVDOCS-5099

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
