### PR TITLE
fix: use cluster admin instead of admin

### DIFF
--- a/modules/administration-guide/examples/snip_che-deploy-open-vsx-using-oc.adoc
+++ b/modules/administration-guide/examples/snip_che-deploy-open-vsx-using-oc.adoc
@@ -1,6 +1,6 @@
 * Installed `oc` and git tools.
 * Installed Podman.
-* Log in to the OpenShift cluster where a {prod-short} is deployed as a cluster administrator.
+* Log in to the OpenShift cluster where the {prod-short} is deployed as a cluster administrator.
 +
 [TIP]
 ====

--- a/modules/administration-guide/examples/snip_che-deploy-open-vsx-using-oc.adoc
+++ b/modules/administration-guide/examples/snip_che-deploy-open-vsx-using-oc.adoc
@@ -1,6 +1,6 @@
 * Installed `oc` and git tools.
 * Installed Podman.
-* Log in to the OpenShift cluster where a {prod-short} is deployed as an administrator.
+* Log in to the OpenShift cluster where a {prod-short} is deployed as a cluster administrator.
 +
 [TIP]
 ====

--- a/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
+++ b/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
@@ -13,7 +13,7 @@ Follow the instructions below to deploy and configure an on-premises Eclipse Ope
 
 .Prerequisites
 
-* Be logged in to a {prod-short} as an administrator.
+* Be logged in to a {prod-short} as a cluster administrator.
 
 .Procedure
 

--- a/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
+++ b/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
@@ -13,7 +13,7 @@ Follow the instructions below to deploy and configure an on-premises Eclipse Ope
 
 .Prerequisites
 
-* Be logged in to {prod-short} as a cluster administrator.
+* Be logged in as a cluster administrator.
 
 .Procedure
 

--- a/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
+++ b/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
@@ -13,7 +13,7 @@ Follow the instructions below to deploy and configure an on-premises Eclipse Ope
 
 .Prerequisites
 
-* Be logged in to a {prod-short} as a cluster administrator.
+* Be logged in to {prod-short} as a cluster administrator.
 
 .Procedure
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

Use **cluster administrator** instead of **administrator**

<img width="1920" height="919" alt="screenshot-68a4900f8cb2973c1311fc5f--eclipse-che-docs-pr_netlify_app-2025_08_19-17_58_00" src="https://github.com/user-attachments/assets/44196352-fb79-40da-bb0d-4674795620ba" />

