### PR TITLE
feat: allow to configure product.json using Config Map

### DIFF
--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -9,7 +9,7 @@
 
 With the multi-root workspace feature, you can work with multiple project folders in the same workspace. This is useful when you are working on several related projects at once, such as product documentation and product code repositories.
 
-TIP: See link: https://code.visualstudio.com/docs/editing/workspaces/workspaces[What is a VS Code workspace] for better understanding and authoring the workspace files.
+TIP: See link:https://code.visualstudio.com/docs/editing/workspaces/workspaces[What is a VS Code workspace] for better understanding and authoring the workspace files.
 
 [NOTE]
 ====

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -9,7 +9,7 @@
 
 With the multi-root workspace feature, you can work with multiple project folders in the same workspace. This is useful when you are working on several related projects at once, such as product documentation and product code repositories.
 
-TIP: See link:https://code.visualstudio.com/docs/editor/workspaces[What is a VS Code "workspace"] for better understanding and authoring the workspace files.
+TIP: See link: https://code.visualstudio.com/docs/editing/workspaces/workspaces[What is a VS Code workspace] for better understanding and authoring the workspace files.
 
 [NOTE]
 ====

--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -15,9 +15,11 @@ The following sections are currently supported:
 
 * settings.json
 * extensions.json
+* product.json
 
-The `settings.json` section contains various settings that allow to customize different parts of the Code - OSS editor. +
-The `extensions.json` section contains recommented extensions are installed when a workspace is started.
+The *settings.json* section contains various settings that allow to customize different parts of the Code - OSS editor. +
+The *extensions.json* section contains recommended extensions are installed when a workspace is started. +
+The *product.json* section contains properties that you need to add to the editor's *product.json* file. If the property already exists, its value will be updated.
 
 .Procedure
 
@@ -47,6 +49,19 @@ data:
         "titleBar.activeForeground": "#ffffff"
       }
     }
+  product.json: |
+    {
+      "extensionEnabledApiProposals": {
+        "ms-python.python": [
+          "contribEditorContentMenu",
+          "quickPickSortByLabel",
+        ]
+      },
+      "trustedExtensionAuthAccess": [
+        "<publisher1>.<extension1>",
+        "<publisher2>.<extension2>"
+      ]
+    }
 immutable: false
 ----
 ====
@@ -67,4 +82,7 @@ Make sure that the Configmap contains data in a valid JSON format.
 * Go to the `Extensions` view (`F1 → View: Show Extensions`) and check that the extensions are installed
 * Ensure that the extensions from the ConfigMap are present in the `.code-workspace` file by using the `F1 → File: Open File...` command. By default, the workspace file is placed at `/projects/.code-workspace`.
 
-
+. Verify that product properties defined in the ConfigMap are being added to the Visual Studio Code *product.json*:
+* Open a terminal, run the command `cat /checode/entrypoint-logs.txt | grep "Node.js dir"` and copy the Visual Studio Code path.
+* Press `Ctrl + O`, paste the copied path and open *product.json* file.
+* Ensure that *product.json* file contains all the properties defined in the ConfigMap.

--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -17,8 +17,8 @@ The following sections are currently supported:
 * extensions.json
 * product.json
 
-The *settings.json* section contains various settings that allow to customize different parts of the Code - OSS editor. +
-The *extensions.json* section contains recommended extensions are installed when a workspace is started. +
+The *settings.json* section contains various settings with which you can customize different parts of the Code - OSS editor. +
+The *extensions.json* section contains recommended extensions that are installed when a workspace is started. +
 The *product.json* section contains properties that you need to add to the editor's *product.json* file. If the property already exists, its value will be updated.
 
 .Procedure


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Updates `Administration Guide > Configuring Visual Studio Code - Open Source ("Code - OSS") > Applying editor configurations` section, describes how to add properties to `product.json`.

![Screenshot from 2025-03-14 12-43-40](https://github.com/user-attachments/assets/68576813-5ba3-4d48-bad6-b4e5a1b9dd48)

![Screenshot from 2025-03-14 12-43-47](https://github.com/user-attachments/assets/a43c9121-dc4b-4184-90be-8edc8d3373fc)

## What issues does this pull request fix or reference?
https://github.com/eclipse-che/che/issues/23270

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
