### PR TITLE
chore: add info about building plugin registry for ppc64le and s390x

### DIFF
--- a/modules/administration-guide/partials/proc_adding-or-removing-extensions-in-the-embedded-open-vsx-registry-instance.adoc
+++ b/modules/administration-guide/partials/proc_adding-or-removing-extensions-in-the-embedded-open-vsx-registry-instance.adoc
@@ -43,6 +43,11 @@ If the extension publisher is unavailable or unwilling to publish the extension 
 ====
 
 .. Using {prod-short} instance:
++
+[IMPORTANT]
+====
+For IBM Power (`ppc64le`) and IBM Z (`s390x`), the custom plugin registry is expected to be built locally on the corresponding architecture.
+====
 
 ... Login to your {prod-short} instance as an administrator.
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.


-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Add info that for ppc64le and s390x, the custom plugin registry is expected to be built only locally

![screenshot-67b728a9c660e537450c8ae9--eclipse-che-docs-pr_netlify_app-2025_02_20-15_07_25](https://github.com/user-attachments/assets/82e5bf37-7b18-411c-95cd-57788e8af0c9)
## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-8241

## Specify the version of the product this pull request applies to
Che 7.95 - DS 3.18
Che 7.97 - DS 3.19 
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
