### PR TITLE
feat: Explain how users can override the editor's container image

### DIFF
--- a/modules/end-user-guide/nav.adoc
+++ b/modules/end-user-guide/nav.adoc
@@ -5,6 +5,7 @@
 *** xref:optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc[]
 **** xref:url-parameter-concatenation.adoc[]
 **** xref:url-parameter-for-the-ide.adoc[]
+**** xref:url-parameter-for-the-ide-image.adoc[]
 **** xref:url-parameter-for-starting-duplicate-workspaces.adoc[]
 **** xref:url-parameter-for-the-devfile-file-name.adoc[]
 **** xref:url-parameter-for-the-devfile-file-path.adoc[]

--- a/modules/end-user-guide/pages/optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc
+++ b/modules/end-user-guide/pages/optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc
@@ -11,6 +11,7 @@ When you start a new workspace, {prod-short} configures the workspace according 
 
 * xref:url-parameter-concatenation.adoc[]
 * xref:url-parameter-for-the-ide.adoc[]
+* xref:url-parameter-for-the-ide-image.adoc[]
 * xref:url-parameter-for-starting-duplicate-workspaces.adoc[]
 * xref:url-parameter-for-the-devfile-file-name.adoc[]
 * xref:url-parameter-for-the-devfile-file-path.adoc[]

--- a/modules/end-user-guide/pages/url-parameter-for-the-ide-image.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-ide-image.adoc
@@ -1,0 +1,28 @@
+:_content-type: CONCEPT
+:description: URL parameter for the IDE image
+:keywords: parameter, URL, IDE, image
+:navtitle: URL parameter for the IDE image
+//:page-aliases:
+
+[id="url-parameter-for-the-ide-image"]
+= URL parameter for the IDE image
+
+You can use the `editor-image` parameter to set the custom IDE image in the following scenarios:
+
+* The Git repository contains no xref:defining-a-common-ide.adoc[`/.che/che-editor.yaml`] file in the source-code, and you want to specify the target IDE with the custom image.
+
+* The Git repository contains xref:defining-a-common-ide.adoc[`/.che/che-editor.yaml`] file in the source-code, and you want to override the first container image listed in the `components` section of the editor's devfile.
+
+The URL parameter to override the IDE image is `editor-image=`:
+
+[source,subs="+quotes,+attributes,+macros"]
+----
+pass:c,a,q[{prod-url}]#__<git_repository_url>__?editor-image=__<image>__
+----
+
+.Example:
+`pass:c,a,q[{prod-url}]#https://github.com/eclipse-che/che-docs?editor-image=quay.io/che-incubator/che-code:next`
+
+or
+
+`pass:c,a,q[{prod-url}]#https://github.com/eclipse-che/che-docs?che-editor=che-incubator/che-code/latest&editor-image=quay.io/che-incubator/che-code:next`

--- a/modules/end-user-guide/pages/url-parameter-for-the-ide-image.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-ide-image.adoc
@@ -7,17 +7,24 @@
 [id="url-parameter-for-the-ide-image"]
 = URL parameter for the IDE image
 
-You can use the `editor-image` parameter to set the custom IDE image in the following scenarios:
+You can use the `editor-image` parameter to set the custom IDE image for the workspace.
 
-* The Git repository contains no xref:defining-a-common-ide.adoc[`/.che/che-editor.yaml`] file in the source-code, and you want to specify the target IDE with the custom image.
+[IMPORTANT]
+====
 
-* The Git repository contains xref:defining-a-common-ide.adoc[`/.che/che-editor.yaml`] file in the source-code, and you want to override the first container image listed in the `components` section of the editor's devfile.
+* If the Git repository contains xref:defining-a-common-ide.adoc[`/.che/che-editor.yaml`] file in the source-code, the custom editor will be overridden with the new IDE image.
+
+* If the Git repository contains no xref:defining-a-common-ide.adoc[`/.che/che-editor.yaml`] file in the source-code, the default editor will be overridden with the new IDE image.
+
+* If you want to override the supported IDE and change the target editor image, you can use both parameters together: `che-editor` and  `editor-image` URL parameters.
+
+====
 
 The URL parameter to override the IDE image is `editor-image=`:
 
 [source,subs="+quotes,+attributes,+macros"]
 ----
-pass:c,a,q[{prod-url}]#__<git_repository_url>__?editor-image=__<image>__
+pass:c,a,q[{prod-url}]#__<git_repository_url>__?editor-image=__<container_registry/image_name:image_tag>__
 ----
 
 .Example:

--- a/modules/end-user-guide/pages/url-parameter-for-the-ide-image.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-ide-image.adoc
@@ -12,9 +12,9 @@ You can use the `editor-image` parameter to set the custom IDE image for the wor
 [IMPORTANT]
 ====
 
-* If the Git repository contains xref:defining-a-common-ide.adoc[`/.che/che-editor.yaml`] file in the source-code, the custom editor will be overridden with the new IDE image.
+* If the Git repository contains xref:defining-a-common-ide.adoc[`/.che/che-editor.yaml`] file, the custom editor will be overridden with the new IDE image.
 
-* If the Git repository contains no xref:defining-a-common-ide.adoc[`/.che/che-editor.yaml`] file in the source-code, the default editor will be overridden with the new IDE image.
+* If there is no xref:defining-a-common-ide.adoc[`/.che/che-editor.yaml`] file in the Git repository, the default editor will be overridden with the new IDE image.
 
 * If you want to override the supported IDE and change the target editor image, you can use both parameters together: `che-editor` and  `editor-image` URL parameters.
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR added an explanation info of how users can override the editor's container image.

![Знімок екрана 2024-02-19 о 16 19 24](https://github.com/eclipse-che/che-docs/assets/6310786/cffc5d1b-3133-4942-b023-01e0a4e7ba56)


## What issues does this pull request fix or reference?
https://github.com/eclipse/che/issues/22733
## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
