### PR TITLE
chore: Simplify Importing untrusted TLS certificates to Che doc

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -30,4 +30,5 @@ IgnoreURLs:
   - https://git.example.com:8443
   - https://stackoverflow.com/questions/tagged/eclipse-che
   - https://example.com/
+  - https://gdpr.eu/
 

--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -16,14 +16,17 @@ Therefore, you must import into {prod-short} all untrusted CA chains in use by a
 * A source code repositories provider (Git)
 
 {prod-short} uses labeled ConfigMaps in {prod-short} {orch-namespace} as sources for TLS certificates.
-The ConfigMaps can have an arbitrary amount of keys with a random amount of certificates each. Operator merges all ConfigMaps into a single one titled `ca-certs-merged`, and mounts it as a volume in the {prod-short} server, dashboard and workspace pods. 
-By default, the Operator mounts the `ca-certs-merged` ConfigMap in a user's workspace at two locations: `/public-certs` and `/etc/pki/ca-trust/extracted/pem`. The `/etc/pki/ca-trust/extracted/pem` directory is where the system stores extracted CA certificates for trusted certificate authorities on Red Hat (e.g., CentOS, Fedora). CLI tools automatically use certificates from the system-trusted locations, when the user's workspace is up and running.
+The ConfigMaps can have an arbitrary amount of keys with a random amount of certificates each.
+All certificates are mounted into:
 
-[NOTE]
+* `/public-certs` location of {prod-short} server and dashboard pods
+* `/public-certs` and `/etc/pki/ca-trust/extracted/pem` locations of workspaces pods
+
+The `/etc/pki/ca-trust/extracted/pem` directory is where the system stores extracted CA certificates for trusted certificate authorities on Red Hat (e.g., CentOS, Fedora). CLI tools automatically use certificates from the system-trusted locations, when the user's workspace is up and running.
+
+[IMPORTANT]
 ====
-When an OpenShift cluster contains cluster-wide trusted CA certificates added through the link:https://docs.openshift.com/container-platform/latest/networking/configuring-a-custom-pki.html#nw-proxy-configure-object_configuring-a-custom-pki[cluster-wide-proxy configuration],
-{prod-short} Operator detects them and automatically injects them into a ConfigMap with the `config.openshift.io/inject-trusted-cabundle="true"` label.
-Based on this annotation, OpenShift automatically injects the cluster-wide trusted CA certificates inside the `ca-bundle.crt` key of the ConfigMap.
+On OpenShift cluster, {prod-short} operator automatically adds Red Hat Enterprise Linux CoreOS (RHCOS) trust bundle into mounted certificates.
 ====
 
 .Prerequisites


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
chore: Simplify Importing untrusted TLS certificates to Che doc

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-7990

## Specify the version of the product this pull request applies to
main

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
