### PR TITLE
fix: postgressql removed from docs

### DIFF
--- a/modules/administration-guide/pages/calculating-che-resource-requirements.adoc
+++ b/modules/administration-guide/pages/calculating-che-resource-requirements.adoc
@@ -31,19 +31,6 @@ The `tools` component of the devfile defines the following requests and limits:
     cpuLimit: 4000m
 ----
 ====
-+
-.`postgresql`
-====
-The `postgresql` component does not define any requests and limits and therefore falls back on the defaults for the dedicated container:
-
-[source,yaml,subs="+attributes,+quotes,macros"]
-----
-    memoryLimit: 128M
-    memoryRequest: 64M
-    cpuRequest: 10m
-    cpuLimit: 1000m
-----
-====
 
 ** During the workspace startup, an internal `che-gateway` container is implicitly provisioned with the following requests and limits:
 +

--- a/modules/administration-guide/pages/calculating-che-resource-requirements.adoc
+++ b/modules/administration-guide/pages/calculating-che-resource-requirements.adoc
@@ -64,14 +64,6 @@ The `tools` component of the devfile defines the following requests and limits:
 |4000 m
 |1000 m
 
-|Database
-|`workspace`
-|`postgresql`
-|128 MiB
-|64 MiB
-|1000 m
-|10 m
-
 |{prod-short} gateway
 |`workspace`
 |`che-gateway`
@@ -81,10 +73,10 @@ The `tools` component of the devfile defines the following requests and limits:
 |50 m
 
 3+>s|Total
->s|6.4 GiB
->s|640 MiB
->s|5500 m
->s|1060 m
+>s|6.3 GiB
+>s|576 MiB
+>s|4500 m
+>s|1050 m
 |===
 ====
 

--- a/tools/create_architecture_diagrams.py
+++ b/tools/create_architecture_diagrams.py
@@ -15,7 +15,6 @@ from diagrams import *
 from diagrams.custom import Custom
 from diagrams.k8s.controlplane import APIServer
 from diagrams.k8s.rbac import User
-from diagrams.onprem.database import PostgreSQL
 from diagrams.onprem.network import Traefik
 from diagrams.onprem.vcs import Git
 from diagrams.outscale.compute import Compute
@@ -61,14 +60,13 @@ def architecture_diagrams(prod_short, project_context, orchestrator_name):
         devfile_registries = SimpleStorageService('Devfile registries')
         che_host = Custom(prod_short + ' server', icon_path=prod_icon)
         git = Git('Git provider')
-        postgres = PostgreSQL('PostgreSQL')
         plugin_registry = SimpleStorageService('Plug-in registry')
         kubernetes_api = APIServer(orchestrator_name + ' API')
         user = User('User browser')
         user >> che_gateway
         che_gateway >> [che_dashboard, devfile_registries, che_host,
                         plugin_registry, kubernetes_api]
-        che_host >> [postgres, git]
+        che_host >> [git]
 
     filename = file_path + 'gateway-interactions'
     with Diagram(filename=filename,
@@ -106,14 +104,12 @@ def architecture_diagrams(prod_short, project_context, orchestrator_name):
                  direction="TB",
                  graph_attr=graph_attr):
         che_host = Custom(prod_short + ' server', icon_path=prod_icon)
-        postgres = PostgreSQL('PostgreSQL')
         git_provider = Git('Git provider')
         crd_workspace = APIServer('API')
         che_dashboard = Custom('User dashboard', icon_path=prod_icon)
         che_dashboard >> che_host
         che_host >> [git_provider]
         che_host >> crd_workspace
-        che_host >> postgres
 
     filename = file_path + 'devfile-registry-interactions'
     with Diagram(filename=filename,


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

removed postgressql from docs

## What issues does this pull request fix or reference?

https://github.com/eclipse-che/che/issues/23111

## Specify the version of the product this pull request applies to

main, 7.90

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
