### PR TITLE
Improve JetBrains warning visibility

### DIFF
--- a/modules/administration-guide/pages/configuring-editors-download-urls.adoc
+++ b/modules/administration-guide/pages/configuring-editors-download-urls.adoc
@@ -6,7 +6,12 @@
 [id="configuring-editors-download-urls"]
 = Configuring editors download URLs
 
-This procedure describes how to configure download URLs for editors. This feature is valuable in air-gapped environments where editors cannot be retrieved from the public internet. Currently, this option is intended only for JetBrains editors and should not be used for other editor types.
+This procedure describes how to configure download URLs for editors. This feature is valuable in air-gapped environments where editors cannot be retrieved from the public internet.
+
+[IMPORTANT]
+====
+This configuration option is currently supported only for JetBrains editors. Do not use this feature with other editor types.
+====
 
 .Prerequisites
 


### PR DESCRIPTION
## What does this pull request change?

This PR improves the visibility of an important warning in the "Configuring editors download URLs" documentation by converting it from inline text to an IMPORTANT admonition block.

**Change:** Converted the warning about JetBrains-only support for custom editor download URLs from plain text embedded in the introduction paragraph to a visually distinct IMPORTANT admonition block.

**Rationale:** The current warning is easy to miss as it's embedded within the introductory paragraph. Users configuring air-gapped environments might overlook this critical limitation and attempt to apply this configuration to non-JetBrains editors, which could lead to issues. An admonition block makes this restriction immediately visible and harder to miss.

## What issues does this pull request fix or reference?

This addresses feedback from downstream Red Hat OpenShift Dev Spaces documentation team about the warning not being prominent enough for users.

## Specify the version of the product this pull request applies to

- [x] `main` (current development branch)

## Pull Request Checklist

- [x] This PR addresses an existing issue or introduces a new feature
- [x] The documentation change improves clarity and user experience
- [x] The change follows AsciiDoc best practices for admonition blocks
- [x] The warning message has been reworded for better clarity while preserving the original meaning