### PR TITLE
Improve doc for the 'Applying editor configurations' page

### DIFF
--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -21,7 +21,7 @@ The following sections are currently supported:
 The *settings.json* section contains various settings with which you can customize different parts of the Code - OSS editor. +
 The *extensions.json* section contains recommended extensions that are installed when a workspace is started. +
 The *product.json* section contains properties that you need to add to the editor's *product.json* file. If the property already exists, its value will be updated. +
-The *configurations.json* section contains properties related to Code - OSS editor configuration. For example, you can use the `extensions.install-from-vsix-enabled` property to disable `Install from VSIX` command.
+The *configurations.json* section contains properties for Code - OSS editor configuration. For example, you can use the `extensions.install-from-vsix-enabled` property to disable `Install from VSIX` command.
 
 .Procedure
 
@@ -79,7 +79,7 @@ immutable: false
 Make sure that the Configmap contains data in a valid JSON format.
 ====
 
-TIP: Consider adding the ConfigMap to the `eclipse-che` namespace. It allows to replicate the ConfigMap across all user namespaces while preventing modifications within user's namespaces. See xref:configuring-a-user-namespace.adoc[].
+TIP: Consider adding the ConfigMap to the {prod-namespace} namespace. By adding it to the namespace, you replicate the ConfigMap across all user namespaces while preventing modifications within user's namespaces. See xref:configuring-a-user-namespace.adoc[].
 
 .Verification
 . Verify that settings defined in the ConfigMap are applied using one of the following methods:


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
There were some comments in my PR for the `7.100.x` - https://github.com/eclipse-che/che-docs/pull/2890.
Let's apply them for the `main`. 

<img width="659" alt="image" src="https://github.com/user-attachments/assets/b36b2faa-545e-46fc-a631-8680b15d7813" />

<img width="658" alt="image" src="https://github.com/user-attachments/assets/27dfdc4a-1c03-4157-b02e-94108b7e458b" />

## What issues does this pull request fix or reference?
It was done for the https://issues.redhat.com/browse/CRW-8313
PR in the Che-Code: https://github.com/che-incubator/che-code/pull/537

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
