### PR TITLE
Update the GitHub oauth configuration page

### DIFF
--- a/modules/administration-guide/partials/proc_applying-the-github-oauth-app-secret.adoc
+++ b/modules/administration-guide/partials/proc_applying-the-github-oauth-app-secret.adoc
@@ -36,7 +36,7 @@ metadata:
   annotations:
     che.eclipse.org/oauth-scm-server: github
     che.eclipse.org/scm-server-endpoint: __<github_server_url>__ <2>
-    che.eclipse.org/scm-github-disable-subdomain-isolation: true <3>
+    che.eclipse.org/scm-github-disable-subdomain-isolation: 'false' <3>
 type: Opaque
 stringData:
   id: __<GitHub_OAuth_Client_ID>__ <4>
@@ -44,7 +44,7 @@ stringData:
 ----
 <1> The {prod-short} namespace. The default is `{prod-namespace}`.
 <2> This depends on the GitHub product your organization is using: When hosting repositories on GitHub.com or GitHub Enterprise Cloud, omit this line or enter the default `https://github.com`. When hosting repositories on GitHub Enterprise Server, enter the GitHub Enterprise Server URL.
-<3> This line is only added for GitHub Enterprise Server with disabled link:https://docs.github.com/en/enterprise-server/admin/configuration/hardening-security-for-your-enterprise/enabling-subdomain-isolation#about-subdomain-isolation[subdomain isolation] option. If the subdomain isolation option is enabled on GitHub Enterprise Server, you must either omit this annotation or set it to `false`.
+<3> If you are using GitHub Enterprise Server with disabled link:https://docs.github.com/en/enterprise-server/admin/configuration/hardening-security-for-your-enterprise/enabling-subdomain-isolation#about-subdomain-isolation[subdomain isolation] option, you must set the annotation to `true`, otherwise you can either omit the annotation, or set it to 'true'.
 <4> The *GitHub OAuth Client ID*.
 <5> The *GitHub OAuth Client Secret*.
 

--- a/modules/administration-guide/partials/proc_applying-the-github-oauth-app-secret.adoc
+++ b/modules/administration-guide/partials/proc_applying-the-github-oauth-app-secret.adoc
@@ -44,7 +44,7 @@ stringData:
 ----
 <1> The {prod-short} namespace. The default is `{prod-namespace}`.
 <2> This depends on the GitHub product your organization is using: When hosting repositories on GitHub.com or GitHub Enterprise Cloud, omit this line or enter the default `https://github.com`. When hosting repositories on GitHub Enterprise Server, enter the GitHub Enterprise Server URL.
-<3> If you are using GitHub Enterprise Server with disabled link:https://docs.github.com/en/enterprise-server/admin/configuration/hardening-security-for-your-enterprise/enabling-subdomain-isolation#about-subdomain-isolation[subdomain isolation] option, you must set the annotation to `true`, otherwise you can either omit the annotation, or set it to 'true'.
+<3> If you are using GitHub Enterprise Server with a disabled link:https://docs.github.com/en/enterprise-server/admin/configuration/hardening-security-for-your-enterprise/enabling-subdomain-isolation#about-subdomain-isolation[subdomain isolation] option, you must set the annotation to `true`, otherwise you can either omit the annotation or set it to `false`.
 <4> The *GitHub OAuth Client ID*.
 <5> The *GitHub OAuth Client Secret*.
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
In order to avoid confusion when configuring GitHub enterprise oauth remove the `che.eclipse.org/scm-github-disable-subdomain-isolation` annotation from the secret content and move the description to a new `important` section.

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-6307
## Specify the version of the product this pull request applies to
next
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
