### PR TITLE
CRW-9501: Remove 'Tech Preview' designation from JetBrains Gateway.

### DIFF
--- a/modules/end-user-guide/pages/ides-in-workspaces.adoc
+++ b/modules/end-user-guide/pages/ides-in-workspaces.adoc
@@ -26,18 +26,9 @@ The default IDE in a new workspace is Microsoft Visual Studio Code - Open Source
 * `latest` is the default IDE that loads in a new workspace when the URL parameter or `che-editor.yaml` is not used.
 * `insiders` is the development version.
 
-| link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community Edition]
-| Deprecated
-|
-* `che-incubator/che-idea/latest`
-* `che-incubator/che-idea/next`
-|
-* `latest` is the stable version.
-* `next` is the development version.
-
 | link:https://github.com/redhat-developer/devspaces-gateway-plugin/[JetBrains IntelliJ IDEA Ultimate Edition
 (over JetBrains Gateway)]
-| Technology Preview
+| Available
 |
 * `che-incubator/che-idea-server/latest`
 * `che-incubator/che-idea-server/next`

--- a/modules/end-user-guide/pages/url-parameter-for-the-ide.adoc
+++ b/modules/end-user-guide/pages/url-parameter-for-the-ide.adoc
@@ -38,18 +38,9 @@ pass:c,a,q[{prod-url}]#__<git_repository_url>__?che-editor=__<editor_key>__
 * `latest` is the default IDE that loads in a new workspace when the URL parameter or `che-editor.yaml` is not used.
 * `insiders` is the development version.
 
-| link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community Edition]
-| Deprecated
-|
-* `che-incubator/che-idea/latest`
-* `che-incubator/che-idea/next`
-|
-* `latest` is the stable version.
-* `next` is the development version.
-
 | link:https://github.com/redhat-developer/devspaces-gateway-plugin/[JetBrains IntelliJ IDEA Ultimate Edition
 (over JetBrains Gateway)]
-| Technology Preview
+| Available
 |
 * `che-incubator/che-idea-server/latest`
 * `che-incubator/che-idea-server/next`

--- a/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
+++ b/modules/end-user-guide/partials/ref_parameters-for-che-editor-yaml.adoc
@@ -18,18 +18,9 @@ The simplest way to select an IDE in the `che-editor.yaml` is to specify the `id
 * `latest` is the default IDE that loads in a new workspace when the URL parameter or `che-editor.yaml` is not used.
 * `insiders` is the development version.
 
-| link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community Edition]
-| Deprecated
-|
-* `che-incubator/che-idea/latest`
-* `che-incubator/che-idea/next`
-|
-* `latest` is the stable version.
-* `next` is the development version.
-
 | link:https://github.com/redhat-developer/devspaces-gateway-plugin/[JetBrains IntelliJ IDEA Ultimate Edition
 (over JetBrains Gateway)]
-| Technology Preview
+| Available
 |
 * `che-incubator/che-idea-server/latest`
 * `che-incubator/che-idea-server/next`

--- a/modules/overview/pages/introduction-to-eclipse-che.adoc
+++ b/modules/overview/pages/introduction-to-eclipse-che.adoc
@@ -11,7 +11,7 @@
 * A multi-container workspace for each developer with the ability to replicate with a single click using {prod} factories.
 * Pre-built stacks with the ability to create custom stacks for any language or runtime.
 * An enterprise integration using OpenShift OAuth or Dex.
-* Browser-based IDEs; integration with link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code - Open Source] and others such as link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA Community Edition].
+* Browser-based IDEs; integration with link:https://github.com/che-incubator/che-code[Microsoft Visual Studio Code - Open Source] and others such as link:https://github.com/che-incubator/jetbrains-editor-images[JetBrains IntelliJ IDEA].
 * Support of tools protocols, such as the Language Server Protocol or Debug Adapter Protocol.
 * A plugin mechanism compatible with Visual Studio Code extensions.
 * A software development kit (SDK) for creating custom cloud developer platforms.


### PR DESCRIPTION
- Remove "JetBrains IntelliJ IDEA Community Edition" ([CRW-9400](https://issues.redhat.com//browse/CRW-9400))

Tested with `./tools/runnerpreview.sh`. CC'ing @ibuziuk , @gtrivedi88 for awareness.

Sample :

<img width="771" height="520" alt="image" src="https://github.com/user-attachments/assets/455f3bb3-cf31-47bd-8291-82efacf90d96" />
