### PR TITLE
Fix AsciiDoc DocBook XML parsing errors

### DIFF
--- a/modules/administration-guide/pages/configuring-proxy.adoc
+++ b/modules/administration-guide/pages/configuring-proxy.adoc
@@ -65,7 +65,7 @@ In some proxy configurations, `localhost` may not translate to `127.0.0.1`. Both
 
 . Start a workspace
 
-. Verify that the workspace pod contains `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy` and `https_proxy` environment variables, each set to `__<protocol>__://<user>:<password@<domain>:<port>`.
+. Verify that the workspace pod contains `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy` and `https_proxy` environment variables, each set to `<protocol>://<user>:<password>@<domain>:<port>`.
 
 . Verify that the workspace pod contains `NO_PROXY` and `no_proxy` environment variables, each set to comma-separated list of non-proxy hosts.
 

--- a/modules/administration-guide/partials/proc_configuring-number-of-replicas.adoc
+++ b/modules/administration-guide/partials/proc_configuring-number-of-replicas.adoc
@@ -25,7 +25,7 @@ spec:
     name: __<deployment_name>__ <1>
   ...
 ----
-<1> The `__<deployment_name>__` corresponds to the one following deployments:
+<1> The `<deployment_name>` corresponds to the one following deployments:
 * `{prod-deployment}`
 * `che-gateway`
 * `{prod-deployment}-dashboard`

--- a/modules/administration-guide/partials/proc_creating-lets-encrypt-certificate-for-che-on-amazon-elastic-kubernetes-service.adoc
+++ b/modules/administration-guide/partials/proc_creating-lets-encrypt-certificate-for-che-on-amazon-elastic-kubernetes-service.adoc
@@ -121,7 +121,7 @@ spec:
                 name: cert-manager-acme-dns01-route53
 EOF
 ----
-<1> Replace `__<email_address>__` with your email address.
+<1> Replace `<email_address>` with your email address.
 
 . Create the {prod-namespace} namespace:
 +

--- a/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
@@ -45,11 +45,11 @@ openssl rand -base64 24 > bitbucket-shared-secret
 
 . Paste the content of the `bitbucket-shared-secret` file as the *Shared secret*.
 
-. Enter `__<bitbucket_server_url>__/plugins/servlet/oauth/request-token` as the *Request Token URL*.
+. Enter `<bitbucket_server_url>/plugins/servlet/oauth/request-token` as the *Request Token URL*.
 
-. Enter `__<bitbucket_server_url>__/plugins/servlet/oauth/access-token` as the *Access token URL*.
+. Enter `<bitbucket_server_url>/plugins/servlet/oauth/access-token` as the *Access token URL*.
 
-. Enter `__<bitbucket_server_url>__/plugins/servlet/oauth/authorize` as the *Authorize URL*.
+. Enter `<bitbucket_server_url>/plugins/servlet/oauth/authorize` as the *Authorize URL*.
 
 . Check the *Create incoming link* checkbox and click *Continue*.
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

The quay.io/ivanhorvath/ccutil:amazing container image was updated between December 2025 and January 2026 with stricter DocBook XML validation.

Timeline for downstream publishing:

December 4, 2025: Build succeeded with the error present (commit c6c22a9)
January 13, 2026: Build succeeded with the error present (commit 3468e8b - "Single sourced on 2026-01-13T15:41+00:00")
January 30, 2026 (today): Build fails with "Opening and ending tag mismatch" error


<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?

The error has been in the upstream source code since at least September 2025, but:

Old ccutil version (pre-January 2026):

Lenient XML parser that didn't enforce strict tag nesting
Allowed malformed <literal><emphasis> nesting to pass
New ccutil version (current):

Stricter DocBook XML validation (likely updated AsciiDoctor or xmllint version)
Now correctly rejects the malformed XML created by `__<password@<domain>__`

## What issues does this pull request fix or reference?

This commit fixes multiple AsciiDoc formatting issues that cause
DocBook XML parsing errors with stricter validators:

1. configuring-proxy.adoc (line 68):
   - Fixed missing '>' after '<password' placeholder
   - Changed '<password@<domain>' to '<password>@<domain>'
   - Removed nested formatting (backticks with double underscores)

2. Removed double underscores inside backticks across multiple files:
   - proc_configuring-number-of-replicas.adoc
   - proc_creating-lets-encrypt-certificate-for-che-on-amazon-elastic-kubernetes-service.adoc
   - proc_setting-up-an-application-link-on-the-bitbucket-server.adoc

The pattern \`__<placeholder>__\` inside backticks creates improperly
nested XML tags: <literal><emphasis>text</emphasis></literal>, which
causes build failures with error: "Opening and ending tag mismatch:
emphasis line X and literal".

These issues were caught by updated ccutil container with stricter
XML validation.

## Specify the version of the product this pull request applies to

`main` and `7.113`

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
