### PR TITLE
Update ubi8 images to ubi9 images

### DIFF
--- a/modules/end-user-guide/pages/url-parameter-for-container-image.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-container-image.adoc
@@ -21,4 +21,4 @@ pass:c,a,q[{prod-url}]#__<git_repository_url>__?image=__<container_image_url>__
 ----
 
 .Example
-`pass:c,a,q[{prod-url}]#https://github.com/eclipse-che/che-docs?image=quay.io/devfile/universal-developer-image:ubi8-latest`
+`pass:c,a,q[{prod-url}]#https://github.com/eclipse-che/che-docs?image=quay.io/devfile/universal-developer-image:ubi9-latest`

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -50,7 +50,7 @@ NOTE: {prod-short} administrators who intend to create workspaces for other user
 components:
   - name: tooling-container
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-latest
+      image: quay.io/devfile/universal-developer-image:ubi9-latest
 ----
 ====
 +
@@ -82,7 +82,7 @@ spec:
     components:#<6>
       - name: tooling-container
         container:
-          image: quay.io/devfile/universal-developer-image:ubi8-latest
+          image: quay.io/devfile/universal-developer-image:ubi9-latest
 ----
 <1> Name of the `DevWorkspace` custom resource. This will be the name of the new workspace.
 <2> User namespace, which is the target {orch-namespace} for the new workspace.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

Since ubi8 based udi image has been deprecated, this PR updates the ubi8 references in the docs to ubi9.

<img width="1491" height="841" alt="image" src="https://github.com/user-attachments/assets/ac2dadf3-43ff-432d-a417-f56b463fc9f4" />

<img width="1501" height="821" alt="image" src="https://github.com/user-attachments/assets/091f2ff8-e151-4931-be6d-391008585207" />

## What issues does this pull request fix or reference?
n/a

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
