### PR TITLE
feat: Allow to configure 2 gitlab providers simultaneously

### DIFF
--- a/modules/administration-guide/partials/proc_applying-the-gitlab-authorized-application-secret.adoc
+++ b/modules/administration-guide/partials/proc_applying-the-gitlab-authorized-application-secret.adoc
@@ -56,3 +56,5 @@ EOF
 ----
 
 . Verify in the output that the Secret is created.
+
+To configure OAuth 2.0 for another Gitlab provider, you have to repeat the steps above and create a second Gitlab OAuth Secret with a different name.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Add an info about configuring additional gitlab oauth provider
## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-7142
## Specify the version of the product this pull request applies to
next
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
