### PR TITLE
feat: update autoscaler docs to use new Che CR field (#2762)

### DIFF
--- a/modules/administration-guide/pages/configuring-machine-autoscaling.adoc
+++ b/modules/administration-guide/pages/configuring-machine-autoscaling.adoc
@@ -20,24 +20,18 @@ You need to make additional configurations to the {prod-short} installation to e
 
 .Procedure
 
-. In the CheCluster Custom Resource, set the `spec.devEnvironments.startTimeoutSeconds` field to at least 600 seconds to allow time for a new node to be provisioned when needed during workspace startup.
+. In the CheCluster Custom Resource, set the following fields to allow proper workspace startup when the autoscaler is provisioning a new node.
 +
 [source,yaml,subs="+quotes,+attributes"]
 ----
 spec:
   devEnvironments:
-    startTimeoutSeconds: 600
+    startTimeoutSeconds: 600 <1>
+    ignoredUnrecoverableEvents: <2>
+      - FailedScheduling
 ----
-
-. In the DevWorkspaceOperatorConfig Custom Resource in the {prod-namespace} namespace, add the `FailedScheduling` event to the `config.workpsace.ignoredUnrecoverableEvents` field. This allows the workspace startup to not fail if not enough nodes are available. When the new node is provisioned, this allows the workspace startup to continue. 
-+
-[source,yaml,subs="+quotes,+attributes"]
-----
-config:
-  workspace:
-    ignoredUnrecoverableEvents:
-    - FailedScheduling
-----
+<1> Set to at least 600 seconds to allow time for a new node to be provisioned during workspace startup.
+<2> Ignore the `FailedScheduling` event to allow workspace startup to continue when a new node is provisioned. 
 
 == When the autoscaler removes a node
 To prevent workspace pods from being evicted when the autoscaler needs to remove a node, add the `"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"` annotation to every workspace pod.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR cherry-picks changes from this PR: https://github.com/eclipse-che/che-docs/pull/2762

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
