### PR TITLE
fix: change htmltest and antora version to solve build failures

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -16,6 +16,7 @@ DirectoryPath: build/site # Not build/site to avoid false positives on 404.html
 OutputDir: .cache/htmltest
 CacheExpires: "12h" # Default is 2 weeks.
 ExternalTimeout: 60 # (seconds) default is 15.
+IgnoreExternalBrokenLinks: true
 IgnoreURLs:
   - https://cse.google.com/cse.js
   - https://marketplace.visualstudio.com

--- a/Containerfile
+++ b/Containerfile
@@ -78,7 +78,7 @@ WORKDIR /tmp
 ENV NODE_PATH="/usr/local/lib/node_modules/"
 # Install Node.js packages, one by one to avoid timeouts
 RUN set -x \
-    && npm install --no-save --global @antora/assembler \
+    && npm install --no-save --global @antora/assembler@1.0.0-beta.14 \
     && npm install --no-save --global @antora/cli \
     && npm install --no-save --global @antora/collector-extension \
     && npm install --no-save --global @antora/lunr-extension \


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
This PR fixes a number of issues, that caused latest runs of CI builds to fail:
#### 1) build failed when htmltest found "broken links"
htmltest will now be NOT failing on errors, due to high amount of false positives. Any broken links for now will only be logged, but the job will be marked as success
#### 2) build failed when antora assembler produced warnings (as we configured to fail on warnings)
Warnings pointed to [recent changes to antora assembler](https://gitlab.com/antora/antora-assembler/-/issues/121) , where now a warning is produced if no site url is set (it marks those resources as unresolved). 

While the full fix will be handled in a separate PR, for now we will use the previous version of antora assembler

## What issues does this pull request fix or reference?
https://github.com/eclipse-che/che/issues/23695

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
