### PR TITLE
feat: publication-builder job will also trigger che-website-publish job

### DIFF
--- a/.github/workflows/publication-builder.yaml
+++ b/.github/workflows/publication-builder.yaml
@@ -65,3 +65,9 @@ jobs:
           github_token: ${{ secrets.CHE_BOT_GITHUB_TOKEN }}
           publish_branch: publication
           publish_dir: build/site
+  call-che-website-publish:
+    name: "Call website publication update"
+    needs: build
+    uses: eclipse-che/che-website-publish/blob/main/.github/workflows/publish.yaml
+    secrets:
+      CHE_BOT_GITHUB_TOKEN: ${{ secrets.CHE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Updating publication-builder job, so that it will automatically trigger che-website-publish job on completion (as an alternative to the current twice a day timed run of the publish job), further bridging[ Phase 4 and Phase 5](https://github.com/eclipse-che/che-release?tab=readme-ov-file#statuses) of Che release steps

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
