### PR TITLE
chore: remove che-pycharm editor from the supported IDEs

### DIFF
--- a/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
+++ b/modules/end-user-guide/examples/snip_che-table-of-supported-editors.adoc
@@ -16,14 +16,6 @@
 * `latest` is the stable version.
 * `next` is the development version.
 
-| link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains PyCharm Community Edition]
-|
-* `che-incubator/che-pycharm/latest`
-* `che-incubator/che-pycharm/next`
-|
-* `latest` is the stable version.
-* `next` is the development version.
-
 | link:https://github.com/redhat-developer/devspaces-gateway-plugin/[JetBrains IntelliJ IDEA Ultimate Edition (over JetBrains Gateway)]
 |
 * `che-incubator/che-idea-server/latest`


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Remove che-pycharm editor from the supported IDEs

**Depends on https://github.com/eclipse-che/che-plugin-registry/pull/1930**

## What issues does this pull request fix or reference?
https://github.com/eclipse-che/che/issues/22964

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
