### PR TITLE
Trusted extensions

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -9,8 +9,6 @@
 schemaVersion: 2.2.2
 metadata:
   name: che-docs
-attributes:
-  controller.devfile.io/storage-type: ephemeral
 components:
   - name: tools
     container:

--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -83,6 +83,7 @@
 ** xref:configuring-fuse.adoc[]
 * xref:managing-ide-extensions.adoc[]
 ** xref:extensions-for-microsoft-visual-studio-code-open-source.adoc[]
+** xref:trusted-extensions-for-microsoft-visual-studio-code.adoc[]
 * xref:managing-workloads-using-the-che-server-api.adoc[]
 * xref:upgrading-che.adoc[]
 ** xref:upgrading-the-chectl-management-tool.adoc[]

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -28,13 +28,37 @@ Use the `trustedExtensionAuthAccess` field with caution as it could potentially 
 ====
 Since the Visual Studio Code editor is bundled within `che-code` image, you can only change the `product.json` file when the workspace is started up.
 ====
-* Define the __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma.
+
+The first you need to define __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma.
+You can define the variable in the devfile or in the ConfigMap.
+
+====
+* Define the __VSCODE_TRUSTED_EXTENSIONS__ environment variable in the devfile.yaml.
 [source,yaml]
 ----
    env:
      - name: VSCODE_TRUSTED_EXTENSIONS
        value: "<publisher1>.<extension1>,<publisher2>.<extension2>"
 ----
+====
+
+====
+* Create a ConfigMap with __VSCODE_TRUSTED_EXTENSIONS__ environment variable.
+[source,yaml]
+----
+   kind: ConfigMap
+   apiVersion: v1
+   metadata:
+     name: trusted-extensions
+     labels:
+       controller.devfile.io/mount-to-devworkspace: 'true'
+       controller.devfile.io/watch-configmap: 'true'
+     annotations:
+       controller.devfile.io/mount-as: env
+   data:
+     VSCODE_TRUSTED_EXTENSIONS: '<publisher1>.<extension1>,<publisher2>.<extension2>'
+----
+====
 
 .Verification
 

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -21,7 +21,7 @@ This is particularly useful when you have extensions that require access to serv
 Note that this should be used with caution as it could potentially lead to security risks if misused. Only trusted extensions should be given this access.
 
 .Procedure
-Since the VS Code editor is bundled within `che-code` image, it is possible to change the `product.json` file only when the workspace is started up.
+Since the Visual Studio Code editor is bundled within `che-code` image, it is possible to change the `product.json` file only when the workspace is started up.
 To do that it needs to define __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma.
 [source,yaml]
 ----

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -29,11 +29,13 @@ Use the `trustedExtensionAuthAccess` field with caution as it could potentially 
 Since the Visual Studio Code editor is bundled within `che-code` image, you can only change the `product.json` file when the workspace is started up.
 ====
 
-The first you need to define __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma.
-You can define the variable in the devfile or in the ConfigMap.
+The first you need to define __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma. The value of the variable will be taken and parsed right after workspace is started and the corresponding `trustedExtensionAuthAccess` section will be added to the `product.json` right before the Visual Studio Code is started.
 
+You can define the variable in the devfile or in the ConfigMap. These options are equal, just pick that better fit your needs.
+With a ConfigMap the variable will be propagated on all your workspaces, you do not need to add the variable to each the devfile you are using.
+
+.Define the __VSCODE_TRUSTED_EXTENSIONS__ environment variable in the devfile.yaml.
 ====
-* Define the __VSCODE_TRUSTED_EXTENSIONS__ environment variable in the devfile.yaml.
 [source,yaml]
 ----
    env:
@@ -42,8 +44,8 @@ You can define the variable in the devfile or in the ConfigMap.
 ----
 ====
 
+.Mount a ConfigMap with __VSCODE_TRUSTED_EXTENSIONS__ environment variable.
 ====
-* Create a ConfigMap with __VSCODE_TRUSTED_EXTENSIONS__ environment variable.
 [source,yaml]
 ----
    kind: ConfigMap

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -7,7 +7,7 @@
 = Configure trusted extensions for Microsoft Visual Studio Code
 
 
-You can use the `trustedExtensionAuthAccess` field in the `product.json` file of Visual Studio Code to specify which extensions are trusted to access authentication tokens.
+You can use the `trustedExtensionAuthAccess` field in the `product.json` file of Microsoft Visual Studio Code to specify which extensions are trusted to access authentication tokens.
 [source,json]
 ----
 	"trustedExtensionAuthAccess": [

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -18,6 +18,8 @@ You can use the `trustedExtensionAuthAccess` field in the `product.json` file of
 
 This is particularly useful when you have extensions that require access to services such as GitHub, Microsoft, or any other service that requires OAuth. By adding the extension IDs to this field, you are granting them the permission to access these tokens.
 
+You can define the variable in the devfile or in the ConfigMap. Pick the option that better suits your needs.
+With a ConfigMap, the variable will be propagated on all your workspaces and you do not need to add the variable to each the devfile you are using.
 [WARNING]
 ====
 Use the `trustedExtensionAuthAccess` field with caution as it could potentially lead to security risks if misused. Give access only to trusted extensions.

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -32,9 +32,6 @@ Since the Microsoft Visual Studio Code editor is bundled within `che-code` image
 ====
 
 
-You can define the variable in the devfile or in the ConfigMap. These options are equal, just pick that better fit your needs.
-With a ConfigMap the variable will be propagated on all your workspaces, you do not need to add the variable to each the devfile you are using.
-
 .Define the __VSCODE_TRUSTED_EXTENSIONS__ environment variable in the devfile.yaml.
 ====
 [source,yaml]

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -24,7 +24,10 @@ Use the `trustedExtensionAuthAccess` field with caution as it could potentially 
 ====
 
 .Procedure
-Since the Visual Studio Code editor is bundled within `che-code` image, it is possible to change the `product.json` file only when the workspace is started up.
+[IMPORTANT]
+====
+Since the Visual Studio Code editor is bundled within `che-code` image, you can only change the `product.json` file when the workspace is started up.
+====
 To do that it needs to define __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma.
 [source,yaml]
 ----

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -7,7 +7,7 @@
 = Configure trusted extensions for Microsoft Visual Studio Code
 
 
-The `trustedExtensionAuthAccess` field in the `product.json` file of Visual Studio Code is used to specify which extensions are trusted to access authentication tokens.
+You can use the `trustedExtensionAuthAccess` field in the `product.json` file of Visual Studio Code to specify which extensions are trusted to access authentication tokens.
 [source,json]
 ----
 	"trustedExtensionAuthAccess": [

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -18,7 +18,10 @@ You can use the `trustedExtensionAuthAccess` field in the `product.json` file of
 
 This is particularly useful when you have extensions that require access to services such as GitHub, Microsoft, or any other service that requires OAuth. By adding the extension IDs to this field, you are granting them the permission to access these tokens.
 
-Note that this should be used with caution as it could potentially lead to security risks if misused. Only trusted extensions should be given this access.
+[WARNING]
+====
+Use the `trustedExtensionAuthAccess` field with caution as it could potentially lead to security risks if misused. Give access only to trusted extensions.
+====
 
 .Procedure
 Since the Visual Studio Code editor is bundled within `che-code` image, it is possible to change the `product.json` file only when the workspace is started up.

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -28,7 +28,7 @@ Use the `trustedExtensionAuthAccess` field with caution as it could potentially 
 ====
 Since the Visual Studio Code editor is bundled within `che-code` image, you can only change the `product.json` file when the workspace is started up.
 ====
-To do that it needs to define __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma.
+* Define the __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma.
 [source,yaml]
 ----
    env:

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -31,7 +31,6 @@ Use the `trustedExtensionAuthAccess` field with caution as it could potentially 
 Since the Microsoft Visual Studio Code editor is bundled within `che-code` image, you can only change the `product.json` file when the workspace is started up.
 ====
 
-The first you need to define __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma. The value of the variable will be taken and parsed right after workspace is started and the corresponding `trustedExtensionAuthAccess` section will be added to the `product.json` right before the Visual Studio Code is started.
 
 You can define the variable in the devfile or in the ConfigMap. These options are equal, just pick that better fit your needs.
 With a ConfigMap the variable will be propagated on all your workspaces, you do not need to add the variable to each the devfile you are using.

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -16,7 +16,7 @@ You can use the `trustedExtensionAuthAccess` field in the `product.json` file of
 	]
 ----
 
-This is particularly useful when you have extensions that require access to services such as GitHub, Microsoft, or any other service that requires OAuth. By adding the extension IDs to this field, you’re granting them the permission to access these tokens.
+This is particularly useful when you have extensions that require access to services such as GitHub, Microsoft, or any other service that requires OAuth. By adding the extension IDs to this field, you are granting them the permission to access these tokens.
 
 Note that this should be used with caution as it could potentially lead to security risks if misused. Only trusted extensions should be given this access.
 

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -35,4 +35,7 @@ To do that it needs to define __VSCODE_TRUSTED_EXTENSIONS__ environment variable
      - name: VSCODE_TRUSTED_EXTENSIONS
        value: "<publisher1>.<extension1>,<publisher2>.<extension2>"
 ----
-The value of the variable will be parsed on the workspace startup and the corresponding `trustedExtensionAuthAccess` section will be added to the `product.json`.
+
+.Verification
+
+* The value of the variable will be parsed on the workspace startup and the corresponding `trustedExtensionAuthAccess` section will be added to the `product.json`.

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -32,7 +32,9 @@ Since the Microsoft Visual Studio Code editor is bundled within `che-code` image
 ====
 
 
-.Define the __VSCODE_TRUSTED_EXTENSIONS__ environment variable in the devfile.yaml.
+. Define the __VSCODE_TRUSTED_EXTENSIONS__ environment variable. Choose between defining the variable in devfile.yaml or mounting a ConfigMap with the variable instead.
+.. Define the __VSCODE_TRUSTED_EXTENSIONS__ environment variable in devfile.yaml:
++
 ====
 [source,yaml]
 ----
@@ -42,7 +44,8 @@ Since the Microsoft Visual Studio Code editor is bundled within `che-code` image
 ----
 ====
 
-.Mount a ConfigMap with __VSCODE_TRUSTED_EXTENSIONS__ environment variable.
+.. Mount a ConfigMap with __VSCODE_TRUSTED_EXTENSIONS__ environment variable:
++
 ====
 [source,yaml]
 ----

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -26,7 +26,7 @@ Use the `trustedExtensionAuthAccess` field with caution as it could potentially 
 .Procedure
 [IMPORTANT]
 ====
-Since the Visual Studio Code editor is bundled within `che-code` image, you can only change the `product.json` file when the workspace is started up.
+Since the Microsoft Visual Studio Code editor is bundled within `che-code` image, you can only change the `product.json` file when the workspace is started up.
 ====
 
 The first you need to define __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma. The value of the variable will be taken and parsed right after workspace is started and the corresponding `trustedExtensionAuthAccess` section will be added to the `product.json` right before the Visual Studio Code is started.

--- a/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/trusted-extensions-for-microsoft-visual-studio-code.adoc
@@ -1,0 +1,32 @@
+:_content-type: PROCEDURE
+:description: Configure trusted extensions for Microsoft Visual Studio Code
+:keywords: extensions, vs-code, vsx, open-vsx, marketplace
+:navtitle: Configure trusted extensions for Microsoft Visual Studio Code
+
+[id="visual-studio-code-trusted-extensions"]
+= Configure trusted extensions for Microsoft Visual Studio Code
+
+
+The `trustedExtensionAuthAccess` field in the `product.json` file of Visual Studio Code is used to specify which extensions are trusted to access authentication tokens.
+[source,json]
+----
+	"trustedExtensionAuthAccess": [
+		"<publisher1>.<extension1>",
+		"<publisher2>.<extension2>"
+	]
+----
+
+This is particularly useful when you have extensions that require access to services such as GitHub, Microsoft, or any other service that requires OAuth. By adding the extension IDs to this field, you’re granting them the permission to access these tokens.
+
+Note that this should be used with caution as it could potentially lead to security risks if misused. Only trusted extensions should be given this access.
+
+.Procedure
+Since the VS Code editor is bundled within `che-code` image, it is possible to change the `product.json` file only when the workspace is started up.
+To do that it needs to define __VSCODE_TRUSTED_EXTENSIONS__ environment variable and specify one or several extensions separated by comma.
+[source,yaml]
+----
+   env:
+     - name: VSCODE_TRUSTED_EXTENSIONS
+       value: "<publisher1>.<extension1>,<publisher2>.<extension2>"
+----
+The value of the variable will be parsed on the workspace startup and the corresponding `trustedExtensionAuthAccess` section will be added to the `product.json`.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Adds a page explaining how to specify trusted extensions for Microsoft VS Code editor.

![Screenshot from 2024-04-09 21-38-12](https://github.com/eclipse-che/che-docs/assets/1655894/cee4e01a-4f9d-47e8-a37a-8258009054bb)


## What issues does this pull request fix or reference?
Part of https://github.com/eclipse/che/issues/22781

## Specify the version of the product this pull request applies to
che-code/7.84.0

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
