### PR TITLE
docs: update prerequisites for installing Ingress-Nginx Controller on…

### DIFF
--- a/modules/administration-guide/partials/proc_installing-ingress-nginx-controller-on-amazon-elastic-kubernetes-service.adoc
+++ b/modules/administration-guide/partials/proc_installing-ingress-nginx-controller-on-amazon-elastic-kubernetes-service.adoc
@@ -7,6 +7,13 @@
 
 Follow these instructions to install the link:https://kubernetes.github.io/ingress-nginx/[Ingress-Nginx Controller] on {eks-short}.
 
+.Prerequisites
+
+* Ensure your VPC subnets have the appropriate tags for load balancer discovery:
+** For public subnets (with internet gateway routes): `kubernetes.io/role/elb=1`
+** For private subnets (without internet gateway routes): `kubernetes.io/role/internal-elb=1`
+** For all subnets: `kubernetes.io/cluster/<CLUSTER_NAME>=shared` or `kubernetes.io/cluster/<CLUSTER_NAME>=owned`
+
 .Procedure
 
 . Install the `Ingress-Nginx Controller` using `Helm`:
@@ -22,7 +29,8 @@ helm install ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-backend-protocol"=tcp \
   --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-cross-zone-load-balancing-enabled"="true" \
-  --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type"=nlb
+  --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-type"=nlb \
+  --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-scheme"="internet-facing"
 ----
 
 . Verify that you can access the load balancer externally.


### PR DESCRIPTION
procedures: Configure ingress-nginx for internet-facing load balancer on EKS

<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

This pull request updates the procedure for installing the Ingress-Nginx Controller on Amazon EKS. It adds a Helm option to configure the AWS load balancer as internet-facing.

Specifically, it adds the following line to the `helm install` command:
`--set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-scheme"="internet-facing"`

This ensures that the load balancer created for the ingress controller is accessible from the internet, which is a common requirement for public-facing applications.

## What issues does this pull request fix or reference?

This change addresses the need for a publicly accessible ingress controller on EKS.

## Specify the version of the product this pull request applies to

This applies to Eclipse Che installations on Amazon EKS.

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.