### PR TITLE
Cherry-pick | Backport 2984 to 7.109

### DIFF
--- a/modules/administration-guide/pages/security-best-practices.adoc
+++ b/modules/administration-guide/pages/security-best-practices.adoc
@@ -223,6 +223,23 @@ you can enforce project-specific policies to prevent bad actors from consuming e
 These mechanisms contribute to better resource management, stability, and fairness within an OpenShift cluster.
 More details about link:https://docs.openshift.com/container-platform/4.14/applications/quotas/quotas-setting-per-project.html[Resource Quotas] and link:https://docs.openshift.com/container-platform/4.14/nodes/clusters/nodes-cluster-limit-ranges.html[Limit Ranges] are available in the OpenShift documentation.
 
+.Network policies
+
+Network policies provide an additional layer of security by controlling network traffic between
+Pods in a {kubernetes} cluster. By default, every Pod can communicate with every other Pod and service on the cluster,
+see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/networking_overview/index#about-openshift-sdn[OpenShift networking overview].
+
+Implementing network policies allows you to:
+
+* Control ingress and egress traffic to and from workspace Pods
+* Limit the attack surface by denying unauthorized network access
+
+When configuring network policies for {prod},
+ensure that Pods in the {prod-short} namespace can still communicate with Pods in user namespaces,
+as this is required for proper functionality.
+
+For detailed instructions on implementing network policies with {prod}, see xref:configuring-network-policies.adoc[].
+
 .Disconnected environment
 
 An air-gapped OpenShift disconnected cluster refers to an OpenShift cluster

--- a/modules/administration-guide/pages/security-best-practices.adoc
+++ b/modules/administration-guide/pages/security-best-practices.adoc
@@ -221,7 +221,7 @@ By combining Resource Quotas and Limit Ranges,
 you can enforce project-specific policies to prevent bad actors from consuming excessive resources.
 
 These mechanisms contribute to better resource management, stability, and fairness within an OpenShift cluster.
-More details about link:https://docs.openshift.com/container-platform/4.14/applications/quotas/quotas-setting-per-project.html[Resource Quotas] and link:https://docs.openshift.com/container-platform/4.14/nodes/clusters/nodes-cluster-limit-ranges.html[Limit Ranges] are available in the OpenShift documentation.
+More details about link:https://docs.openshift.com/container-platform/4.14/applications/quotas/quotas-setting-per-project.html[Resource quotas] and link:https://docs.openshift.com/container-platform/4.14/nodes/clusters/nodes-cluster-limit-ranges.html[Limit ranges] are available in the OpenShift documentation.
 
 .Network policies
 

--- a/modules/administration-guide/pages/security-best-practices.adoc
+++ b/modules/administration-guide/pages/security-best-practices.adoc
@@ -226,7 +226,7 @@ More details about link:https://docs.openshift.com/container-platform/4.14/appli
 .Network policies
 
 Network policies provide an additional layer of security by controlling network traffic between
-Pods in a {kubernetes} cluster. By default, every Pod can communicate with every other Pod and service on the cluster,
+Pods in a {kubernetes} cluster. By default, every pod can communicate with every other pod and service on the cluster,
 see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/networking_overview/index#about-openshift-sdn[OpenShift networking overview].
 
 Implementing network policies allows you to:

--- a/modules/administration-guide/pages/security-best-practices.adoc
+++ b/modules/administration-guide/pages/security-best-practices.adoc
@@ -226,7 +226,7 @@ More details about link:https://docs.openshift.com/container-platform/4.14/appli
 .Network policies
 
 Network policies provide an additional layer of security by controlling network traffic between
-Pods in a {kubernetes} cluster. By default, every pod can communicate with every other pod and service on the cluster,
+pods in a {kubernetes} cluster. By default, every pod can communicate with every other pod and service on the cluster,
 see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/networking_overview/index#about-openshift-sdn[OpenShift networking overview].
 
 Implementing network policies allows you to:

--- a/modules/administration-guide/pages/security-best-practices.adoc
+++ b/modules/administration-guide/pages/security-best-practices.adoc
@@ -235,7 +235,7 @@ Implementing network policies allows you to:
 * Limit the attack surface by denying unauthorized network access
 
 When configuring network policies for {prod},
-ensure that Pods in the {prod-short} namespace can still communicate with Pods in user namespaces,
+ensure that pods in the {prod-short} namespace can still communicate with pods in user namespaces,
 as this is required for proper functionality.
 
 For detailed instructions on implementing network policies with {prod}, see xref:configuring-network-policies.adoc[].

--- a/modules/administration-guide/pages/security-best-practices.adoc
+++ b/modules/administration-guide/pages/security-best-practices.adoc
@@ -231,7 +231,7 @@ see link:https://docs.redhat.com/en/documentation/openshift_container_platform/{
 
 Implementing network policies allows you to:
 
-* Control ingress and egress traffic to and from workspace Pods
+* Control ingress and egress traffic to and from workspace pods
 * Limit the attack surface by denying unauthorized network access
 
 When configuring network policies for {prod},

--- a/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
+++ b/modules/administration-guide/partials/snip_preparing-images-for-a-restricted-environment.adoc
@@ -7,7 +7,7 @@
 
 * The OpenShift cluster has at least 64 GB of disk space.
 
-* The OpenShift cluster is ready to operate on a restricted network. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/disconnected_environments/mirroring-in-disconnected-environments[About disconnected installation mirroring] and link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admin/olm-restricted-networks.html[Using Operator Lifecycle Manager on restricted networks].
+* The OpenShift cluster is ready to operate on a restricted network. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html-single/disconnected_environments/mirroring-in-disconnected-environments[About disconnected installation mirroring] and link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admin/olm-restricted-networks.html[Using Operator Lifecycle Manager on restricted networks].
 
 // NOTE for testers: don't use the internal registry present on `crc`.
 
@@ -26,7 +26,7 @@
 
 * `skopeo` version 1.6 or higher. See link:https://github.com/containers/skopeo/blob/main/install.md[Installing Skopeo].
 
-* An active `skopeo` session with administrative access to the private Docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/disconnected_environments/mirroring-in-disconnected-environments[Mirroring images for a disconnected installation].
+* An active `skopeo` session with administrative access to the private Docker registry. link:https://github.com/containers/skopeo#authenticating-to-a-registry[Authenticating to a registry], and link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html-single/disconnected_environments/mirroring-in-disconnected-environments[Mirroring images for a disconnected installation].
 
 * `{prod-cli}` for {prod-short} version {prod-ver}. See xref:installing-the-chectl-management-tool.adoc[].
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

This is a cherry-pick PR based on https://github.com/eclipse-che/che-docs/pull/2984 for 7.107.x.

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to

7.109.x

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
