### PR TITLE
fix: adding empty snippet (crw-4945)

### DIFF
--- a/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
+++ b/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
@@ -37,3 +37,5 @@ $ {prod-cli} server:deploy \
 . Allow incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}s. See: xref:configuring-network-policies.adoc[].
 
 include::partial$snip_installing-che-in-a-restricted-environment-additional-resources.adoc[]
+
+include::example$snip_{project-context}-setting-up-ansible.sample.adoc[]

--- a/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
+++ b/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
@@ -38,4 +38,4 @@ $ {prod-cli} server:deploy \
 
 include::partial$snip_installing-che-in-a-restricted-environment-additional-resources.adoc[]
 
-include::example$snip_{project-context}-setting-up-ansible.sample.adoc[]
+include::example$snip_{project-context}-setting-up-ansible-sample.adoc[]

--- a/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
+++ b/modules/administration-guide/pages/installing-che-in-a-restricted-environment.adoc
@@ -38,4 +38,4 @@ $ {prod-cli} server:deploy \
 
 include::partial$snip_installing-che-in-a-restricted-environment-additional-resources.adoc[]
 
-include::example$snip_{project-context}-setting-up-ansible-sample.adoc[]
+include::partial$snip_{project-context}-setting-up-ansible-sample.adoc[]


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
adding an empty snippet to match downstream content

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-4945

## Specify the version of the product this pull request applies to
7.74.x, 3.9

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
