### PR TITLE
fix: correct community meetings wiki url

### DIFF
--- a/modules/overview/pages/introduction-to-eclipse-che.adoc
+++ b/modules/overview/pages/introduction-to-eclipse-che.adoc
@@ -53,9 +53,9 @@ Community blog::
 
 Learn about the latest of {prod} and submit your blog posts to the link:https://che.eclipseprojects.io[{prod} blog].
 
-Weekly meetings::
+Community meetings::
 
-Join us in the link:https://github.com/eclipse/che/wiki/{prod-short}-Dev-Meetings[{prod-short} community meeting] every Monday.
+Join us in the link:https://github.com/eclipse/che/wiki/{prod-id}-community-meetings[{prod-short} community meeting], available on-demand.
 
 Roadmap::
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Broken community meetings wiki URL. (The Che community meeting link currently leads to creating new wiki page, instead I would say it should lead there https://github.com/eclipse-che/che/wiki/Eclipse-Che-Community-Meetings)

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to
main (Eclipse Che 7.89.0)
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
