### PR TITLE
Change the disable subdomain isolation property to false

### DIFF
--- a/modules/administration-guide/partials/proc_applying-the-github-oauth-app-secret.adoc
+++ b/modules/administration-guide/partials/proc_applying-the-github-oauth-app-secret.adoc
@@ -36,7 +36,7 @@ metadata:
   annotations:
     che.eclipse.org/oauth-scm-server: github
     che.eclipse.org/scm-server-endpoint: __<github_server_url>__ <2>
-    che.eclipse.org/scm-github-disable-subdomain-isolation: true <3>
+    che.eclipse.org/scm-github-disable-subdomain-isolation: 'false' <3>
 type: Opaque
 stringData:
   id: __<GitHub_OAuth_Client_ID>__ <4>


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
* Change the `disable subdomain isolation` property to `false` as most of GitHub server instances are running with enabled `subdomain isolation` property and it is recommended to enable the `subdomain isolation` in the GitHub setup page. 
* Wrap the `false` value in braces in order to meet the yaml format. 
## What issues does this pull request fix or reference?
fixes https://github.com/eclipse/che/issues/22813

## Specify the version of the product this pull request applies to
next
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
