### PR TITLE
chore: add warning message about starting openvsx workspace

### DIFF
--- a/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
+++ b/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
@@ -21,6 +21,11 @@ Follow the instructions below to deploy and configure an on-premises Eclipse Ope
 +
 Create a workspace by using the following link:https://github.com/eclipse/openvsx[Eclipse Open VSX repository].
 +
+[WARNING]
+====
+The link:https://github.com/eclipse/openvsx/blob/master/.devfile.yaml[.devfile.yaml] includes an `elasticsearch` component that does not support IBM Power (ppc64le) or IBM Z (s390x) architectures. To successfully start the workspace on these architectures, the only option is to remove this component from the devfile. Alternatively, you can refer to  <<using-oc-tool,Using OpenShift CLIT tool>> documentation, which describes how to run Open VSX separately without starting a workspace.
+====
++
 [TIP]
 ====
 The environment, including all necessary commands, is defined in the `.devfile.yaml` file.
@@ -66,6 +71,7 @@ To publish your extensions to Open VSX, update the `extensions.txt` file as need
 +
 Start any workspace and check the available extensions in the Extensions view of the workspace IDE or by opening the `internal` route in the OpenVSX OpenShift project.
 
+[id="using-oc-tool"]
 == Using OpenShift CLI (`oc`) tool
 
 .Prerequisites

--- a/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
+++ b/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
@@ -23,7 +23,7 @@ Create a workspace by using the following link:https://github.com/eclipse/openvs
 +
 [WARNING]
 ====
-The link:https://github.com/eclipse/openvsx/blob/master/.devfile.yaml[.devfile.yaml] includes an `elasticsearch` component that does not support IBM Power (ppc64le) or IBM Z (s390x) architectures. To successfully start the workspace on these architectures, the only option is to remove this component from the devfile. Alternatively, you can refer to  <<using-oc-tool,Using OpenShift CLIT tool>> documentation, which describes how to run Open VSX separately without starting a workspace.
+The link:https://github.com/eclipse/openvsx/blob/master/.devfile.yaml[.devfile.yaml] includes an `elasticsearch` component that does not support IBM Power (ppc64le) or IBM Z (s390x) architectures. To successfully start the workspace on these architectures, the only option is to remove this component from the devfile. Alternatively, you can refer to  <<using-oc-tool,Using OpenShift CLI tool>> documentation, which describes how to run Open VSX separately without starting a workspace.
 ====
 +
 [TIP]


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Add a warning message about starting openvsx workspace for IBM Z / Power

<img width="903" height="557" alt="Screenshot 2025-09-01 at 14 38 12" src="https://github.com/user-attachments/assets/4174ce39-87ef-4102-aa60-059ec6aa1f0d" />


## What issues does this pull request fix or reference?
It's not possible to start openvsx workspace using https://github.com/eclipse/openvsx

## Specify the version of the product this pull request applies to
DS 3.23.0
Che 7.107.0

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.
