### PR TITLE
chore: Allow to configure editor download urls

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -90,6 +90,7 @@
 *** xref:show-deprecated-editors.adoc[]
 *** xref:configuring-default-editor.adoc[]
 *** xref:concealing-editors.adoc[]
+*** xref:configuring-editors-download-urls.adoc[]
 *** xref:customizing-openshift-che-consolelink-icon.adoc[]
 ** xref:managing-identities-and-authorizations.adoc[]
 *** xref:configuring-oauth-for-git-providers.adoc[]

--- a/modules/administration-guide/pages/configuring-dashboard.adoc
+++ b/modules/administration-guide/pages/configuring-dashboard.adoc
@@ -11,6 +11,8 @@
 
 * xref:configuring-editors-definitions.adoc[]
 
+* xref:configuring-editors-download-urls.adoc[]
+
 * xref:show-deprecated-editors.adoc[]
 
 * xref:configuring-default-editor.adoc[]

--- a/modules/administration-guide/pages/configuring-editors-download-urls.adoc
+++ b/modules/administration-guide/pages/configuring-editors-download-urls.adoc
@@ -6,7 +6,7 @@
 [id="configuring-editors-download-urls"]
 = Configuring editors download urls
 
-Learn how to configure editors download urls. This feature is valuable in air-gapped environments where editors cannot be retrieved from the public internet.
+Learn how to configure editors download urls. This feature is valuable in air-gapped environments where editors cannot be retrieved from the public internet. Currently, this option is intended only for JetBrains editors and should not be used for other editor types.
 
 .Prerequisites
 

--- a/modules/administration-guide/pages/configuring-editors-download-urls.adoc
+++ b/modules/administration-guide/pages/configuring-editors-download-urls.adoc
@@ -4,7 +4,7 @@
 :navtitle: Configuring editors download urls
 
 [id="configuring-editors-download-urls"]
-= Configuring editors download urls
+= Configuring editors download URLs
 
 Learn how to configure editors download urls. This feature is valuable in air-gapped environments where editors cannot be retrieved from the public internet. Currently, this option is intended only for JetBrains editors and should not be used for other editor types.
 

--- a/modules/administration-guide/pages/configuring-editors-download-urls.adoc
+++ b/modules/administration-guide/pages/configuring-editors-download-urls.adoc
@@ -10,7 +10,7 @@ This procedure describes how to configure download URLs for editors. This featur
 
 .Prerequisites
 
-* An active `{orch-cli}` session with administrative permissions to the {orch-name} cluster. See {orch-cli-link}.
+* You have an active `_orch-cli_` session with administrative permissions to the `{orch-name}` cluster. For more information, see {orch-cli-link}.
 
 * `jq`. See link:https://stedolan.github.io/jq/download/[Downloading `jq`].
 

--- a/modules/administration-guide/pages/configuring-editors-download-urls.adoc
+++ b/modules/administration-guide/pages/configuring-editors-download-urls.adoc
@@ -6,7 +6,7 @@
 [id="configuring-editors-download-urls"]
 = Configuring editors download URLs
 
-Learn how to configure editors download urls. This feature is valuable in air-gapped environments where editors cannot be retrieved from the public internet. Currently, this option is intended only for JetBrains editors and should not be used for other editor types.
+This procedure describes how to configure download URLs for editors. This feature is valuable in air-gapped environments where editors cannot be retrieved from the public internet. Currently, this option is intended only for JetBrains editors and should not be used for other editor types.
 
 .Prerequisites
 

--- a/modules/administration-guide/pages/configuring-editors-download-urls.adoc
+++ b/modules/administration-guide/pages/configuring-editors-download-urls.adoc
@@ -1,0 +1,38 @@
+:_content-type: PROCEDURE
+:description: Configuring editors download urls
+:keywords: administration guide, dashboard, editors
+:navtitle: Configuring editors download urls
+
+[id="configuring-editors-download-urls"]
+= Configuring editors download urls
+
+Learn how to configure editors download urls. This feature is valuable in air-gapped environments where editors cannot be retrieved from the public internet.
+
+.Prerequisites
+
+* An active `{orch-cli}` session with administrative permissions to the {orch-name} cluster. See {orch-cli-link}.
+
+* `jq`. See link:https://stedolan.github.io/jq/download/[Downloading `jq`].
+
+.Procedure
+
+include::example$snip_che-editor-id-list.adoc[]
+
+. Configure the download URLs for editors:
++
+[source,subs="+quotes,+attributes"]
+----
+{orch-cli} patch checluster/{prod-checluster} \
+  --namespace {prod-namespace} \
+  --type='merge' \
+  -p '{
+    "spec": {
+      "devEnvironments": {
+        "editorsDownloadUrls": [
+          { "editor": "publisher1/editor-name1/version1", "url": "https://example.com/editor1.tar.gz" },
+          { "editor": "publisher2/editor-name2/version2", "url": "https://example.com/editor2.tar.gz" }
+        ]
+      }
+    }
+  }'
+----

--- a/modules/end-user-guide/pages/idea-ultimate.adoc
+++ b/modules/end-user-guide/pages/idea-ultimate.adoc
@@ -67,16 +67,3 @@ image::gateway-select-ws.png[Connecting to OpenShift API server,link="{imagesdir
 +
 
 image::gateway-connecting.png[Connecting to remote host,link="{imagesdir}/gateway-connecting.png"]
-
-== Using in a disconnected cluster
-
-The following URLs must be allow-listed on the proxy side:
-
-* https://download.jetbrains.com/idea/ideaIU-2024.3.2.1.tar.gz
-* https://download.jetbrains.com/webstorm/WebStorm-2024.3.2.1.tar.gz
-* https://download.jetbrains.com/python/pycharm-professional-2024.3.2.tar.gz
-* https://download.jetbrains.com/go/goland-2024.3.2.1.tar.gz
-* https://download.jetbrains.com/cpp/CLion-2024.3.2.tar.gz
-* https://download.jetbrains.com/webide/PhpStorm-2024.3.2.1.tar.gz
-* https://download.jetbrains.com/ruby/RubyMine-2024.3.2.1.tar.gz
-* https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.4.tar.gz


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Add article about configuring editors urls.

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-8933

## Specify the version of the product this pull request applies to
main
7.107.x

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
