### PR TITLE
fix: add extra notes for enabling fuse

### DIFF
--- a/modules/administration-guide/pages/enabling-fuse-for-all-workspaces.adoc
+++ b/modules/administration-guide/pages/enabling-fuse-for-all-workspaces.adoc
@@ -40,6 +40,8 @@ data:
     mount_program="/usr/bin/fuse-overlayfs"
 ----
 ====
++
+WARNING: Creating this ConfigMap will cause all running workspaces to restart.
 
 . Set the necessary annotation in the `spec.devEnvironments.workspacesPodAnnotations` field of the CheCluster custom resource.
 +
@@ -81,3 +83,15 @@ graphDriverName: overlay
       fuse-overlayfs: version 1.12
   Backing Filesystem: overlayfs
 ----
++
+[NOTE]
+====
+The following error might occur for existing workspaces:
+
+[source]
+----
+ERRO[0000] User-selected graph driver "overlay" overwritten by graph driver "vfs" from database - delete libpod local files ("/home/user/.local/share/containers/storage") to resolve.  May prevent use of images created by other tools 
+----
+
+In this case, delete the libpod local files as mentioned in the error message. 
+====

--- a/modules/end-user-guide/pages/enabling-overlay-with-a-configmap.adoc
+++ b/modules/end-user-guide/pages/enabling-overlay-with-a-configmap.adoc
@@ -69,6 +69,8 @@ data:
     [storage.options.overlay]
     mount_program="/usr/bin/fuse-overlayfs"
 ----
++
+WARNING: Creating this ConfigMap will cause all of your running workspaces to restart.
 
 .Verification steps
 
@@ -91,3 +93,15 @@ graphDriverName: overlay
       fuse-overlayfs: version 1.12
   Backing Filesystem: overlayfs
 ----
++
+[NOTE]
+====
+The following error might occur for existing workspaces:
+
+[source]
+----
+ERRO[0000] User-selected graph driver "overlay" overwritten by graph driver "vfs" from database - delete libpod local files ("/home/user/.local/share/containers/storage") to resolve.  May prevent use of images created by other tools 
+----
+
+In this case, delete the libpod local files as mentioned in the error message. 
+====


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR adds extra notes and warnings for the fuse configuration docs:

Warning:
![Screenshot from 2024-07-23 09-52-20](https://github.com/user-attachments/assets/bc21f771-38ac-40b6-acd7-f0656783e52b)

Note:
![Screenshot from 2024-07-23 09-52-29](https://github.com/user-attachments/assets/05a3226f-6124-4800-a66d-93643700c7bd)



## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
