### PR TITLE
Add the storage requirements for the JetBrains editors

### DIFF
--- a/modules/end-user-guide/pages/idea-ultimate.adoc
+++ b/modules/end-user-guide/pages/idea-ultimate.adoc
@@ -23,7 +23,7 @@ The `oc login` command establishes the authenticated session and saves the conne
 
 [IMPORTANT]
 ====
-In addition to the recommendations about calculating xref:administration-guide:calculating-che-resource-requirements.adoc[memory and CPU], make sure the storage size is enough to download and unpack the JetBrains IDE. For the largest one, CLion, it requires about 8.5 GB of disk space.
+In addition to the recommendations about calculating xref:administration-guide:calculating-che-resource-requirements.adoc[memory and CPU], make sure you have enough empty storage space to download and unpack the JetBrains IDE. For reference, CLion IDE, which is the largest of the IDEs, requires approximately 8.5 GB of disk space.
 ====
 
 .Connecting JetBrains IntelliJ IDEA Ultimate Edition to a new workspace

--- a/modules/end-user-guide/pages/idea-ultimate.adoc
+++ b/modules/end-user-guide/pages/idea-ultimate.adoc
@@ -23,7 +23,7 @@ The `oc login` command establishes the authenticated session and saves the conne
 
 [IMPORTANT]
 ====
-In addition to the recommendations about calculating xref:administration-guide:calculating-che-resource-requirements.adoc[memory and CPU], make sure you have enough empty storage space to download and unpack the JetBrains IDE. For reference, CLion IDE, which is the largest of the IDEs, requires approximately 8.5 GB of disk space.
+In addition to the recommendations for calculating xref:administration-guide:calculating-che-resource-requirements.adoc[memory and CPU], ensure you have sufficient PVC size to download and unpack the JetBrains IDE. For reference, CLion IDE, which is the largest of the IDEs, requires approximately 8.5 GB of disk space.
 ====
 
 .Connecting JetBrains IntelliJ IDEA Ultimate Edition to a new workspace

--- a/modules/end-user-guide/pages/idea-ultimate.adoc
+++ b/modules/end-user-guide/pages/idea-ultimate.adoc
@@ -21,6 +21,11 @@ Integration with the link:https://www.jetbrains.com/remote-development/gateway/[
 The `oc login` command establishes the authenticated session and saves the connection information to the configuration file which is read by the Gateway provider for OpenShift Dev Spaces.
 ====
 
+[IMPORTANT]
+====
+In addition to the recommendations about calculating xref:calculating-che-resource-requirements.adoc.adoc[memory and CPU], make sure the storage size is enough to download and unpack JetBrains IDE. For the largest one, CLion, it requires about 8.5 GB of the disk space.
+====
+
 .Connecting JetBrains IntelliJ IDEA Ultimate Edition to a new workspace
 
 .Procedure

--- a/modules/end-user-guide/pages/idea-ultimate.adoc
+++ b/modules/end-user-guide/pages/idea-ultimate.adoc
@@ -23,7 +23,7 @@ The `oc login` command establishes the authenticated session and saves the conne
 
 [IMPORTANT]
 ====
-In addition to the recommendations for calculating xref:administration-guide:calculating-che-resource-requirements.adoc[memory and CPU], ensure you have sufficient PVC size to download and unpack the JetBrains IDE. For reference, CLion IDE, which is the largest of the IDEs, requires approximately 8.5 GB of disk space.
+In addition to the recommendations for calculating xref:administration-guide:calculating-che-resource-requirements.adoc[memory and CPU], make sure you have sufficient PVC size to download and unpack the JetBrains IDE. For reference, CLion IDE, which is the largest of the IDEs, requires approximately 8.5 GB of disk space.
 ====
 
 .Connecting JetBrains IntelliJ IDEA Ultimate Edition to a new workspace

--- a/modules/end-user-guide/pages/idea-ultimate.adoc
+++ b/modules/end-user-guide/pages/idea-ultimate.adoc
@@ -23,7 +23,7 @@ The `oc login` command establishes the authenticated session and saves the conne
 
 [IMPORTANT]
 ====
-In addition to the recommendations about calculating xref:calculating-che-resource-requirements.adoc.adoc[memory and CPU], make sure the storage size is enough to download and unpack JetBrains IDE. For the largest one, CLion, it requires about 8.5 GB of the disk space.
+In addition to the recommendations about calculating xref:administration-guide:calculating-che-resource-requirements.adoc[memory and CPU], make sure the storage size is enough to download and unpack the JetBrains IDE. For the largest one, CLion, it requires about 8.5 GB of disk space.
 ====
 
 .Connecting JetBrains IntelliJ IDEA Ultimate Edition to a new workspace


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Adds the storage requirements for running the JetBrains editor.

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-9370

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
