### PR TITLE
Cherry pick NetworkPolicy podSelector fix to 7.94.x branch

### DIFF
--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -84,9 +84,7 @@ metadata:
   name: allow-from-workspaces-namespaces
   namespace: {prod-namespace}   <1>
 spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/component: che-gateway   <2>
+  podSelector: {}   <2>
   ingress:
     - from:
         - podSelector: {}
@@ -98,7 +96,7 @@ spec:
 ----
 <1> The {prod-short} namespace.
 The default is `{prod-namespace}`.
-<2> The `podSelector` only selects che-gateway pods
+<2> The empty `podSelector` selects all pods in the {prod-short} namespace.
 ====
 +
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR cherry picks the fix from https://github.com/eclipse-che/che-docs/pull/2818 to the 7.94.x branch.

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-6251

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
