### PR TITLE
chore: Add a URL parameter for the existing workspace name

### DIFF
--- a/modules/end-user-guide/nav.adoc
+++ b/modules/end-user-guide/nav.adoc
@@ -14,6 +14,7 @@
 **** xref:url-parameter-for-container-image.adoc[]
 **** xref:url-parameter-for-memory-limit.adoc[]
 **** xref:url-parameter-for-cpu-limit.adoc[]
+**** xref:url-parameter-for-the-existing-workspace-name.adoc[]
 ** xref:starting-a-workspace-from-a-raw-devfile-url.adoc[]
 ** xref:basic-actions-you-can-perform-on-a-workspace.adoc[]
 ** xref:authenticating-to-a-git-server-from-a-workspace.adoc[]

--- a/modules/end-user-guide/pages/optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc
+++ b/modules/end-user-guide/pages/optional-parameters-for-the-urls-for-starting-a-new-workspace.adoc
@@ -20,3 +20,4 @@ When you start a new workspace, {prod-short} configures the workspace according 
 * xref:url-parameter-for-container-image.adoc[]
 * xref:url-parameter-for-memory-limit.adoc[]
 * xref:url-parameter-for-cpu-limit.adoc[]
+* xref:url-parameter-for-the-existing-workspace-name.adoc[]

--- a/modules/end-user-guide/pages/url-parameter-for-starting-duplicate-workspaces.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-starting-duplicate-workspaces.adoc
@@ -18,4 +18,4 @@ The URL parameter for starting a duplicate workspace is `new`:
 pass:c,a,q[{prod-url}]#__<git_repository_url>__?new
 ----
 
-NOTE: If you currently have a workspace that you started using a URL, then visiting the URL again without the `new` URL parameter results in an error message.
+NOTE: If you currently have a workspace that you started using a URL, then visiting the URL again without the `new` URL parameter opens an existing workspace..

--- a/modules/end-user-guide/pages/url-parameter-for-starting-duplicate-workspaces.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-starting-duplicate-workspaces.adoc
@@ -18,4 +18,7 @@ The URL parameter for starting a duplicate workspace is `new`:
 pass:c,a,q[{prod-url}]#__<git_repository_url>__?new
 ----
 
-NOTE: If you currently have a workspace that you started using a URL, then visiting the URL again without the `new` URL parameter opens an existing workspace..
+[NOTE] 
+====
+If you currently have a workspace that you started by using a URL, then visiting the URL again without the `new` URL parameter opens the existing workspace.
+====

--- a/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
@@ -7,9 +7,12 @@
 [id="url-parameter-for-the-existing-workspace-name"]
 = URL parameter for the existing workspace name
 
-If the URL for starting a new workspace contain a URL parameter specifying the existing workspace name,
-an existing workspace created from the same URL is opened, or a new workspace is created.
-The specified existing workspace name will be preferred if multiple workspaces were created from the same URL.
+If you start a new workspace with a URL that contains the `existing` URL parameter specifying an existing workspace name, the existing workspace created from the same URL is opened. If no workspace from the same URL exists yet, a new workspace is created.
+
+[NOTE]
+====
+If you create multiple workspaces from the same URL, the specified existing workspace name will be preferred.
+====
 
 The URL parameter for the existing workspace name is `existing=`:
 

--- a/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
@@ -11,13 +11,13 @@ If you start a new workspace with a URL that contains the `existing` URL paramet
 
 When specifying the `existing` URL parameter, following situations may arise:
 
-1. No workspaces created from the same URL, and a new workspace is created.
+* If there is no workspace created from the same URL, a new workspace is created.
 
-2. The specified existing workspace name may not match any existing workspaces, and a warning will appear, in which you will need to select one of the following actions:
- - Create a new workspace.
- - Select an existing workspace to open.
+* If the specified existing workspace name matches an existing workspace created from the same URL and the existing workspace is opened.
 
-3. The specified existing workspace name may match one of the existing workspaces created from the same URL; the existing workspace is opened.
+* If the specified existing workspace name does not match any existing workspaces, a warning appears and you need to select one of the following actions:
+ ** Create a new workspace.
+ ** Select an existing workspace to open.
 
 [NOTE]
 ====

--- a/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
@@ -7,11 +7,25 @@
 [id="url-parameter-for-the-existing-workspace-name"]
 = URL parameter for the existing workspace name
 
-If you start a new workspace with a URL that contains the `existing` URL parameter specifying an existing workspace name, the existing workspace created from the same URL is opened. If no workspace from the same URL exists yet, a new workspace is created.
+If you start a new workspace with a URL that contains the `existing` URL parameter specifying an existing workspace name, the existing workspace created from the same URL is opened.
+
+When specifying the `existing` URL parameter, several situations may arise:
+
+1. No workspaces created from the same URL, and a new workspace is created.
+
+2. The specified existing workspace name may not match any existing workspaces, and a warning will appear, in which you will need to select one of the following actions:
+ - Create a new workspace.
+ - Select an existing workspace to open.
+
+3. The specified existing workspace name may match one of the existing workspaces created from the same URL; the existing workspace is opened.
 
 [NOTE]
 ====
-If you create multiple workspaces from the same URL, the specified existing workspace name will be preferred.
+To create multiple workspaces from the same URL, you can use the `new` URL parameter:
+[source,subs="+quotes,+attributes,+macros"]
+----
+pass:c,a,q[{prod-url}]#__<git_repository_url>__?new
+----
 ====
 
 The URL parameter for the existing workspace name is `existing=`:
@@ -25,7 +39,7 @@ pass:c,a,q[{prod-url}]#__<git_repository_url>__?existing=__<existing_workspace_n
 
 ====
 
-`pass:c,a,q[{prod-url}]#https://github.com/eclipse-che/che-docs?existing=che-docs`
+`pass:c,a,q[{prod-url}]#<git_repository_url>?existing=workspace_name`
 
 ====
 

--- a/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
@@ -1,0 +1,33 @@
+:_content-type: CONCEPT
+:description: URL parameter for the existing workspace name
+:keywords: existing-workspace-name, how-to-start-workspace
+:navtitle: URL parameter for the existing workspace name
+:page-aliases:
+
+[id="url-parameter-for-the-existing-workspace-name"]
+= URL parameter for the existing workspace name
+
+If the URL for starting a new workspace contain a URL parameter specifying the existing workspace name,
+an existing workspace created from the same URL is opened, or a new workspace is created.
+The specified existing workspace name will be preferred if multiple workspaces were created from the same URL.
+
+The URL parameter for the existing workspace name is `existing=`:
+
+[source,subs="+quotes,+attributes,+macros"]
+----
+pass:c,a,q[{prod-url}]#__<git_repository_url>__?existing=__<existing_workspace_name>__
+----
+
+.Example
+
+====
+
+`pass:c,a,q[{prod-url}]#https://github.com/eclipse-che/che-docs?existing=che-docs`
+
+====
+
+This URL opens the existing workspace named `che-docs` if it was created from the same URL.
+
+.Additional resources
+
+* xref:url-parameter-for-starting-duplicate-workspaces.adoc[]

--- a/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
@@ -9,6 +9,14 @@
 
 If you start a new workspace with a URL that contains the `existing` URL parameter specifying an existing workspace name, the existing workspace created from the same URL is opened.
 
+.Example
+
+====
+
+`pass:c,a,q[{prod-url}]#<git_repository_url>?existing=workspace_name`
+
+====
+
 When specifying the `existing` URL parameter, following situations may arise:
 
 * If there is no workspace created from the same URL, a new workspace is created.
@@ -27,23 +35,6 @@ To create multiple workspaces from the same URL, you can use the `new` URL param
 pass:c,a,q[{prod-url}]#__<git_repository_url>__?new
 ----
 ====
-
-The URL parameter for the existing workspace name is `existing=`:
-
-[source,subs="+quotes,+attributes,+macros"]
-----
-pass:c,a,q[{prod-url}]#__<git_repository_url>__?existing=__<existing_workspace_name>__
-----
-
-.Example
-
-====
-
-`pass:c,a,q[{prod-url}]#<git_repository_url>?existing=workspace_name`
-
-====
-
-This URL opens the existing workspace named `che-docs` if it was created from the same URL.
 
 .Additional resources
 

--- a/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-existing-workspace-name.adoc
@@ -9,7 +9,7 @@
 
 If you start a new workspace with a URL that contains the `existing` URL parameter specifying an existing workspace name, the existing workspace created from the same URL is opened.
 
-When specifying the `existing` URL parameter, several situations may arise:
+When specifying the `existing` URL parameter, following situations may arise:
 
 1. No workspaces created from the same URL, and a new workspace is created.
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR adds a URL parameter for the existing workspace name.


## What issues does this pull request fix or reference?
need for https://github.com/eclipse-che/che/issues/23402

## Specify the version of the product this pull request applies to
DS 3.23

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
