### PR TITLE
Add Microsoft DevAzure Server notes

### DIFF
--- a/modules/administration-guide/pages/configuring-oauth-2-for-microsoft-azure-devops-services.adoc
+++ b/modules/administration-guide/pages/configuring-oauth-2-for-microsoft-azure-devops-services.adoc
@@ -16,6 +16,9 @@ pass:[<!-- vale RedHat.Spelling = YES -->]
 . Set up the Microsoft Azure DevOps Services OAuth App (OAuth 2.0).
 . Apply the Microsoft Azure DevOps Services OAuth App Secret.
 
+[IMPORTANT]
+Microsoft DevAzure Server does not support oAuth2, see link:https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops[the documentation page].
+
 include::partial$proc_setting-up-the-microsoft-azure-devops-services-oauth-app.adoc[leveloffset=+1]
 
 include::partial$proc_applying-the-microsoft-azure-devops-services-oauth-app-secret.adoc[leveloffset=+1]

--- a/modules/administration-guide/pages/configuring-oauth-2-for-microsoft-azure-devops-services.adoc
+++ b/modules/administration-guide/pages/configuring-oauth-2-for-microsoft-azure-devops-services.adoc
@@ -17,7 +17,7 @@ pass:[<!-- vale RedHat.Spelling = YES -->]
 . Apply the Microsoft Azure DevOps Services OAuth App Secret.
 
 [IMPORTANT]
-Microsoft DevAzure Server does not support oAuth2, see link:https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops[the documentation page].
+OAuth 2.0 isn't supported on Azure DevOps Server, see link:https://learn.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops[the documentation page].
 
 include::partial$proc_setting-up-the-microsoft-azure-devops-services-oauth-app.adoc[leveloffset=+1]
 

--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -84,7 +84,7 @@ type: Opaque
 <1> Your {prod-short} user ID.
 <2> The Git provider name: `github` or `gitlab` or `bitbucket-server` or `azure-devops`.
 <3> The Git provider URL.
-<4> This line is only applicable to `azure-devops`: your Git provider user organization, or collection if DevAzure Server is used.
+<4> This line is only applicable to `azure-devops`: your Git provider user organization, or collection if Azure DevOps Server is used.
 
 . Visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
 

--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -130,6 +130,8 @@ To generate the key-value pair, use the following command:
 echo -n "extraheader = \"Authorization: Basic "$(printf ":%s" <personal access token> | base64)\"
 ```
 see link:https://learn.microsoft.com/en-us/azure/devops/repos/git/auth-overview?view=azure-devops&tabs=Linux#personal-access-tokens[the documentation page] for more information.
+
+This header is needed for remote git operations to Azure Devops Server, e.g. `git clone`. This authorization method has higher priority over the git credentials store, so git will fail on remote operations to other git providers. To be able to use other providers you need to remove the `extraheader` from the gitconfig.
 ====
 
 .Verification

--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -116,6 +116,20 @@ __<Secret_prepared_in_step_5>__
 EOF
 ----
 ====
+. Azure DevOps Server. If you are using Azure DevOps Server, you must also modify the xref:mounting-git-configuration.adoc[workspace's
+gitconfig] with the following section:
++
+```
+[http]
+    extraheader = "Authorization: Basic <base64-encoded(:personal-access-token)>"
+```
+To generate the key-value pair, use the following command:
++
+```
+echo -n "extraheader = Authorization: Basic "$(printf ":%s" <personal access token> | base64)
+```
++
+see link:https://learn.microsoft.com/en-us/azure/devops/repos/git/auth-overview?view=azure-devops&tabs=Linux#personal-access-tokens[the documentation page] for more information.
 
 .Verification
 

--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -131,7 +131,7 @@ echo -n "extraheader = \"Authorization: Basic "$(printf ":%s" <personal access t
 ```
 see link:https://learn.microsoft.com/en-us/azure/devops/repos/git/auth-overview?view=azure-devops&tabs=Linux#personal-access-tokens[the documentation page] for more information.
 
-This header is needed for remote git operations to Azure Devops Server, e.g. `git clone`. This authorization method has higher priority over the git credentials store, so git will fail on remote operations to other git providers. To be able to use other providers you need to remove the `extraheader` from the gitconfig.
+The `extraheader` configuration is needed for remote git operations to Azure Devops Server, e.g. `git clone`. This authorization method has a higher priority over the git credentials store, and as a result, the remote operations to other Git providers will fail.
 ====
 
 .Verification

--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -116,20 +116,21 @@ __<Secret_prepared_in_step_5>__
 EOF
 ----
 ====
-. Azure DevOps Server. If you are using Azure DevOps Server, you must also modify the xref:mounting-git-configuration.adoc[workspace's
+
+[IMPORTANT]
+====
+If you are using Azure DevOps Server, you must also modify the xref:mounting-git-configuration.adoc[workspace's
 gitconfig] with the following section:
-+
 ```
 [http]
     extraheader = "Authorization: Basic <base64-encoded(:personal-access-token)>"
 ```
 To generate the key-value pair, use the following command:
-+
 ```
-echo -n "extraheader = Authorization: Basic "$(printf ":%s" <personal access token> | base64)
+echo -n "extraheader = \"Authorization: Basic "$(printf ":%s" <personal access token> | base64)\"
 ```
-+
 see link:https://learn.microsoft.com/en-us/azure/devops/repos/git/auth-overview?view=azure-devops&tabs=Linux#personal-access-tokens[the documentation page] for more information.
+====
 
 .Verification
 

--- a/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
+++ b/modules/end-user-guide/pages/using-a-git-provider-access-token.adoc
@@ -84,7 +84,7 @@ type: Opaque
 <1> Your {prod-short} user ID.
 <2> The Git provider name: `github` or `gitlab` or `bitbucket-server` or `azure-devops`.
 <3> The Git provider URL.
-<4> This line is only applicable to `azure-devops`: your Git provider user organization.
+<4> This line is only applicable to `azure-devops`: your Git provider user organization, or collection if DevAzure Server is used.
 
 . Visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
* Add a note to the Azure Devops oauth setup page that the Server version does not support oAuth 2.
* Modify the description of the `Organization` annotation in the Personal Access Token setup page.

## What issues does this pull request fix or reference?
do not merge until https://github.com/eclipse-che/che/issues/23306 is merged
## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
