### PR TITLE
chore: Update configuring-a-user-namespace.doc

### DIFF
--- a/modules/administration-guide/pages/configuring-a-user-namespace.adoc
+++ b/modules/administration-guide/pages/configuring-a-user-namespace.adoc
@@ -108,7 +108,7 @@ stringData:
 ----
 ====
 +
-.Replicate a Secret into every user {orch-namespace} and automatically mount a `trusted-certificates.crt` file into every user container by path `/etc/pki/ca-trust/source/anchors`:
+.Replicate a Secret into every user {orch-namespace} and automatically mount a `secret.data` file into every user container by path `/home/user/secrets`:
 ====
 [source,yaml,subs="+attributes,+quotes"]
 ----
@@ -122,14 +122,11 @@ metadata:
     app.kubernetes.io/component: workspaces-config
   annotations:
     controller.devfile.io/mount-as: subpath
-    controller.devfile.io/mount-path: /etc/pki/ca-trust/source/anchors
+    controller.devfile.io/mount-path: /home/user/secrets
 stringData:
-  trusted-certificates.crt: |
+  secret.data: |
     ...
 ----
-NOTE: Run `update-ca-trust` command on workspace startup to import certificates.
-It can be achieved manually or by adding this command to a `postStart` event in a devfile.
-See the link:https://devfile.io/docs/{devfile-api-version}/adding-event-bindings#post-start-object[Adding event bindings in a devfile].
 ====
 +
 .Replicate a Secret into every user {orch-namespace} and automatically mount as environment variables into every user container:


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Updates `configuring-a-user-namespace.doc` to removing mentioning about `update-ca-trust` command to add certificates to trust store for several reasons:
- It doesn't work anymore
- It is possible to use the doc to import certificates into a trust store https://eclipse.dev/che/docs/stable/administration-guide/importing-untrusted-tls-certificates/



## What issues does this pull request fix or reference?
N/A

## Specify the version of the product this pull request applies to
main

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
