### PR TITLE
fix: Find out operator subscription name and namespace (#2803)

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -87,7 +87,6 @@ asciidoc:
     prod-operator-index: registry.access.redhat.com/redhat/community-operator-index:v{ocp4-ver}
     prod-operator-package-name: eclipse-che
     prod-operator: che-operator
-    prod-operator-subscription: eclipse-che
     prod-prev-short: Che
     prod-prev-id-short: che
     prod-prev-ver: "previous minor version"

--- a/modules/administration-guide/pages/concealing-editors-definitions.adoc
+++ b/modules/administration-guide/pages/concealing-editors-definitions.adoc
@@ -63,15 +63,16 @@ CHE_EDITOR_CONCEAL_CONFIGMAP_NAME=che-conceal-$CHE_EDITOR_CONCEAL_FILE_NAME
     --from-literal=$CHE_EDITOR_CONCEAL_FILE_NAME=""
 ----
 
-. Find out the Operator subscription namespace (if it exists):
+. Find out the Operator subscription name and namespace (if it exists):
 +
 [source,subs="+attributes"]
 ----
-SUBSCRIPTION_NAMESPACE=$({orch-cli} get subscription \
+SUBSCRIPTION=$({orch-cli} get subscriptions \
     --all-namespaces \
-    --field-selector=metadata.name={prod-operator-subscription} \
-    --output jsonpath='{.items[0].metadata.namespace}' 2>/dev/null
-)
+    --output json \
+        | jq -r '.items[] | select(.spec.name=="{prod-operator-package-name}")')
+SUBSCRIPTION_NAMESPACE=$(echo $SUBSCRIPTION | jq -r '.metadata.namespace')
+SUBSCRIPTION_NAME=$(echo $SUBSCRIPTION | jq -r '.metadata.name')
 ----
 
 . Patch the {kubernetes} resource to mount the ConfigMap with the empty editor definition. The resource to patch depends on the existence of the Operator subscription. If the subscription exists, then the subscription should be patched. If not, patch the Operator deployment:
@@ -79,8 +80,8 @@ SUBSCRIPTION_NAMESPACE=$({orch-cli} get subscription \
 [source,subs="+attributes"]
 ----
 if [[ -n $SUBSCRIPTION_NAMESPACE ]]; then
-    if [[ $({orch-cli} get subscription {prod-operator-subscription} --namespace $SUBSCRIPTION_NAMESPACE --output jsonpath='{.spec.config}') == "" ]]; then
-        {orch-cli} patch subscription {prod-operator-subscription} \
+    if [[ $({orch-cli} get subscription $SUBSCRIPTION_NAME --namespace $SUBSCRIPTION_NAMESPACE --output jsonpath='{.spec.config}') == "" ]]; then
+        {orch-cli} patch subscription $SUBSCRIPTION_NAME \
           --namespace $SUBSCRIPTION_NAMESPACE \
           --type json \
           --patch '[{
@@ -90,8 +91,8 @@ if [[ -n $SUBSCRIPTION_NAMESPACE ]]; then
             }]'
     fi
 
-    if [[ $({orch-cli} get subscription {prod-operator-subscription} --namespace $SUBSCRIPTION_NAMESPACE --output jsonpath='{.spec.config.volumes}') == "" ]]; then
-        {orch-cli} patch subscription {prod-operator-subscription} \
+    if [[ $({orch-cli} get subscription $SUBSCRIPTION_NAME --namespace $SUBSCRIPTION_NAMESPACE --output jsonpath='{.spec.config.volumes}') == "" ]]; then
+        {orch-cli} patch subscription $SUBSCRIPTION_NAME \
           --namespace $SUBSCRIPTION_NAMESPACE \
           --type json \
           --patch '[{
@@ -101,8 +102,8 @@ if [[ -n $SUBSCRIPTION_NAMESPACE ]]; then
             }]'
     fi
 
-    if [[ $({orch-cli} get subscription {prod-operator-subscription} --namespace $SUBSCRIPTION_NAMESPACE --output jsonpath='{.spec.config.volumeMounts}') == "" ]]; then
-        {orch-cli} patch subscription {prod-operator-subscription} \
+    if [[ $({orch-cli} get subscription $SUBSCRIPTION_NAME --namespace $SUBSCRIPTION_NAMESPACE --output jsonpath='{.spec.config.volumeMounts}') == "" ]]; then
+        {orch-cli} patch subscription $SUBSCRIPTION_NAME \
           --namespace $SUBSCRIPTION_NAMESPACE \
           --type json \
           --patch '[{
@@ -112,7 +113,7 @@ if [[ -n $SUBSCRIPTION_NAMESPACE ]]; then
             }]'
     fi
 
-    {orch-cli} patch subscription {prod-operator-subscription} \
+    {orch-cli} patch subscription $SUBSCRIPTION_NAME \
       --namespace $SUBSCRIPTION_NAMESPACE \
       --type json \
       --patch '[{


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
fix: Find out operator subscription name and namespace

## What issues does this pull request fix or reference?
https://github.com/eclipse-che/che/issues/23087

## Specify the version of the product this pull request applies to
7.92.x

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
