### PR TITLE
Fixed typo

### DIFF
--- a/modules/administration-guide/partials/proc_viewing-dev-workspace-operator-metrics-on-grafana-dashboards.adoc
+++ b/modules/administration-guide/partials/proc_viewing-dev-workspace-operator-metrics-on-grafana-dashboards.adoc
@@ -37,4 +37,4 @@ NOTE: The dashboard definition is based on Grafana 6.x dashboards. Not all Grafa
 
 . In the *Administrator* view of the OpenShift web console, go to *Observe* -> *Dashboards*.
 
-. Go to *Dashboard* -> *Che Server JVM* and verify that the dashboard panels contain data.
+. Go to *Dashboard* -> *Dev Workspace Operator* and verify that the dashboard panels contain data.


### PR DESCRIPTION
Fixed a typo that references to "Che Server JVM" instead of "Dev Workspace Operator"