### PR TITLE
Fixed typo

### DIFF
--- a/modules/administration-guide/partials/proc_viewing-che-metrics-on-grafana-dashboards.adoc
+++ b/modules/administration-guide/partials/proc_viewing-che-metrics-on-grafana-dashboards.adoc
@@ -40,7 +40,7 @@ NOTE: The dashboard definition is based on Grafana 6.x dashboards. Not all Grafa
 
 . In the *Administrator* view of the OpenShift web console, go to *Observe* -> *Dashboards*.
 
-. Go to *Dashboard* -> *Dev Workspace Operator* and verify that the dashboard panels contain data.
+. Go to *Dashboard* -> *Che Server JVM* and verify that the dashboard panels contain data.
 +
 .Quick Facts
 image::monitoring/monitoring-che-che-server-jvm-dashboard-quick-facts.png[The *JVM quick facts* panel, link="{imagesdir}/monitoring/monitoring-che-che-server-jvm-dashboard-quick-facts.png"]


### PR DESCRIPTION
Fixed a typo that references to "Dev Workspace Operator" instead of "Che Server JVM"