### PR TITLE
procedures: Allow to disable 'Install from VSIX' command using ConfigMap

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,8 +1,8 @@
 ---
 name: docs
 title: Documentation
-version: next
-prerelease: true
+version: 7.100.x
+prerelease: false
 start_page: overview:introduction-to-eclipse-che.adoc
 nav:
   - modules/overview/nav.adoc
@@ -25,7 +25,7 @@ asciidoc:
     # for the project
     che-plugin-registry-directory: che-plugin-registry
     devworkspace-operator-index-disconnected-install: quay.io/devfile/devworkspace-operator-index:release-digest
-    devworkspace-operator-version-patch: "0.32.1"
+    devworkspace-operator-version-patch: "0.33.0"
     devworkspace: DevWorkspace
     devworkspace-id: devworkspace
     docker-cli: docker
@@ -98,8 +98,8 @@ asciidoc:
     prod-upstream: Eclipse&#160;Che
     prod-url: "https://__&lt;che_fqdn&gt;__"
     prod-ver-major: "7"
-    prod-ver-patch: "7.99.0"
-    prod-ver: "7.99"
+    prod-ver-patch: "7.100.0"
+    prod-ver: "7.100"
     prod-workspace: che-ws
     prod: Eclipse&#160;Che
     prod2: Eclipse&#160;Che

--- a/antora.yml
+++ b/antora.yml
@@ -21,7 +21,7 @@ asciidoc:
     ocp: OpenShift&#160;Container&#160;Platform
     # recommended OCP version for new deployments
     # included in links to OCP docs and in catalog source links: do not include the "v" prefix here
-    ocp4-ver: "4.12"
+    ocp4-ver: "4.18"
     # for the project
     che-plugin-registry-directory: che-plugin-registry
     devworkspace-operator-index-disconnected-install: quay.io/devfile/devworkspace-operator-index:release-digest

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -43,7 +43,7 @@ The default is `{prod-namespace}`.
 <2> The empty `podSelector` selects all Pods in the {orch-namespace}.
 ====
 +
-* OPTIONAL: In case you applied link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy], you also must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`. 
+* OPTIONAL: In case you applied link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/networking/network-security#nw-networkpolicy-multitenant-isolation_multitenant-network-policy[Configuring multitenant isolation with network policy], you also must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`.
 The `allow-from-openshift-apiserver` NetworkPolicy allows incoming traffic from `openshift-apiserver` namespace to the `devworkspace-webhook-server` enabling webhooks.
 The `allow-from-workspaces-namespaces` NetworkPolicy allows incoming traffic from each user project to `che-gateway` pod.
 +
@@ -105,4 +105,4 @@ The default is `{prod-namespace}`.
 
 * link:https://kubernetes.io/docs/concepts/security/multi-tenancy/#network-isolation[Network isolation]
 
-* link:https://docs.openshift.com/container-platform/{ocp4-ver}/networking/network_policy/multitenant-network-policy.html[Configuring multitenant isolation with network policy]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/networking/network-security#nw-networkpolicy-multitenant-isolation_multitenant-network-policy[Configuring multitenant isolation with network policy]

--- a/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
+++ b/modules/administration-guide/pages/configuring-single-and-multiroot-workspaces.adoc
@@ -9,7 +9,7 @@
 
 With the multi-root workspace feature, you can work with multiple project folders in the same workspace. This is useful when you are working on several related projects at once, such as product documentation and product code repositories.
 
-TIP: See link:https://code.visualstudio.com/docs/editor/workspaces[What is a VS Code "workspace"] for better understanding and authoring the workspace files.
+TIP: See link:https://code.visualstudio.com/docs/editing/workspaces/workspaces[What is a VS Code workspace] for better understanding and authoring the workspace files.
 
 [NOTE]
 ====

--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -16,14 +16,16 @@ The following sections are currently supported:
 * settings.json
 * extensions.json
 * product.json
+* configurations.json
 
 The *settings.json* section contains various settings with which you can customize different parts of the Code - OSS editor. +
 The *extensions.json* section contains recommended extensions that are installed when a workspace is started. +
-The *product.json* section contains properties that you need to add to the editor's *product.json* file. If the property already exists, its value will be updated.
+The *product.json* section contains properties that you need to add to the editor's *product.json* file. If the property already exists, its value will be updated. +
+The *configurations.json* section contains properties that allows to configure Code - OSS editor. For example, `extensions.install-from-vsix-enabled` property can be used to disable `Install from VSIX` command.
 
 .Procedure
 
-* Add a new ConfigMap to the user's {orch-namespace}, define the `settings.json`  and `extensions.json` sections, specify the settings you want to add, and the IDs of the extensions you want to install.
+* Add a new ConfigMap to the user's {orch-namespace}, define the supported sections, specify the properties you want to add.
 +
 ====
 [source,yaml]
@@ -62,6 +64,10 @@ data:
         "<publisher2>.<extension2>"
       ]
     }
+  configurations.json: |
+    {
+      "extensions.install-from-vsix-enabled": false
+    }
 immutable: false
 ----
 ====
@@ -72,6 +78,8 @@ immutable: false
 ====
 Make sure that the Configmap contains data in a valid JSON format.
 ====
+
+TIP: Consider adding the ConfigMap to the `eclipse-che` namespace. It allows to replicate the ConfigMap across all user namespaces while preventing modifications within user's namespaces. See xref:configuring-a-user-namespace.adoc[].
 
 .Verification
 . Verify that settings defined in the ConfigMap are applied using one of the following methods:
@@ -86,3 +94,8 @@ Make sure that the Configmap contains data in a valid JSON format.
 * Open a terminal, run the command `cat /checode/entrypoint-logs.txt | grep "Node.js dir"` and copy the Visual Studio Code path.
 * Press `Ctrl + O`, paste the copied path and open *product.json* file.
 * Ensure that *product.json* file contains all the properties defined in the ConfigMap.
+
+. Verify that `extensions.install-from-vsix-enabled` property defined in the ConfigMap is applied to the Code - OSS editor:
+* Open the Command Palette (use `F1`) to check that `Install from VSIX` command is not present in the list of commands.
+* Use `F1 → Open View → Extensions` to open the `Extensions` panel, then click `...` on the view (`Views and More Actions` tooltip) to check that `Install from VSIX` action is absent in the list of actions.
+* Go to the Explorer, find a file with the `vsix` extension (redhat.vscode-yaml-1.17.0.vsix, for example), open menu for that file. `Install from VSIX` action should be absent in the menu.

--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -15,9 +15,11 @@ The following sections are currently supported:
 
 * settings.json
 * extensions.json
+* product.json
 
-The `settings.json` section contains various settings that allow to customize different parts of the Code - OSS editor. +
-The `extensions.json` section contains recommented extensions are installed when a workspace is started.
+The *settings.json* section contains various settings with which you can customize different parts of the Code - OSS editor. +
+The *extensions.json* section contains recommended extensions that are installed when a workspace is started. +
+The *product.json* section contains properties that you need to add to the editor's *product.json* file. If the property already exists, its value will be updated.
 
 .Procedure
 
@@ -47,6 +49,19 @@ data:
         "titleBar.activeForeground": "#ffffff"
       }
     }
+  product.json: |
+    {
+      "extensionEnabledApiProposals": {
+        "ms-python.python": [
+          "contribEditorContentMenu",
+          "quickPickSortByLabel",
+        ]
+      },
+      "trustedExtensionAuthAccess": [
+        "<publisher1>.<extension1>",
+        "<publisher2>.<extension2>"
+      ]
+    }
 immutable: false
 ----
 ====
@@ -67,4 +82,7 @@ Make sure that the Configmap contains data in a valid JSON format.
 * Go to the `Extensions` view (`F1 → View: Show Extensions`) and check that the extensions are installed
 * Ensure that the extensions from the ConfigMap are present in the `.code-workspace` file by using the `F1 → File: Open File...` command. By default, the workspace file is placed at `/projects/.code-workspace`.
 
-
+. Verify that product properties defined in the ConfigMap are being added to the Visual Studio Code *product.json*:
+* Open a terminal, run the command `cat /checode/entrypoint-logs.txt | grep "Node.js dir"` and copy the Visual Studio Code path.
+* Press `Ctrl + O`, paste the copied path and open *product.json* file.
+* Ensure that *product.json* file contains all the properties defined in the ConfigMap.

--- a/modules/administration-guide/pages/enabling-access-to-dev-fuse-for-openshift.adoc
+++ b/modules/administration-guide/pages/enabling-access-to-dev-fuse-for-openshift.adoc
@@ -18,7 +18,7 @@ This procedure is not necessary for OpenShift versions 4.15 and later, since the
 ====
 Creating `MachineConfig` resources on an OpenShift cluster is a potentially dangerous task, as you are making advanced, system-level changes to the cluster.
 
-View the link:https://docs.openshift.com/container-platform/{ocp4-ver}/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks[MachineConfig documentation] for more details and possible risks.
+View the link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/machine_configuration/machine-config-index#about-machine-config-operator_machine-config-overview[MachineConfig documentation] for more details and possible risks.
 
 ====
 

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -7,7 +7,7 @@
 
 * The OpenShift cluster has at least 64 GB of disk space.
 
-* The OpenShift cluster is ready to operate on a restricted network. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/installing/disconnected_install/index.html[About disconnected installation mirroring] and link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admin/olm-restricted-networks.html[Using Operator Lifecycle Manager on restricted networks].
+* The OpenShift cluster is ready to operate on a restricted network. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/disconnected_environments/mirroring-in-disconnected-environments[About disconnected installation mirroring] and link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admin/olm-restricted-networks.html[Using Operator Lifecycle Manager on restricted networks].
 
 // NOTE for testers: don't use the internal registry present on `crc`.
 
@@ -26,7 +26,7 @@
 
 * `skopeo` version 1.6 or higher. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo].
 
-* An active `skopeo` session with administrative access to the private Docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.openshift.com/container-platform/{ocp4-ver}/installing/disconnected_install/installing-mirroring-installation-images.html[Mirroring images for a disconnected installation].
+* An active `skopeo` session with administrative access to the private Docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/disconnected_environments/mirroring-in-disconnected-environments[Mirroring images for a disconnected installation].
 
 * `{prod-cli}` for {prod-short} version {prod-ver}. See xref:installing-the-chectl-management-tool.adoc[].
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Backport of https://github.com/eclipse-che/che-docs/pull/2888

## What issues does this pull request fix or reference?
It was done for the https://issues.redhat.com/browse/CRW-8313
PR in the Che-Code: https://github.com/che-incubator/che-code/pull/537

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
