### PR TITLE
docs: Apply editor configurations from a ConfigMap

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -109,6 +109,7 @@
 ** xref:configuring-single-and-multiroot-workspaces.adoc[]
 ** xref:trusted-extensions-for-microsoft-visual-studio-code.adoc[]
 ** xref:default-extensions-for-microsoft-visual-studio-code.adoc[]
+** xref:editor-configurations-for-microsoft-visual-studio-code.adoc[]
 * xref:managing-workloads-using-the-che-server-api.adoc[]
 * xref:upgrading-che.adoc[]
 ** xref:upgrading-the-chectl-management-tool.adoc[]

--- a/modules/administration-guide/pages/configuring-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/configuring-visual-studio-code.adoc
@@ -12,3 +12,4 @@ Learn how to configure Visual Studio Code - Open Source ("Code - OSS").
 * xref:configuring-single-and-multiroot-workspaces.adoc[]
 * xref:trusted-extensions-for-microsoft-visual-studio-code.adoc[]
 * xref:default-extensions-for-microsoft-visual-studio-code.adoc[]
+* xref:editor-configurations-for-microsoft-visual-studio-code.adoc[]

--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -21,7 +21,7 @@ The `extensions.json` section contains recommented extensions are installed when
 
 .Procedure
 
-* Add a new ConfigMap to the user's {orch-namespace}, define the `__settings.json__`  and `__extensions.json__` sections, specify the settings you want to add, and the IDs of the extensions you want to install.
+* Add a new ConfigMap to the user's {orch-namespace}, define the `settings.json`  and `extensions.json` sections, specify the settings you want to add, and the IDs of the extensions you want to install.
 +
 ====
 [source,yaml]

--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -16,7 +16,7 @@ The following sections are currently supported:
 * settings.json
 * extensions.json
 
-`settings.json` section contains various settings that allow to customize different parts of the Code - OSS editor. +
+The `settings.json` section contains various settings that allow to customize different parts of the Code - OSS editor. +
 `extensions.json` section contains recommented extensions are installed when a workspace is started.
 
 .Procedure

--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -21,7 +21,7 @@ The `extensions.json` section contains recommented extensions are installed when
 
 .Procedure
 
-* Add a new ConfigMap to the user's {orch-namespace}, define the __settings.json__  and __extensions.json__ sections, specify the settings you want to add and the IDs of the extensions you want to install.
+* Add a new ConfigMap to the user's {orch-namespace}, define the `__settings.json__`  and `__extensions.json__` sections, specify the settings you want to add, and the IDs of the extensions you want to install.
 +
 ====
 [source,yaml]

--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -55,7 +55,7 @@ immutable: false
 
 [NOTE]
 ====
-Ensure the Configmap contains data in a valid JSON format.
+Make sure that the Configmap contains data in a valid JSON format.
 ====
 
 .Verification

--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -17,7 +17,7 @@ The following sections are currently supported:
 * extensions.json
 
 The `settings.json` section contains various settings that allow to customize different parts of the Code - OSS editor. +
-`extensions.json` section contains recommented extensions are installed when a workspace is started.
+The `extensions.json` section contains recommented extensions are installed when a workspace is started.
 
 .Procedure
 

--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -1,0 +1,70 @@
+:_content-type: PROCEDURE
+:description: Applying editor configurations
+:keywords: settings, extensions, configurations
+:navtitle: Applying editor configurations
+// :page-aliases:
+
+[id="visual-studio-code-editor-configs"]
+= Applying editor configurations
+
+You can configure Visual Studio Code - Open Source editor by adding configurations to a ConfigMap.
+These configurations are applied to any workspace you open.
+Once a workspace is started, the editor checks for this ConfigMap and stores configurations to the corresponding config files.
+
+The following sections are currently supported:
+
+* settings.json
+* extensions.json
+
+`settings.json` section contains various settings that allow to customize different parts of the Code - OSS editor. +
+`extensions.json` section contains recommented extensions are installed when a workspace is started.
+
+.Procedure
+
+* Add a new ConfigMap to the user's {orch-namespace}, define the __settings.json__  and __extensions.json__ sections, specify the settings you want to add and the IDs of the extensions you want to install.
++
+====
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vscode-editor-configurations
+data: 
+  extensions.json: |
+    {
+      "recommendations": [
+          "dbaeumer.vscode-eslint",
+          "github.vscode-pull-request-github"
+      ]
+    }
+  settings.json: |
+    {
+      "window.header": "A HEADER MESSAGE",
+      "window.commandCenter": false,
+      "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#CCA700",
+        "titleBar.activeForeground": "#ffffff"
+      }
+    }
+immutable: false
+----
+====
+
+* Start or restart your workspace 
+
+[NOTE]
+====
+Ensure the Configmap contains data in a valid JSON format.
+====
+
+.Verification
+. Verify that settings defined in the ConfigMap are applied using one of the following methods:
+* Use `F1 → Preferences: Open Remote Settings` to check if the defined settings are applied. 
+* Ensure that the settings from the ConfigMap are present in the `/checode/remote/data/Machine/settings.json` file by using the `F1 → File: Open File...` command to inspect the file's content.
+
+. Verify that extensions defined in the ConfigMap are applied:
+* Go to the `Extensions` view (`F1 → View: Show Extensions`) and check that the extensions are installed
+* Ensure that the extensions from the ConfigMap are present in the `.code-workspace` file by using the `F1 → File: Open File...` command. By default, the workspace file is placed at `/projects/.code-workspace`.
+
+


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Adds a page that contains steps how to apply editor configurations using a ConfigMap.

<img width="1147" alt="image" src="https://github.com/user-attachments/assets/6dc5d53a-0a67-404c-bffc-a9c088b17b44" />

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/d33ff8ee-8ea3-4b72-97ab-0692f533fe44" />

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/8898a011-bb74-4037-97e6-1d49b638436f" />


## What issues does this pull request fix or reference?
It was done for the https://issues.redhat.com/browse/CRW-7258.
PR in the Che-Code: https://github.com/che-incubator/che-code/pull/460

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
