### PR TITLE
fix: fix case of kubectl create secret tls

### DIFF
--- a/modules/administration-guide/pages/configuring-che-hostname.adoc
+++ b/modules/administration-guide/pages/configuring-che-hostname.adoc
@@ -32,7 +32,7 @@ $ {orch-cli} create {orch-namespace} {prod-namespace}
 +
 [subs="+quotes,attributes"]
 ----
-$ {orch-cli} create secret TLS __<tls_secret_name>__ \ <1>
+$ {orch-cli} create secret tls __<tls_secret_name>__ \ <1>
 --key __<key_file>__ \ <2>
 --cert __<cert_file>__ \ <3>
 -n {prod-namespace}


### PR DESCRIPTION
## What does this pull request change?

`kubectl create secret TLS` does not work, must be case-sensitive.

## What issues does this pull request fix or reference?

None.

## Specify the version of the product this pull request applies to

Any.

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
