### PR TITLE
fix: updated ocp version and links

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -98,8 +98,8 @@ asciidoc:
     prod-upstream: Eclipse&#160;Che
     prod-url: "https://__&lt;che_fqdn&gt;__"
     prod-ver-major: "7"
-    prod-ver-patch: "7.99.0"
-    prod-ver: "7.99"
+    prod-ver-patch: "7.101.0"
+    prod-ver: "7.101"
     prod-workspace: che-ws
     prod: Eclipse&#160;Che
     prod2: Eclipse&#160;Che

--- a/antora.yml
+++ b/antora.yml
@@ -21,7 +21,7 @@ asciidoc:
     ocp: OpenShift&#160;Container&#160;Platform
     # recommended OCP version for new deployments
     # included in links to OCP docs and in catalog source links: do not include the "v" prefix here
-    ocp4-ver: "4.12"
+    ocp4-ver: "4.17"
     # for the project
     che-plugin-registry-directory: che-plugin-registry
     devworkspace-operator-index-disconnected-install: quay.io/devfile/devworkspace-operator-index:release-digest

--- a/antora.yml
+++ b/antora.yml
@@ -21,7 +21,7 @@ asciidoc:
     ocp: OpenShift&#160;Container&#160;Platform
     # recommended OCP version for new deployments
     # included in links to OCP docs and in catalog source links: do not include the "v" prefix here
-    ocp4-ver: "4.17"
+    ocp4-ver: "4.18"
     # for the project
     che-plugin-registry-directory: che-plugin-registry
     devworkspace-operator-index-disconnected-install: quay.io/devfile/devworkspace-operator-index:release-digest

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -43,7 +43,7 @@ The default is `{prod-namespace}`.
 <2> The empty `podSelector` selects all Pods in the {orch-namespace}.
 ====
 +
-* OPTIONAL: In case you applied link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy], you also must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`. 
+* OPTIONAL: In case you applied link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/networking/network-security#nw-networkpolicy-multitenant-isolation_multitenant-network-policy[Configuring multitenant isolation with network policy], you also must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`.
 The `allow-from-openshift-apiserver` NetworkPolicy allows incoming traffic from `openshift-apiserver` namespace to the `devworkspace-webhook-server` enabling webhooks.
 The `allow-from-workspaces-namespaces` NetworkPolicy allows incoming traffic from each user project to `che-gateway` pod.
 +

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -105,4 +105,4 @@ The default is `{prod-namespace}`.
 
 * link:https://kubernetes.io/docs/concepts/security/multi-tenancy/#network-isolation[Network isolation]
 
-* link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/networking/network-security#nw-networkpolicy-multitenant-isolation_multitenant-network-policy[Configuring multitenant isolation with network policy]

--- a/modules/administration-guide/pages/enabling-access-to-dev-fuse-for-openshift.adoc
+++ b/modules/administration-guide/pages/enabling-access-to-dev-fuse-for-openshift.adoc
@@ -18,7 +18,7 @@ This procedure is not necessary for OpenShift versions 4.15 and later, since the
 ====
 Creating `MachineConfig` resources on an OpenShift cluster is a potentially dangerous task, as you are making advanced, system-level changes to the cluster.
 
-View the link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html-single/post-installation_configuration/index#post-install-machine-configuration-tasks[MachineConfig documentation] for more details and possible risks.
+View the link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/machine_configuration/machine-config-index#about-machine-config-operator_machine-config-overview[MachineConfig documentation] for more details and possible risks.
 
 ====
 

--- a/modules/administration-guide/pages/enabling-access-to-dev-fuse-for-openshift.adoc
+++ b/modules/administration-guide/pages/enabling-access-to-dev-fuse-for-openshift.adoc
@@ -18,7 +18,7 @@ This procedure is not necessary for OpenShift versions 4.15 and later, since the
 ====
 Creating `MachineConfig` resources on an OpenShift cluster is a potentially dangerous task, as you are making advanced, system-level changes to the cluster.
 
-View the link:https://docs.openshift.com/container-platform/{ocp4-ver}/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks[MachineConfig documentation] for more details and possible risks.
+View the link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html-single/post-installation_configuration/index#post-install-machine-configuration-tasks[MachineConfig documentation] for more details and possible risks.
 
 ====
 

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -7,7 +7,7 @@
 
 * The OpenShift cluster has at least 64 GB of disk space.
 
-* The OpenShift cluster is ready to operate on a restricted network. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/installing/disconnected_install/index.html[About disconnected installation mirroring] and link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admin/olm-restricted-networks.html[Using Operator Lifecycle Manager on restricted networks].
+* The OpenShift cluster is ready to operate on a restricted network. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/disconnected_environments/mirroring-in-disconnected-environments[About disconnected installation mirroring] and link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admin/olm-restricted-networks.html[Using Operator Lifecycle Manager on restricted networks].
 
 // NOTE for testers: don't use the internal registry present on `crc`.
 
@@ -26,7 +26,7 @@
 
 * `skopeo` version 1.6 or higher. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo].
 
-* An active `skopeo` session with administrative access to the private Docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.openshift.com/container-platform/{ocp4-ver}/installing/disconnected_install/installing-mirroring-installation-images.html[Mirroring images for a disconnected installation].
+* An active `skopeo` session with administrative access to the private Docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/disconnected_environments/mirroring-in-disconnected-environments[Mirroring images for a disconnected installation].
 
 * `{prod-cli}` for {prod-short} version {prod-ver}. See xref:installing-the-chectl-management-tool.adoc[].
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

updated ocp version in antora and replaced old ocp docs links

## What issues does this pull request fix or reference?

https://issues.redhat.com/browse/CRW-8295

## Specify the version of the product this pull request applies to

main, 7.100

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
