### PR TITLE
chore: update upload-artifact GH action to v4

### DIFF
--- a/.github/workflows/build-and-validate-on-pr.yaml
+++ b/.github/workflows/build-and-validate-on-pr.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > PR_SHA
 
       - name: Upload artifact doc-content
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: doc-content
           path: |

--- a/.github/workflows/build-and-validate-on-push.yaml
+++ b/.github/workflows/build-and-validate-on-push.yaml
@@ -50,7 +50,7 @@ jobs:
         run: CI=true antora generate antora-playbook-for-development.yml --stacktrace --log-failure-level=warn
 
       - name: Upload artifact doc-content
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: doc-content
           path: build/site


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Updates `actions/upload-artifact` from v3 to v4

## What issues does this pull request fix or reference?
Because v3 is depreacted, there is a workflow failure: https://github.com/eclipse-che/che-docs/actions/runs/13063620188/job/36451933090

See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
