### PR TITLE
fix: redhat doc links

### DIFF
--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -7,7 +7,7 @@
 
 * The OpenShift cluster has at least 64 GB of disk space.
 
-* The OpenShift cluster is ready to operate on a restricted network. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/disconnected_environments/mirroring-in-disconnected-environments[About disconnected installation mirroring] and link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admin/olm-restricted-networks.html[Using Operator Lifecycle Manager on restricted networks].
+* The OpenShift cluster is ready to operate on a restricted network. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/disconnected_environments/installing-mirroring-disconnected-about[About disconnected installation mirroring] and link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admin/olm-restricted-networks.html[Using Operator Lifecycle Manager on restricted networks].
 
 // NOTE for testers: don't use the internal registry present on `crc`.
 

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -26,7 +26,7 @@
 
 * `skopeo` version 1.6 or higher. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo].
 
-* An active `skopeo` session with administrative access to the private Docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/disconnected_environments/mirroring-in-disconnected-environments[Mirroring images for a disconnected installation].
+* An active `skopeo` session with administrative access to the private Docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/disconnected_environments/installing-mirroring-disconnected-about[Mirroring images for a disconnected installation].
 
 * `{prod-cli}` for {prod-short} version {prod-ver}. See xref:installing-the-chectl-management-tool.adoc[].
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
fix: redhat doc links 

## What issues does this pull request fix or reference?
https://github.com/eclipse-che/che-docs/pull/2981

## Specify the version of the product this pull request applies to
main

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
