### PR TITLE
fix: use cluster admin instead of admin (#2953)

### DIFF
--- a/modules/administration-guide/examples/snip_che-deploy-open-vsx-using-oc.adoc
+++ b/modules/administration-guide/examples/snip_che-deploy-open-vsx-using-oc.adoc
@@ -1,6 +1,6 @@
 * Installed `oc` and git tools.
 * Installed Podman.
-* Log in to the OpenShift cluster where a {prod-short} is deployed as an administrator.
+* Log in to the OpenShift cluster where the {prod-short} is deployed as a cluster administrator.
 +
 [TIP]
 ====

--- a/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
+++ b/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
@@ -13,7 +13,7 @@ Follow the instructions below to deploy and configure an on-premises Eclipse Ope
 
 .Prerequisites
 
-* Be logged in to a {prod-short} as an administrator.
+* Be logged in as a cluster administrator.
 
 .Procedure
 


### PR DESCRIPTION
Backport changes from https://github.com/eclipse-che/che-docs/pull/2953 into 7.107.x