### PR TITLE
feat: update autoscaler documentation

### DIFF
--- a/modules/administration-guide/pages/configuring-machine-autoscaling.adoc
+++ b/modules/administration-guide/pages/configuring-machine-autoscaling.adoc
@@ -27,11 +27,8 @@ You need to make additional configurations to the {prod-short} installation to e
 spec:
   devEnvironments:
     startTimeoutSeconds: 600 <1>
-    ignoredUnrecoverableEvents: <2>
-      - FailedScheduling
 ----
 <1> Set to at least 600 seconds to allow time for a new node to be provisioned during workspace startup.
-<2> Ignore the `FailedScheduling` event to allow workspace startup to continue when a new node is provisioned. 
 
 == When the autoscaler removes a node
 To prevent workspace pods from being evicted when the autoscaler needs to remove a node, add the `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` annotation to every workspace pod.

--- a/modules/administration-guide/pages/configuring-machine-autoscaling.adoc
+++ b/modules/administration-guide/pages/configuring-machine-autoscaling.adoc
@@ -27,8 +27,11 @@ You need to make additional configurations to the {prod-short} installation to e
 spec:
   devEnvironments:
     startTimeoutSeconds: 600 <1>
+    ignoredUnrecoverableEvents: <2>
+      - FailedScheduling
 ----
 <1> Set to at least 600 seconds to allow time for a new node to be provisioned during workspace startup.
+<2> Ignore the `FailedScheduling` event to allow workspace startup to continue when a new node is provisioned. This setting is enabled by default.
 
 == When the autoscaler removes a node
 To prevent workspace pods from being evicted when the autoscaler needs to remove a node, add the `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` annotation to every workspace pod.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Update autoscaling documentation, as there will be no need to change ignoredUnrecoverableEvents anymore. PR is related to these changes https://github.com/eclipse-che/che-operator/pull/1897

## What issues does this pull request fix or reference?
https://github.com/devfile/devworkspace-operator/issues/1280
## Specify the version of the product this pull request applies to
7.92.0

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
