### PR TITLE
fix: wrong CLI (CRW-8656)

### DIFF
--- a/modules/administration-guide/pages/concealing-editors.adoc
+++ b/modules/administration-guide/pages/concealing-editors.adoc
@@ -6,7 +6,7 @@
 [id="concealing-editors"]
 = Concealing editors
 
-Learn how to conceal {prod-short} editor. This is useful when you want to hide selected editors from the Dashboard UI, e.g. hide the IntelliJ IDEA Ultimate and have only Visual Studio Code - Open Source visible.
+Learn how to conceal {prod-short} editors. This is useful when you want to hide selected editors from the Dashboard UI, e.g. hide the IntelliJ IDEA Ultimate and have only Visual Studio Code - Open Source visible.
 
 .Prerequisites
 

--- a/modules/administration-guide/pages/concealing-editors.adoc
+++ b/modules/administration-guide/pages/concealing-editors.adoc
@@ -6,7 +6,7 @@
 [id="concealing-editors"]
 = Concealing editors
 
-Learn how to conceal {prod-short} editors. This is useful when you want to hide selected editors from the Dashboard UI, e.g. hide the IntelliJ IDEA Ultimate and have only Visual Studio Code - Open Source visible.
+Learn how to conceal {prod-short} editor. This is useful when you want to hide selected editors from the Dashboard UI, e.g. hide the IntelliJ IDEA Ultimate and have only Visual Studio Code - Open Source visible.
 
 .Prerequisites
 

--- a/modules/administration-guide/pages/uninstalling-che.adoc
+++ b/modules/administration-guide/pages/uninstalling-che.adoc
@@ -10,7 +10,7 @@
 
 WARNING: Uninstalling {prod-short} removes all {prod-short}-related user data!
 
-Use `{orch-cli}` to uninstall the {prod-short} instance.
+Use `{prod-cli}` to uninstall the {prod-short} instance.
 
 .Prerequisites
 

--- a/modules/administration-guide/pages/uninstalling-che.adoc
+++ b/modules/administration-guide/pages/uninstalling-che.adoc
@@ -34,5 +34,5 @@ The `--delete-all` option removes the {devworkspace} Operator and the related re
 
 [IMPORTANT]
 ====
-Standard operating procedure (SOP) for removing {devworkspace} Operator manually without `{orch-cli}` is available in the OpenShift Container Platform link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/web_console/web-terminal#removing-devworkspace-operator_uninstalling-web-terminal[official documentation].
+Standard operating procedure (SOP) for removing {devworkspace} Operator manually without `{prod-cli}` is available in the OpenShift Container Platform link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/web_console/web-terminal#removing-devworkspace-operator_uninstalling-web-terminal[official documentation].
 ====


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

replaced kubectl CLI reference with chectl CLI

## What issues does this pull request fix or reference?

https://issues.redhat.com/browse/CRW-8656

## Specify the version of the product this pull request applies to

main, 7.104, 7.102, 7.100

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
