### PR TITLE
docs: configuring multi and single root workspaces

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -85,7 +85,7 @@
 * xref:managing-ide-extensions.adoc[]
 ** xref:extensions-for-microsoft-visual-studio-code-open-source.adoc[]
 ** xref:trusted-extensions-for-microsoft-visual-studio-code.adoc[]
-* xref:configuring-microsoft-visual-studio-code.adoc[]
+* xref:configuring-visual-studio-code.adoc[]
 ** xref:configuring-single-and-multiroot-workspaces.adoc[]
 * xref:managing-workloads-using-the-che-server-api.adoc[]
 * xref:upgrading-che.adoc[]

--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -85,6 +85,8 @@
 * xref:managing-ide-extensions.adoc[]
 ** xref:extensions-for-microsoft-visual-studio-code-open-source.adoc[]
 ** xref:trusted-extensions-for-microsoft-visual-studio-code.adoc[]
+* xref:configuring-microsoft-visual-studio-code.adoc[]
+** xref:configuring-single-and-multiroot-workspaces.adoc[]
 * xref:managing-workloads-using-the-che-server-api.adoc[]
 * xref:upgrading-che.adoc[]
 ** xref:upgrading-the-chectl-management-tool.adoc[]

--- a/modules/administration-guide/pages/configuring-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/configuring-microsoft-visual-studio-code.adoc
@@ -1,12 +1,12 @@
 :_content-type: CONCEPT
-:description: Configuring Microsoft Visual Studio Code
+:description: Configuring Visual Studio Code - Open Source ("Code - OSS")
 :keywords: vscode, workspace
-:navtitle: Configuring Microsoft Visual Studio Code
+:navtitle: Configuring Visual Studio Code - Open Source ("Code - OSS")
 //:page-aliases:
 
 [id="configuring-microsoft-visual-studio-code"]
-= Configuring Microsoft Visual Studio Code
+= Configuring Visual Studio Code - Open Source ("Code - OSS")
 
-Learn how to configure Microsoft Visual Studio Code.
+Learn how to configure Visual Studio Code - Open Source ("Code - OSS").
 
 * xref:configuring-single-and-multiroot-workspaces.adoc[]

--- a/modules/administration-guide/pages/configuring-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/configuring-microsoft-visual-studio-code.adoc
@@ -7,6 +7,6 @@
 [id="configuring-microsoft-visual-studio-code"]
 = Configuring Microsoft Visual Studio Code
 
-This section provides a detailed guide on how to configure Microsoft Visual Studio Code.
+Learn how to configure Microsoft Visual Studio Code.
 
 * xref:configuring-single-and-multiroot-workspaces.adoc[]

--- a/modules/administration-guide/pages/configuring-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/configuring-microsoft-visual-studio-code.adoc
@@ -1,0 +1,12 @@
+:_content-type: CONCEPT
+:description: Configuring Microsoft Visual Studio Code
+:keywords: vscode, workspace
+:navtitle: Configuring Microsoft Visual Studio Code
+//:page-aliases:
+
+[id="configuring-microsoft-visual-studio-code"]
+= Configuring Microsoft Visual Studio Code
+
+This section provides a detailed guide on how to configure Microsoft Visual Studio Code.
+
+* xref:configuring-single-and-multiroot-workspaces.adoc[]

--- a/modules/administration-guide/pages/configuring-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/configuring-microsoft-visual-studio-code.adoc
@@ -9,4 +9,4 @@
 
 Learn how to configure Microsoft Visual Studio Code.
 
-* xref:configuring-single-and-multiroot-workspaces.adoc[]
+* xref:configuring-single-and-multiroot-workspaces.adoc[1]

--- a/modules/administration-guide/pages/configuring-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/configuring-microsoft-visual-studio-code.adoc
@@ -9,4 +9,4 @@
 
 Learn how to configure Microsoft Visual Studio Code.
 
-* xref:configuring-single-and-multiroot-workspaces.adoc[1]
+* xref:configuring-single-and-multiroot-workspaces.adoc[]

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -78,16 +78,13 @@ If the workspace file does not exist in the first project, a new one will be cre
        value: "</projects/project-name/workspace-file>"
 ----
 
-.3. Open a workspace in a single-root mode.
+* Open a workspace in a single-root mode.
 
-You can open Microsoft Visual Studio Code in single-root mode.
-For that you need to define __VSCODE_DEFAULT_WORKSPACE__ environment variable and set it to the root.
-
-====
+** Define __VSCODE_DEFAULT_WORKSPACE__ environment variable and set it to the root.
++
 [source,yaml]
 ----
    env:
      - name: VSCODE_DEFAULT_WORKSPACE
        value: "</>"
 ----
-====

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -60,7 +60,7 @@ You can change the default behavior and provide your own workspace file or switc
 ====
 Be careful when creating a workspace file. In case of errors, an empty Microsoft Visual Studio Code project will open instead.
 ====
-
++
 [IMPORTANT]
 ====
 If you have several projects, the workspace file will be taken from the first project.

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -40,12 +40,10 @@ You can change the default behavior and provide your own workspace file or switc
 
 .Procedure
 
-.1. Provide your own workspace file.
+* Provide your own workspace file.
 
-You can easily use your own workspace file. For that you need to name it `.code-workspace` and put it to the root of your repository. 
-Then after workspace creation, the Microsoft Visual Studio Code will use the workspace file as it is.
-
-====
+** Put a workspace file with the name `.code-workspace` into the root of your repository. After workspace creation, the Microsoft Visual Studio Code will use the workspace file as it is.
++
 [source,json]
 ----
 {
@@ -57,8 +55,7 @@ Then after workspace creation, the Microsoft Visual Studio Code will use the wor
 	]
 }
 ----
-====
-
++
 [IMPORTANT]
 ====
 Be careful when creating a workspace file. In case of errors, an empty Microsoft Visual Studio Code project will open instead.

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -59,7 +59,7 @@ You can change the default behavior and provide your own workspace file or switc
 +
 [IMPORTANT]
 ====
-Be careful when creating a workspace file. In case of errors, an empty Visual Studio Code - Open Source ("Code - OSS") will open instead.
+Be careful when creating a workspace file. In case of errors, an empty Visual Studio Code - Open Source ("Code - OSS") will be opened instead.
 ====
 +
 [IMPORTANT]

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -63,7 +63,7 @@ Be careful when creating a workspace file. In case of errors, an empty Microsoft
 
 [IMPORTANT]
 ====
-In case you have several projects, the workspace file will be taken from the first project.
+If you have several projects, the workspace file will be taken from the first project.
 If the workspace file does not exist in the first project, a new one will be created and placed in the `/projects` directory. 
 ====
 

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -14,7 +14,7 @@ With the multi-root workspace feature, you can work with multiple project folder
 Starting with Dev Spaces 3.11, the workspace is set to open in multi-root mode by default.
 ====
 
-Once workspace is started, the `</projects/.code-workspace>` workspace file is generated. The workspace file will contain all the projects described in the Devfile.
+Once workspace is started, the `</projects/.code-workspace>` workspace file is generated. The workspace file will contain all the projects described in the devfile.
 ====
 [source,json]
 ----

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -61,7 +61,7 @@ Then after workspace creation, the Microsoft Visual Studio Code will use the wor
 
 [IMPORTANT]
 ====
-Be careful when creating a file. In case of errors, an empty Microsoft Visual Studio Code will be opened.
+Be careful when creating a workspace file. In case of errors, an empty Microsoft Visual Studio Code project will open instead.
 ====
 
 [IMPORTANT]

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -1,0 +1,99 @@
+:_content-type: PROCEDURE
+:description: Configuring single and multiroot workspaces
+:keywords: singleroot, multiroot, workspace
+:navtitle: Configuring single and multiroot workspaces
+// :page-aliases:
+
+[id="configuring-single-and-multiroot-workspaces"]
+= Configuring single and multi root workspaces
+
+Multi-root Workspaces is a feature in Microsoft Visual Studio Code that allows you to work with multiple project folders in the same workspace. This is useful when you are working on several related projects at once. For example, you might have a repository with a product's documentation and another with the product's code.
+
+[NOTE]
+====
+Starting with Dev Spaces 3.11, the workspace is set to open in multi-root mode by default.
+====
+
+Once workspace is started, the `</projects/.code-workspace>` workspace file is generated. The workspace file will contain all the projects described in the Devfile.
+====
+[source,json]
+----
+{
+	"folders": [
+		{
+			"name": "<project-1>",
+			"path": "</projects/project-1>"
+		},
+		{
+			"name": "<project-2>",
+			"path": "</projects/project-2>"
+		}
+	]
+}
+----
+====
+
+If the workspace file is already exist, it will be updated, all missing projects will be taken from the Devfile.
+If a project is removed from the Devfile, it will be left in the workspace file.
+
+You can change thee default behavior and provide your own workspace file or switch to the single-root workspace.
+
+.Procedure
++
+.1. Provide your own workspace file.
+
+You can easily use your own workspace file. For that you need to name it `.code-workspace` and put it to the root of your repository. 
+Then after workspace creation, the Microsoft Visual Studio Code will use the workspace file as it is.
+
+====
+[source,json]
+----
+{
+	"folders": [
+		{
+			"name": "<project-name>",
+			"path": "."
+		}
+	]
+}
+----
+====
+
+[IMPORTANT]
+====
+Be careful when creating a file. In case of errors, an empty Microsoft Visual Studio Code will be opened.
+====
+
+[IMPORTANT]
+====
+In case you have several projects, the workspace file will be taken from the first project.
+If the workspace file does not exist in the first project, a new one will be created and placed in the `/projects` directory. 
+====
+
+.2. Specify alternative workspace file.
+
+You can open Microsoft Visual Studio Code specifying any workspace file on the file system.
+To do that you need to define __VSCODE_DEFAULT_WORKSPACE__ environment variable in your Devfile and specify the right location to the workspace file.
+
+====
+[source,yaml]
+----
+   env:
+     - name: VSCODE_DEFAULT_WORKSPACE
+       value: "</projects/project-name/workspace-file>"
+----
+====
+
+.3. Open a workspace in a single-root mode.
+
+You can open Microsoft Visual Studio Code in single-root mode.
+For that you need to define __VSCODE_DEFAULT_WORKSPACE__ environment variable and set it to the root.
+
+====
+[source,yaml]
+----
+   env:
+     - name: VSCODE_DEFAULT_WORKSPACE
+       value: "</>"
+----
+====

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -7,7 +7,7 @@
 [id="configuring-single-and-multiroot-workspaces"]
 = Configuring single and multi root workspaces
 
-Multi-root Workspaces is a feature in Microsoft Visual Studio Code that allows you to work with multiple project folders in the same workspace. This is useful when you are working on several related projects at once. For example, you might have a repository with a product's documentation and another with the product's code.
+With the multi-root workspace feature, you can work with multiple project folders in the same workspace. This is useful when you are working on several related projects at once, such as product documentation and product code repositories.
 
 [NOTE]
 ====

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -67,19 +67,16 @@ In case you have several projects, the workspace file will be taken from the fir
 If the workspace file does not exist in the first project, a new one will be created and placed in the `/projects` directory. 
 ====
 
-.2. Specify alternative workspace file.
+* Specify alternative workspace file.
 
-You can open Microsoft Visual Studio Code specifying any workspace file on the file system.
-To do that you need to define __VSCODE_DEFAULT_WORKSPACE__ environment variable in your Devfile and specify the right location to the workspace file.
-
-====
+** Define the __VSCODE_DEFAULT_WORKSPACE__ environment variable in your devfile and specify the right location to the workspace file.
++
 [source,yaml]
 ----
    env:
      - name: VSCODE_DEFAULT_WORKSPACE
        value: "</projects/project-name/workspace-file>"
 ----
-====
 
 .3. Open a workspace in a single-root mode.
 

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -39,7 +39,7 @@ If a project is removed from the Devfile, it will be left in the workspace file.
 You can change thee default behavior and provide your own workspace file or switch to the single-root workspace.
 
 .Procedure
-+
+
 .1. Provide your own workspace file.
 
 You can easily use your own workspace file. For that you need to name it `.code-workspace` and put it to the root of your repository. 

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -11,7 +11,7 @@ With the multi-root workspace feature, you can work with multiple project folder
 
 [NOTE]
 ====
-Starting with Dev Spaces 3.11, the workspace is set to open in multi-root mode by default.
+Starting with {prod-short} 3.11, the workspace is set to open in multi-root mode by default.
 ====
 
 Once workspace is started, the `</projects/.code-workspace>` workspace file is generated. The workspace file will contain all the projects described in the devfile.

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -14,7 +14,7 @@ With the multi-root workspace feature, you can work with multiple project folder
 Starting with {prod-short} 3.11, the workspace is set to open in multi-root mode by default.
 ====
 
-Once workspace is started, the `</projects/.code-workspace>` workspace file is generated. The workspace file will contain all the projects described in the devfile.
+Once workspace is started, the `/projects/.code-workspace` workspace file is generated. The workspace file will contain all the projects described in the devfile.
 
 [source,json]
 ----

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -33,7 +33,7 @@ Once workspace is started, the `</projects/.code-workspace>` workspace file is g
 ----
 ====
 
-If the workspace file is already exist, it will be updated, all missing projects will be taken from the Devfile.
+If the workspace file already exist, it will be updated and all missing projects will be taken from the devfile.
 If a project is removed from the Devfile, it will be left in the workspace file.
 
 You can change thee default behavior and provide your own workspace file or switch to the single-root workspace.

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -34,7 +34,7 @@ Once workspace is started, the `</projects/.code-workspace>` workspace file is g
 ====
 
 If the workspace file already exist, it will be updated and all missing projects will be taken from the devfile.
-If a project is removed from the Devfile, it will be left in the workspace file.
+If you remove a project from the devfile, it will be left in the workspace file.
 
 You can change thee default behavior and provide your own workspace file or switch to the single-root workspace.
 

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -9,9 +9,11 @@
 
 With the multi-root workspace feature, you can work with multiple project folders in the same workspace. This is useful when you are working on several related projects at once, such as product documentation and product code repositories.
 
+TIP: See link:https://code.visualstudio.com/docs/editor/workspaces[What is a VS Code "workspace"] for better understanding and authoring the workspace files.
+
 [NOTE]
 ====
-Starting with {prod-short} 3.11, the workspace is set to open in multi-root mode by default.
+Starting with {prod-short} 7.73.0, the workspace is set to open in multi-root mode by default.
 ====
 
 Once workspace is started, the `/projects/.code-workspace` workspace file is generated. The workspace file will contain all the projects described in the devfile.

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -15,7 +15,7 @@ Starting with {prod-short} 3.11, the workspace is set to open in multi-root mode
 ====
 
 Once workspace is started, the `</projects/.code-workspace>` workspace file is generated. The workspace file will contain all the projects described in the devfile.
-====
+
 [source,json]
 ----
 {
@@ -31,7 +31,6 @@ Once workspace is started, the `</projects/.code-workspace>` workspace file is g
 	]
 }
 ----
-====
 
 If the workspace file already exist, it will be updated and all missing projects will be taken from the devfile.
 If you remove a project from the devfile, it will be left in the workspace file.
@@ -58,7 +57,7 @@ You can change the default behavior and provide your own workspace file or switc
 +
 [IMPORTANT]
 ====
-Be careful when creating a workspace file. In case of errors, an empty Microsoft Visual Studio Code project will open instead.
+Be careful when creating a workspace file. In case of errors, an empty Microsoft Visual Studio Code will open instead.
 ====
 +
 [IMPORTANT]

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -21,12 +21,12 @@ Once workspace is started, the `</projects/.code-workspace>` workspace file is g
 {
 	"folders": [
 		{
-			"name": "<project-1>",
-			"path": "</projects/project-1>"
+			"name": "project-1",
+			"path": "/projects/project-1"
 		},
 		{
-			"name": "<project-2>",
-			"path": "</projects/project-2>"
+			"name": "project-2",
+			"path": "/projects/project-2"
 		}
 	]
 }
@@ -41,14 +41,14 @@ You can change the default behavior and provide your own workspace file or switc
 
 * Provide your own workspace file.
 
-** Put a workspace file with the name `.code-workspace` into the root of your repository. After workspace creation, the Microsoft Visual Studio Code will use the workspace file as it is.
+** Put a workspace file with the name `.code-workspace` into the root of your repository. After workspace creation, the Visual Studio Code - Open Source ("Code - OSS") will use the workspace file as it is.
 +
 [source,json]
 ----
 {
 	"folders": [
 		{
-			"name": "<project-name>",
+			"name": "project-name",
 			"path": "."
 		}
 	]
@@ -57,7 +57,7 @@ You can change the default behavior and provide your own workspace file or switc
 +
 [IMPORTANT]
 ====
-Be careful when creating a workspace file. In case of errors, an empty Microsoft Visual Studio Code will open instead.
+Be careful when creating a workspace file. In case of errors, an empty Visual Studio Code - Open Source ("Code - OSS") will open instead.
 ====
 +
 [IMPORTANT]
@@ -74,7 +74,7 @@ If the workspace file does not exist in the first project, a new one will be cre
 ----
    env:
      - name: VSCODE_DEFAULT_WORKSPACE
-       value: "</projects/project-name/workspace-file>"
+       value: "/projects/project-name/workspace-file"
 ----
 
 * Open a workspace in a single-root mode.
@@ -85,5 +85,5 @@ If the workspace file does not exist in the first project, a new one will be cre
 ----
    env:
      - name: VSCODE_DEFAULT_WORKSPACE
-       value: "</>"
+       value: "/"
 ----

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -13,7 +13,7 @@ TIP: See link:https://code.visualstudio.com/docs/editor/workspaces[What is a VS 
 
 [NOTE]
 ====
-Starting with {prod-short} 7.73.0, the workspace is set to open in multi-root mode by default.
+The workspace is set to open in multi-root mode by default.
 ====
 
 Once workspace is started, the `/projects/.code-workspace` workspace file is generated. The workspace file will contain all the projects described in the devfile.

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -36,7 +36,7 @@ Once workspace is started, the `</projects/.code-workspace>` workspace file is g
 If the workspace file already exist, it will be updated and all missing projects will be taken from the devfile.
 If you remove a project from the devfile, it will be left in the workspace file.
 
-You can change thee default behavior and provide your own workspace file or switch to the single-root workspace.
+You can change the default behavior and provide your own workspace file or switch to a single-root workspace.
 
 .Procedure
 

--- a/modules/administration-guide/pages/configuring-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/configuring-visual-studio-code.adoc
@@ -4,7 +4,7 @@
 :navtitle: Configuring Visual Studio Code - Open Source ("Code - OSS")
 //:page-aliases:
 
-[id="configuring-microsoft-visual-studio-code"]
+[id="configuring-visual-studio-code"]
 = Configuring Visual Studio Code - Open Source ("Code - OSS")
 
 Learn how to configure Visual Studio Code - Open Source ("Code - OSS").


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Describes how to configure multi and single root workspaces

![Screenshot from 2024-04-18 11-37-23](https://github.com/eclipse-che/che-docs/assets/1655894/3738b702-eb37-48be-b109-a2c7909e76fb)

## What issues does this pull request fix or reference?
No issue, just adding missing documentation

## Specify the version of the product this pull request applies to
che-code/7.84.0

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
