### PR TITLE
fix validation errors and warnings

### DIFF
--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -38,12 +38,11 @@ spec:
     policyTypes:
     - Ingress
 ----
-====
-+
 <1> The {prod-short} namespace.
 The default is `{prod-namespace}`.
 <2> The empty `podSelector` selects all Pods in the {orch-namespace}.
-
+====
++
 * OPTIONAL: In case you applied link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy], you also must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`. 
 The `allow-from-openshift-apiserver` NetworkPolicy allows incoming traffic from `openshift-apiserver` namespace to the `devworkspace-webhook-server` enabling webhooks.
 The `allow-from-workspaces-namespaces` NetworkPolicy allows incoming traffic from each user project to `che-gateway` pod.
@@ -70,11 +69,10 @@ spec:
   policyTypes:
     - Ingress
 ----
-====
-+
 <1> The {prod-short} namespace.
 The default is `{prod-namespace}`.
 <2> The `podSelector` only selects devworkspace-webhook-server pods
+====
 +
 .`allow-from-workspaces-namespaces.yaml`
 ====
@@ -98,11 +96,11 @@ spec:
   policyTypes:
     - Ingress
 ----
-====
-+
 <1> The {prod-short} namespace.
 The default is `{prod-namespace}`.
 <2> The `podSelector` only selects che-gateway pods
+====
++
 
 .Additional resources
 * xref:configuring-namespace-provisioning.adoc[]

--- a/modules/administration-guide/pages/creating-a-telemetry-plugin.adoc
+++ b/modules/administration-guide/pages/creating-a-telemetry-plugin.adoc
@@ -33,7 +33,6 @@ This document describes the steps required to extend the {prod-short} telemetry 
 
 A finished example of the telemetry backend is available link:https://github.com/che-incubator/devworkspace-telemetry-example-plugin[here].
 
-[discrete]
 == Creating a server that receives events
 
 For demonstration purposes, this example shows how to create a server that receives events from our telemetry plugin and writes them to standard output.

--- a/modules/administration-guide/pages/installing-che-in-the-cloud.adoc
+++ b/modules/administration-guide/pages/installing-che-in-the-cloud.adoc
@@ -3,7 +3,7 @@
 :keywords: overview, running-che-in-the-cloud, installing-che-in-the-cloud
 :navtitle: Installing {prod-short} in the cloud
 
-[id="installing-{prod-id-short}-locally"]
+[id="installing-{prod-id-short}-in-the-cloud"]
 = Installing {prod-short} in the cloud
 
 Deploy and run {prod} in the cloud.
@@ -16,7 +16,7 @@ Deploy and run {prod} in the cloud.
 
 == Deploying {prod-short} in the cloud
 
-Follow the instructions below to start the {prod-short} Server in the cloud using the `{prod-cli}` tool.
+Follow the instructions below to start the {prod-short} Server in the cloud by using the `{prod-cli}` tool.
 
 * xref:installing-che-on-openshift-using-cli.adoc[]
 * xref:installing-che-on-openshift-using-the-web-console.adoc[]

--- a/modules/end-user-guide/pages/starting-a-workspace-from-a-raw-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-workspace-from-a-raw-devfile-url.adoc
@@ -46,7 +46,6 @@ You can pass your personal access token to the URL to access a devfile from *pri
 ----
 pass:c,a,q[{prod-url}]#__https://__<token>__@__<host>__/__<path_to_devfile> <1>
 ----
-+
 <1> Your personal access token that you generated on the Git provider's website.
 +
 This works for GitHub, GitLab, Bitbucket, Microsoft Azure, and other providers that support Personal Access Token.

--- a/modules/end-user-guide/pages/starting-a-workspace-from-a-raw-devfile-url.adoc
+++ b/modules/end-user-guide/pages/starting-a-workspace-from-a-raw-devfile-url.adoc
@@ -47,6 +47,7 @@ You can pass your personal access token to the URL to access a devfile from *pri
 pass:c,a,q[{prod-url}]#__https://__<token>__@__<host>__/__<path_to_devfile> <1>
 ----
 <1> Your personal access token that you generated on the Git provider's website.
+
 +
 This works for GitHub, GitLab, Bitbucket, Microsoft Azure, and other providers that support Personal Access Token.
 +


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Address errors that happen during the build and validate stage:

1) 
```
asciidoctor: ERROR: next@docs::pdf$administration-guide.adoc: line 5995: discret sections do not support nested sections
```
For some reason, antora build incorrectly replaces `[discrete]` tag with `[discret#administration-guide:creating-a-telemetry-plugin:::_creating_a_server_that_receives_eventse]`. breaking apart the tag at the last character. For now, we could remove the heading, while the cause of this issue is still being determined

2) 
```
WARN (asciidoctor): callout list item index: expected 3, got 1
    file: /__w/che-docs/che-docs/modules/administration-guide/pages/configuring-network-policies.adoc:103
    source: /__w/che-docs/che-docs (branch: main <worktree>)
```

most of these warnings could be fixed by moving around admonition / delimiter blocks, removing `+`  linebreaks

3)
```
asciidoctor: WARNING: next@docs::pdf$administration-guide.adoc: line 2484: id assigned to block already in use: installing-che-locally
```
it appears that there are simply two same ids, that was fixed by changing one of them to match the title

## What issues does this pull request fix or reference?
https://github.com/eclipse-che/che/issues/23020

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
