### PR TITLE
Remove broken Kubernetes podcast link

### DIFF
--- a/modules/administration-guide/pages/running-at-scale.adoc
+++ b/modules/administration-guide/pages/running-at-scale.adoc
@@ -24,12 +24,6 @@ are designed as single-user applications, not as multitenant services.
 While there is no strict limit on the number of resources in a {kubernetes} cluster,
 there are certain link:https://kubernetes.io/docs/setup/best-practices/cluster-large/[considerations for large clusters] to remember
 
-[NOTE]
-====
-Learn more about the {kubernetes} scalability in the link:https://kubernetespodcast.com/episode/111-scalability/["Scalability,
-with Wojciech Tyczynski" episode of Kubernetes Podcast].
-====
-
 link:https://www.redhat.com/en/technologies/cloud-computing/openshift[OpenShift Container Platform], which is a certified distribution of {kubernetes}, also provides a set of tested maximums for various resources, which can serve as an initial guideline for planning your environment:
 
 [%header,format=csv]


### PR DESCRIPTION
## What does this pull request change?

- Removed the broken kubernetespodcast.com link that returns 404 error
- Removed the NOTE block referencing the "Scalability, with Wojciech Tyczynski" episode

## What issues does this pull request fix or reference?

- Removed lines 27-31 from [running-at-scale.adoc](modules/administration-guide/pages/running-at-scale.adoc)
- The entire kubernetespodcast.com website appears to be down
## Specify the version of the product this pull request applies to

- [x] `main` (current development branch)

## Pull Request Checklist

- [x] This PR addresses an existing issue or introduces a new feature
- [x] The documentation change improves clarity and user experience
- [x] The change follows AsciiDoc best practices for admonition blocks
- [x] The warning message has been reworded for better clarity while preserving the original meaning