### PR TITLE
Add the 'metadata.attributes.arch' array for supported architectures

### DIFF
--- a/modules/administration-guide/pages/configuring-editors-definitions.adoc
+++ b/modules/administration-guide/pages/configuring-editors-definitions.adoc
@@ -42,6 +42,10 @@ metadata:
   # Additional attributes
   attributes:
     title: This is my editor
+    # (MANDATORY) The supported architectures
+    arch:
+      - x86_64
+      - arm64
     # (MANDATORY) The publisher name
     publisher: publisher
     # (MANDATORY) The editor version


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

This PR added the mandatory 'metadata.attributes.arch' array for supported architectures into editor definitions.

<img width="1221" height="943" alt="Знімок екрана 2025-07-17 о 16 48 50" src="https://github.com/user-attachments/assets/d6436346-bffe-4fca-bf08-c989ab637ba2" />

## What issues does this pull request fix or reference?
It needs for  https://github.com/eclipse-che/che/issues/23491
## Specify the version of the product this pull request applies to

DS 3.22

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
