### PR TITLE
chore: Configuring allowed URLs for Cloud Development Environment

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -29,4 +29,5 @@ IgnoreURLs:
   - https://mattermost.eclipse.org/eclipse/channels/eclipse-che
   - https://git.example.com:8443
   - https://stackoverflow.com/questions/tagged/eclipse-che
+  - https://example.com/*
 

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -29,5 +29,5 @@ IgnoreURLs:
   - https://mattermost.eclipse.org/eclipse/channels/eclipse-che
   - https://git.example.com:8443
   - https://stackoverflow.com/questions/tagged/eclipse-che
-  - https://example.com/*
+  - https://example.com/
 

--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -48,6 +48,7 @@
 *** xref:configuring-workspaces-nodeselector.adoc[]
 *** xref:configuring-the-open-vsx-registry-url.adoc[]
 *** xref:configuring-a-user-namespace.adoc[]
+*** xref:configuring-allowed-urls-for-cloud-development-environments.adoc[]
 ** xref:caching-images-for-faster-workspace-start.adoc[]
 *** xref:installing-image-puller-on-kubernetes-by-using-cli.adoc[]
 *** xref:installing-image-puller-on-openshift-using-cli.adoc[]

--- a/modules/administration-guide/pages/configuring-allowed-urls-for-cloud-development-environments.adoc
+++ b/modules/administration-guide/pages/configuring-allowed-urls-for-cloud-development-environments.adoc
@@ -1,0 +1,33 @@
+:_content-type: PROCEDURE
+:description: Configuring allowed URLs for Cloud Development Environments
+:keywords: administration guide, configuring-allowed-sources
+:navtitle: Configuring allowed URLs for Cloud Development Environments
+
+[id="configuring-allowed-urls-for-cloud-development-environments"]
+= Configuring allowed URLs for Cloud Development Environments
+
+Allowed URLs play an important role in securing the initiation of Cloud Development Environments (CDEs), ensuring that they can only be launched from authorized sources. By utilizing wildcard support, such as `*`, organizations can implement flexible URL patterns, allowing for dynamic and secure CDE initiation across various paths within a domain.
+
+. Configure allowed sources:
++
+[source,subs="+quotes,+attributes"]
+----
+{orch-cli} patch checluster/{prod-checluster} \
+    --namespace {prod-namespace} \
+    --type='merge' \
+    -p \
+'{
+   "spec": {
+     "devEnvironments": {
+       "allowedSources": {
+         "urls": ["url_1", "url_2"] <1>
+       }
+     }
+   }
+ }'
+----
+<1> The array of approved URLs for starting Cloud Development Environments (CDEs). CDEs can only be initiated from these URLs. Wildcards `\*` are supported in URLs. For example, `https://example.com/*` would allow CDEs to be initiated from any path within `example.com`.
+
+.Additional resources
+
+* xref:using-the-cli-to-configure-the-checluster-custom-resource.adoc[]

--- a/modules/administration-guide/pages/configuring-workspaces-globally.adoc
+++ b/modules/administration-guide/pages/configuring-workspaces-globally.adoc
@@ -18,3 +18,5 @@ This section describes how an administrator can configure workspaces globally.
 * xref:deploying-che-with-support-for-git-repositories-with-self-signed-certificates.adoc[]
 
 * xref:configuring-workspaces-nodeselector.adoc[]
+
+* xref:configuring-allowed-urls-for-cloud-development-environments.adoc[]


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
chore: Configuring allowed URLs for Cloud Development Environment

## What issues does this pull request fix or reference?
https://github.com/eclipse-che/che/issues/23030

## Specify the version of the product this pull request applies to
main

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
