### PR TITLE
fix: Swagger API web user interface links

### DIFF
--- a/modules/administration-guide/pages/managing-workloads-using-the-che-server-api.adoc
+++ b/modules/administration-guide/pages/managing-workloads-using-the-che-server-api.adoc
@@ -1,17 +1,19 @@
 :_content-type: PROCEDURE
-:description: Managing {prod-short} server workloads using the {prod-short} server API
+:description: Managing {prod-short} server and {prod-short} dashboard workloads using the API
 :keywords: administration-guide, api
 :navtitle: Using the {prod-short} server API
 :page-aliases:
 
 [id="managing-workloads-using-the-{prod-id-short}-server-api"]
-= Managing {prod-short} server workloads using the {prod-short} server API
+= Managing {prod-short} server and {prod-short} dashboard workloads using the API
 
-To manage {prod-short} server workloads, use the Swagger web user interface to navigate {prod-short} server API.
+To manage {prod-short} server and {prod-short} dashboard workloads, use the Swagger web user interface to navigate API.
 
 .Procedure
 
-* Navigate to the Swagger API web user interface: `pass:c,a,q[{prod-url}]/swagger`.
+* Navigate to the Swagger API web user interface:
+ - `pass:c,a,q[{prod-url}]/swagger`   ({prod-short} server)
+ - `pass:c,a,q[{prod-url}]/dashboard/api/swagger`   ({prod-short} dashboard)
 
 .Additional resources
 

--- a/modules/administration-guide/pages/managing-workloads-using-the-che-server-api.adoc
+++ b/modules/administration-guide/pages/managing-workloads-using-the-che-server-api.adoc
@@ -15,7 +15,7 @@ To manage {prod-short} server and {prod-short} dashboard workloads, use the Swag
  - `pass:c,a,q[{prod-url}]/swagger`   ({prod-short} server)
  - `pass:c,a,q[{prod-url}]/dashboard/api/swagger`   ({prod-short} dashboard)
 
-IMPORTANT: DevWorkspace is a k8s object and manipulations should happen on the Kubernetes API level - xref:../../end-user-guide/pages/managing-workspaces-with-apis.adoc[]
+IMPORTANT: DevWorkspace is a k8s object and manipulations should happen on the Kubernetes API level - xref:end-user-guide:managing-workspaces-with-apis.adoc[]
 
 .Additional resources
 

--- a/modules/administration-guide/pages/managing-workloads-using-the-che-server-api.adoc
+++ b/modules/administration-guide/pages/managing-workloads-using-the-che-server-api.adoc
@@ -15,6 +15,8 @@ To manage {prod-short} server and {prod-short} dashboard workloads, use the Swag
  - `pass:c,a,q[{prod-url}]/swagger`   ({prod-short} server)
  - `pass:c,a,q[{prod-url}]/dashboard/api/swagger`   ({prod-short} dashboard)
 
+IMPORTANT: DevWorkspace is a k8s object and manipulations should happen on the Kubernetes API level - xref:../../end-user-guide/pages/managing-workspaces-with-apis.adoc[]
+
 .Additional resources
 
 * link:https://swagger.io/[Swagger]

--- a/modules/administration-guide/pages/managing-workloads-using-the-che-server-api.adoc
+++ b/modules/administration-guide/pages/managing-workloads-using-the-che-server-api.adoc
@@ -7,7 +7,7 @@
 [id="managing-workloads-using-the-{prod-id-short}-server-api"]
 = Managing {prod-short} server and {prod-short} dashboard workloads using the API
 
-To manage {prod-short} server and {prod-short} dashboard workloads, use the Swagger web user interface to navigate API.
+To manage {prod-short} server and {prod-short} dashboard workloads, use the Swagger web user interface to navigate the API.
 
 .Procedure
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR changes Swagger API web user interface links:

<img width="841" alt="Знімок екрана 2025-06-02 о 16 59 20" src="https://github.com/user-attachments/assets/4f9756bb-a22e-4fe0-b678-b964a9d44b00" />

## What issues does this pull request fix or reference?
fixes: https://github.com/eclipse-che/che/issues/23446
## Specify the version of the product this pull request applies to
 DS 3.22
## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
