### PR TITLE
Fix outdated workspace nodeSelector documentation

### DIFF
--- a/modules/administration-guide/pages/configuring-workspaces-nodeselector.adoc
+++ b/modules/administration-guide/pages/configuring-workspaces-nodeselector.adoc
@@ -11,11 +11,16 @@ This section describes how to configure link:https://kubernetes.io/docs/concepts
 
 .Procedure
 
-{prod-short} uses the `CHE_WORKSPACE_POD_NODE__SELECTOR` environment variable to configure `nodeSelector`. This variable can contain a set of comma-separated `key=value` pairs to form the nodeSelector rule, or `NULL` to disable it.
+{prod-short} uses `CheCluster` Custom Resource to configure `nodeSelector`:
+[source,yaml]
+----
+spec:
+  devEnvironments:
+    nodeSelector:
+      key: value
+----
+This section must contain a set of `key=value` pairs to form the nodeSelector rule.
 
-----
-CHE_WORKSPACE_POD_NODE__SELECTOR=disktype=ssd,cpu=xlarge,[key=value]
-----
 
 [IMPORTANT]
 ====

--- a/modules/administration-guide/pages/configuring-workspaces-nodeselector.adoc
+++ b/modules/administration-guide/pages/configuring-workspaces-nodeselector.adoc
@@ -10,8 +10,10 @@
 This section describes how to configure link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[`nodeSelector`] for Pods of {prod-short} workspaces.
 
 .Procedure
-
+.. Using NodeSelector
++
 {prod-short} uses `CheCluster` Custom Resource to configure `nodeSelector`:
++
 [source,yaml]
 ----
 spec:
@@ -19,8 +21,24 @@ spec:
     nodeSelector:
       key: value
 ----
-This section must contain a set of `key=value` pairs to form the nodeSelector rule.
+This section must contain a set of `key=value` pairs for each link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#built-in-node-labels[node label] to form the link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector[nodeSelector] rule.
 
+.. Using Taints and Tolerations
++
+This works in the opposite way to `nodeSelector`. Instead of specifying which nodes the Pod will be scheduled on, you specify which nodes the Pod cannot be scheduled on. For more information, see: link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration[].
++
+{prod-short} uses `CheCluster` Custom Resource to configure `tolerations`:
++
+[source,yaml]
+----
+spec:
+  devEnvironments:
+    tolerations:
+      - effect: NoSchedule
+        key: key
+        value: value
+        operator: Equal
+----
 
 [IMPORTANT]
 ====

--- a/modules/administration-guide/pages/configuring-workspaces-nodeselector.adoc
+++ b/modules/administration-guide/pages/configuring-workspaces-nodeselector.adoc
@@ -46,7 +46,7 @@ spec:
 
 To avoid Pods and PVCs to be scheduled in different zones on large, multizone clusters, create an additional link:https://kubernetes.io/docs/concepts/storage/storage-classes/[`StorageClass`] object (pay attention to the `allowedTopologies` field), which will coordinate the PVC creation process.
 
-Pass the name of this newly created `StorageClass` to {prod-short} through the `+CHE_INFRA_KUBERNETES_PVC_STORAGE__CLASS__NAME+` environment variable. A default empty value of this variable instructs {prod-short} to use the cluster's default `StorageClass`.
+Pass the name of this newly created `StorageClass` to {prod-short} through the `CheCluster` Custom Resource. For more information, see: xref:configuring-storage-classes.adoc[].
 ====
 
 .Additional resources


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Fix outdated workspace nodeSelector documentation:
![screenshot-0 0 0 0_4000-2024 02 20-09_25_40](https://github.com/eclipse-che/che-docs/assets/7668752/1bb290a7-28f5-4fee-ac63-96bffc89d0cc)

## What issues does this pull request fix or reference?
fixes https://github.com/eclipse/che/issues/22801
## Specify the version of the product this pull request applies to
latest
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
