### PR TITLE
fix: safe-to-evict annotation value

### DIFF
--- a/modules/administration-guide/pages/configuring-machine-autoscaling.adoc
+++ b/modules/administration-guide/pages/configuring-machine-autoscaling.adoc
@@ -34,26 +34,26 @@ spec:
 <2> Ignore the `FailedScheduling` event to allow workspace startup to continue when a new node is provisioned. 
 
 == When the autoscaler removes a node
-To prevent workspace pods from being evicted when the autoscaler needs to remove a node, add the `"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"` annotation to every workspace pod.
+To prevent workspace pods from being evicted when the autoscaler needs to remove a node, add the `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` annotation to every workspace pod.
 
 .Procedure
 
-. In the CheCluster Custom Resource, add the `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"` annotation in the `spec.devEnvironments.workspacesPodAnnotations` field.
+. In the CheCluster Custom Resource, add the `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotation in the `spec.devEnvironments.workspacesPodAnnotations` field.
 +
 [source,yaml,subs="+quotes,+attributes"]
 ----
 spec:
   devEnvironments:
     workspacesPodAnnotations:
-      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 ----
 
 .Verification steps
 
-. Start a workspace and verify that the workspace pod contains the `cluster-autoscaler.kubernetes.io/safe-to-evict: "true"` annotation.
+. Start a workspace and verify that the workspace pod contains the `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotation.
 +
 [subs="+attributes,+quotes"]
 ----
 $ {orch-cli} get pod __<workspace_pod_name>__ -o jsonpath='{.metadata.annotations.cluster-autoscaler\.kubernetes\.io/safe-to-evict}'
-true
+false
 ----


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Fixes nasty typo for the `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotation

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
