### PR TITLE
procedures: Add required netpols in isolated environments

### DIFF
--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -44,7 +44,7 @@ spec:
 The default is `{prod-namespace}`.
 <2> The empty `podSelector` selects all Pods in the {orch-namespace}.
 
-* Optional: In case you applied link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy], you additionally must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`. 
+* OPTIONAL: In case you applied link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy], you also must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`. 
 The `allow-from-openshift-apiserver` NetworkPolicy allows incoming traffic from `openshift-apiserver` namespace to the `devworkspace-webhook-server` enabling webhooks.
 The `allow-from-workspaces-namespaces` NetworkPolicy allows incoming traffic from each user project to `che-gateway` pod.
 +

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -74,7 +74,7 @@ spec:
 +
 <1> The {prod-short} namespace.
 The default is `{prod-namespace}`.
-<2> The `podSelector` only selects webhook-server pods
+<2> The `podSelector` only selects devworkspace-webhook-server pods
 +
 .`allow-from-workspaces-namespaces.yaml`
 ====
@@ -102,7 +102,7 @@ spec:
 +
 <1> The {prod-short} namespace.
 The default is `{prod-namespace}`.
-<2> The `podSelector` only selects webhook-server pods
+<2> The `podSelector` only selects che-gateway pods
 
 .Additional resources
 * xref:configuring-namespace-provisioning.adoc[]

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -44,6 +44,66 @@ spec:
 The default is `{prod-namespace}`.
 <2> The empty `podSelector` selects all Pods in the {orch-namespace}.
 
+* Optional: In case you applied link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy], you additionally must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`. 
+The `allow-from-openshift-apiserver` NetworkPolicy allows incoming traffic from `openshift-apiserver` namespace to the `devworkspace-webhook-server` enabling webhooks.
+The `allow-from-workspaces-namespaces` NetworkPolicy allows incoming traffic from each user project to `che-gateway` pod.
++
+.`allow-from-openshift-apiserver.yaml`
+====
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-apiserver
+  namespace: {prod-namespace}   <1>
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: devworkspace-webhook-server   <2>
+  ingress:
+    - from:
+        - podSelector: {}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-apiserver
+  policyTypes:
+    - Ingress
+----
+====
++
+<1> The {prod-short} namespace.
+The default is `{prod-namespace}`.
+<2> The `podSelector` only selects webhook-server pods
++
+.`allow-from-workspaces-namespaces.yaml`
+====
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-workspaces-namespaces
+  namespace: {prod-namespace}   <1>
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: che-gateway   <2>
+  ingress:
+    - from:
+        - podSelector: {}
+          namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/component: workspaces-namespace
+  policyTypes:
+    - Ingress
+----
+====
++
+<1> The {prod-short} namespace.
+The default is `{prod-namespace}`.
+<2> The `podSelector` only selects webhook-server pods
+
 .Additional resources
 * xref:configuring-namespace-provisioning.adoc[]
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Add instructions to apply additional NetworkPolicies in isolated multitenant environments.

## What issues does this pull request fix or reference?
We found out, that on an isolated multitenant Openshift cluster, configured as described in [Configuring multitenant isolation with network policy](https://docs.openshift.com/container-platform/4.12/networking/network_policy/multitenant-network-policy.html) starting devworkspace instances did not work, due to blocked network traffic.
By applying two additional NetworkPolicies the issue could be solved

## Specify the version of the product this pull request applies to
latest

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.

    
    
**Hint**: I was not able to Preview the change as I am running Mac M1:
`./tools/runnerpreview.sh
Error: choosing an image from manifest list docker://quay.io/eclipse/che-docs:next: no image found in image index for architecture arm64, variant "v8", OS linux`