### PR TITLE
fix: update details about fuse for OpenShift 4.15

### DIFF
--- a/modules/administration-guide/pages/configuring-fuse.adoc
+++ b/modules/administration-guide/pages/configuring-fuse.adoc
@@ -16,6 +16,11 @@ For more efficient image management, use the fuse-overlayfs storage driver which
 
 To use fuse-overlayfs, you must make `/dev/fuse` accessible to workspace containers first.
 
+[NOTE]
+====
+This procedure is not necessary for OpenShift versions 4.15 and later, since the `/dev/fuse` device is available by default. See link:https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html#ocp-4-15-nodes-dev-fuse[Release Notes].
+====
+
 [WARNING]
 ====
 Creating `MachineConfig` resources on an OpenShift cluster is a potentially dangerous task, as you are making advanced, system-level changes to the cluster.

--- a/modules/end-user-guide/pages/accessing-fuse.adoc
+++ b/modules/end-user-guide/pages/accessing-fuse.adoc
@@ -11,17 +11,28 @@ You must have access to `/dev/fuse` to use fuse-overlayfs. This section describe
 
 .Prerequisites
 
-* The administrator has enabled access to `/dev/fuse` by following xref:administration-guide:configuring-fuse.adoc[].
+* For OpenShift versions older than 4.15, the administrator has enabled access to `/dev/fuse` by following xref:administration-guide:configuring-fuse.adoc[].
 * Determine a workspace to use fuse-overlayfs with.
 
 .Procedure
 
 . Use the `pod-overrides` attribute to add the required annotations defined in xref:administration-guide:configuring-fuse.adoc[] to the workspace. The `pod-overrides` attribute allows merging certain fields in the workspace pod's `spec`.
 +
+For OpenShift versions older than 4.15:
++
 [subs="+quotes,+attributes,+macros"]
 ----
 $ {orch-cli} patch devworkspace __<DevWorkspace_name>__ \
   --patch '{"spec":{"template":{"attributes":{"pod-overrides":{"metadata":{"annotations":{"io.kubernetes.cri-o.Devices":"/dev/fuse","io.openshift.podman-fuse":""}}}}}}}' \
+  --type=merge
+----
++
+For OpenShift version 4.15 and later:
++
+[subs="+quotes,+attributes,+macros"]
+----
+$ {orch-cli} patch devworkspace __<DevWorkspace_name>__ \
+  --patch '{"spec":{"template":{"attributes":{"pod-overrides":{"metadata":{"annotations":{"io.kubernetes.cri-o.Devices":"/dev/fuse"}}}}}}}' \
   --type=merge
 ----
 

--- a/modules/end-user-guide/pages/enabling-overlay-with-a-configmap.adoc
+++ b/modules/end-user-guide/pages/enabling-overlay-with-a-configmap.adoc
@@ -35,7 +35,7 @@ Otherwise, you can update the `/home/user/.config/containers/storage.conf` for a
 
 .Prerequisites
 
-* The administrator has enabled access to `/dev/fuse` by following xref:administration-guide:configuring-fuse.adoc[].
+* For OpenShift versions older than 4.15, the administrator has enabled access to `/dev/fuse` by following xref:administration-guide:configuring-fuse.adoc[].
 
 * A workspace with the required annotations are set by following xref:accessing-fuse.adoc[]
 

--- a/modules/end-user-guide/pages/using-the-fuse-overlay-storage-driver.adoc
+++ b/modules/end-user-guide/pages/using-the-fuse-overlay-storage-driver.adoc
@@ -17,7 +17,7 @@ For more efficient image management, use the fuse-overlayfs storage driver which
 
 You must meet the following requirements to fuse-overlayfs in a workspace:
 
-. The administrator has configured `/dev/fuse` access on the cluster by following xref:administration-guide:configuring-fuse.adoc[].
+. For OpenShift versions older than 4.15, the administrator has enabled `/dev/fuse` access on the cluster by following xref:administration-guide:configuring-fuse.adoc[].
 . The workspace has the necessary annotations for using the `/dev/fuse` device. See xref:accessing-fuse.adoc[].
 . The `storage.conf` file in the workspace container has been configured to use fuse-overlayfs. See xref:enabling-overlay-with-a-configmap.adoc[].
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Adds details about fuse for OpenShift versions 4.15 and greater.

For OpenShift version >= 4.15, there is no need to create a `MachineConfig` to enable fuse: https://docs.openshift.com/container-platform/4.15/release_notes/ocp-4-15-release-notes.html#ocp-4-15-nodes-dev-fuse


## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
