### PR TITLE
fix: typo in persistent home docs

### DIFF
--- a/modules/administration-guide/pages/about-persistent-user-home.adoc
+++ b/modules/administration-guide/pages/about-persistent-user-home.adoc
@@ -29,7 +29,7 @@ The primary function of the `stow` command is to run:
 stow -t /home/user/ -d /home/tooling/ --no-folding
 ----
 
-The command above creates symbolic links in `/home/user` for files and directories located in /home/tooling. This populates the persistent volume with symbolic links to the content in `/home/tooling`. As a result, it the `persistentUserHome` feature expects the tooling image to have its `/home/user/` content within `/home/tooling`.
+The command above creates symbolic links in `/home/user` for files and directories located in `/home/tooling`. This populates the persistent volume with symbolic links to the content in `/home/tooling`. As a result, the `persistentUserHome` feature expects the tooling image to have its `/home/user/` content within `/home/tooling`.
 
 For example, if the tools container image contains files in the `home/tooling` directory such as `.config` and `.config-folder/another-file`, stow will create symbolic links in the persistent volume in the following manner:
 

--- a/modules/administration-guide/pages/about-persistent-user-home.adoc
+++ b/modules/administration-guide/pages/about-persistent-user-home.adoc
@@ -29,7 +29,7 @@ The primary function of the `stow` command is to run:
 stow -t /home/user/ -d /home/tooling/ --no-folding
 ----
 
-The command above creates symbolic links in `/home/user` for files and directories located in `/home/tooling`. This populates the persistent volume with symbolic links to the content in `/home/tooling`. As a result, the `persistentUserHome` feature expects the tooling image to have its `/home/user/` content within `/home/tooling`.
+The command above creates symbolic links in `/home/user` for files and directories located in `/home/tooling`. This populates the persistent volume with symbolic links to the content in `/home/tooling`. As a result, the `persistUserHome` feature expects the tooling image to have its `/home/user/` content within `/home/tooling`.
 
 For example, if the tools container image contains files in the `home/tooling` directory such as `.config` and `.config-folder/another-file`, stow will create symbolic links in the persistent volume in the following manner:
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Fixes a typo in the persistent home documentation

## What issues does this pull request fix or reference?
n/a

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
