### PR TITLE
chore: remove dependency on Ruby and Asciidoctor-pdf

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -52,7 +52,6 @@ RUN set -x \
     nodejs \
     python3-pip \
     rsync \
-    rubygem-bundler \
     shyaml \
     tar \
     tox \
@@ -64,7 +63,6 @@ RUN set -x \
     && dnf clean all --quiet \
     && dot -v \
     && node --version \
-    && ruby --version \
     && vale --version
 
 # Install Python packages
@@ -73,13 +71,6 @@ RUN set -x \
     diagrams \
     yq \
     && yq --version
-
-# Install Ruby packages (requires Ruby 2.7)
-RUN set -x \
-    && gem install asciidoctor-pdf \
-    && which asciidoctor-pdf \
-    && asciidoctor --version \
-    && asciidoctor-pdf --version
 
 # WORKDIR is a Node.js prerequisite
 WORKDIR /tmp
@@ -96,6 +87,7 @@ RUN set -x \
     && npm install --no-save --global asciidoctor-kroki \
     && npm install --no-save --global gulp gulp-cli gulp-connect \
     && npm install --no-save --global js-yaml \
+    && npm install --no-save --global asciidoctor \
     && which antora \
     && antora --version \
     && rm /tmp/* --recursive --force
@@ -112,7 +104,6 @@ WORKDIR /projects
 RUN set -x \
     && antora --version \
     && asciidoctor --version \
-    && asciidoctor-pdf --version \
     && bash --version \
     && curl --version \
     && git --version \

--- a/antora-assembler.yml
+++ b/antora-assembler.yml
@@ -14,5 +14,5 @@ root_level: 1
 component_versions: '*'
 section_merge_strategy: fuse
 build:
-    command: asciidoctor-pdf --attribute toclevels=5 --attribute antora-assembler=true --trace --sourcemap
+    command: asciidoctor --attribute toclevels=5 --attribute antora-assembler=true --trace
     keep_aggregate_source: true


### PR DESCRIPTION
## What does this pull request change?

Remove dependency on Ruby and Asciidoctor-pdf, as we do not use the generated PDF.

Use Asciidoctor, Node.js version instead.

Caveats: once the new container is published, you will need to backport the changes made to the `antora-assembler.yml` file to the older branches that you still want to build.

## What issues does this pull request fix or reference?

Fixes container build error.

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
