### PR TITLE
chore: fix docs generating odd newline symbols

### DIFF
--- a/tools/checluster_docs_gen.sh
+++ b/tools/checluster_docs_gen.sh
@@ -159,9 +159,10 @@ parse_section() {
     else
       DESCR_BUFF=$(echo "$section" | yq -M '.properties.'"$PROP"'.description')
     fi
-    DESCR_BUFF="${DESCR_BUFF:1:-1}"       # Removes first and last quotes "
-    DESCR_BUFF="${DESCR_BUFF//\\\"/\"}"   # Removes escaped quotes "
-    DESCR_BUFF="${DESCR_BUFF//:/\\:}"     # Escapes colons
+    DESCR_BUFF="${DESCR_BUFF:1:-1}"                 # Removes first and last quotes "
+    DESCR_BUFF="${DESCR_BUFF//\\\"/\"}"             # Removes escaped quotes "
+    DESCR_BUFF="${DESCR_BUFF//:/\\:}"               # Escapes colons
+    DESCR_BUFF="${DESCR_BUFF//\\n/ }"               # Replace newlines with spaces
     DESCR_BUFF="$(sed 's|Eclipse Che|{prod-short}|g' <<<$DESCR_BUFF)"
     DESCR_BUFF="$(sed 's|Che |{prod-short} |g' <<<$DESCR_BUFF)"
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

With release of Che 7.87.0, the content of [checlusters.yaml](https://github.com/eclipse-che/che-operator/blob/7.87.x/config/crd/bases/org.eclipse.che_checlusters.yaml) has changed due to upgrade of `controller-gen` software, that is used to create it.

Now, multi-line blocks for property descriptions are prefixed with `| -`, which results in creating extra `\n` sequences, when reading this block with yq. Then these sequences will trigger the HTML link check failure, which could be seen in the failure of [this workflow](https://github.com/eclipse-che/che-docs/actions/runs/9448342722/job/26032463596?pr=2743)

To fix this, in the generator script one extra instruction is added to replace any of the `\n` sequences with a space

## What issues does this pull request fix or reference?
This fix is needed to make the docs buildable (and pass the PR check for the release pull request - https://github.com/eclipse-che/che-docs/pull/2743 )

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
