### PR TITLE
fix: importing untrusted tls certificates article

### DIFF
--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -108,7 +108,7 @@ This command returns {prod-short} CA bundle certificates in PEM format:
 +
 [subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
 ----
-{orch-cli} get configmap che-trusted-ca-certs \
+{orch-cli} get configmap ca-certs-merged \
     --namespace=__<workspace_namespace>__ \
     --output='jsonpath={.data.tls-ca-bundle\.pem}'
 ----
@@ -142,6 +142,15 @@ This command returns {prod-short} CA bundle certificates in PEM format:
 {orch-cli} exec __<workspace_pod_name>__ \
     --namespace=__<workspace_namespace>__ \
     -- cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+----
++
+Or if `disableWorkspaceCaBundleMount` set to `true`:
++
+[subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
+----
+{orch-cli} exec __<workspace_pod_name>__ \
+    --namespace=__<workspace_namespace>__ \
+    -- cat /public-certs/tls-ca-bundle.pem
 ----
 
 .Additional resources


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
fix: importing untrusted tls certificates article

## What issues does this pull request fix or reference?
https://github.com/eclipse-che/che/issues/23555

## Specify the version of the product this pull request applies to
main

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
