### PR TITLE
Add a note about using the JetBrains IDEs in a disconnected cluster

### DIFF
--- a/modules/end-user-guide/pages/idea-ultimate.adoc
+++ b/modules/end-user-guide/pages/idea-ultimate.adoc
@@ -70,7 +70,7 @@ image::gateway-connecting.png[Connecting to remote host,link="{imagesdir}/gatewa
 
 == Using in a disconnected cluster
 
-The following URLs must be white-listed on the proxy side:
+The following URLs must be allow-listed on the proxy side:
 
 * https://download.jetbrains.com/idea/ideaIU-2024.3.2.1.tar.gz
 * https://download.jetbrains.com/webstorm/WebStorm-2024.3.2.1.tar.gz

--- a/modules/end-user-guide/pages/idea-ultimate.adoc
+++ b/modules/end-user-guide/pages/idea-ultimate.adoc
@@ -68,7 +68,7 @@ image::gateway-select-ws.png[Connecting to OpenShift API server,link="{imagesdir
 
 image::gateway-connecting.png[Connecting to remote host,link="{imagesdir}/gateway-connecting.png"]
 
-= Using in a disconnected cluster
+== Using in a disconnected cluster
 
 The following URLs must be white-listed on the proxy side:
 

--- a/modules/end-user-guide/pages/idea-ultimate.adoc
+++ b/modules/end-user-guide/pages/idea-ultimate.adoc
@@ -67,3 +67,16 @@ image::gateway-select-ws.png[Connecting to OpenShift API server,link="{imagesdir
 +
 
 image::gateway-connecting.png[Connecting to remote host,link="{imagesdir}/gateway-connecting.png"]
+
+. Using in disconnected cluster
+
+The following URLs must be white-listed on the proxy side:
+
+* https://download.jetbrains.com/idea/ideaIU-2024.3.2.1.tar.gz
+* https://download.jetbrains.com/webstorm/WebStorm-2024.3.2.1.tar.gz
+* https://download.jetbrains.com/python/pycharm-professional-2024.3.2.tar.gz
+* https://download.jetbrains.com/go/goland-2024.3.2.1.tar.gz
+* https://download.jetbrains.com/cpp/CLion-2024.3.2.tar.gz
+* https://download.jetbrains.com/webide/PhpStorm-2024.3.2.1.tar.gz
+* https://download.jetbrains.com/ruby/RubyMine-2024.3.2.1.tar.gz
+* https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.4.tar.gz

--- a/modules/end-user-guide/pages/idea-ultimate.adoc
+++ b/modules/end-user-guide/pages/idea-ultimate.adoc
@@ -68,7 +68,7 @@ image::gateway-select-ws.png[Connecting to OpenShift API server,link="{imagesdir
 
 image::gateway-connecting.png[Connecting to remote host,link="{imagesdir}/gateway-connecting.png"]
 
-. Using in disconnected cluster
+= Using in a disconnected cluster
 
 The following URLs must be white-listed on the proxy side:
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Adds a note about using the JetBrains IDEs in a disconnected cluster.

## What issues does this pull request fix or reference?
for https://issues.redhat.com/browse/CRW-8884

## Specify the version of the product this pull request applies to
3.22

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
