### PR TITLE
Backport #3018 to 7.113.x: docs: Adding information about the openvsx rate limits and usage tiers

### DIFF
--- a/modules/administration-guide/partials/proc_selecting-an-open-vsx-registry-instance.adoc
+++ b/modules/administration-guide/partials/proc_selecting-an-open-vsx-registry-instance.adoc
@@ -24,6 +24,11 @@ spec:
 ----
 <1> For example: `openVSXURL: "pass:c,a,q[https://open-vsx.org]"`.
 +
+[WARNING]
+====
+To ensure the stability and performance of the community-supported Open VSX Registry, API usage is organized into defined tiers. The Eclipse Foundation implements these limits to protect infrastructure from high-frequency automated traffic and to provide consistent service quality for all users. For more information, see link:https://github.com/EclipseFdn/open-vsx.org/wiki/rate-limiting[Rate Limits and Usage Tiers] and the link:https://github.com/EclipseFdn/open-vsx.org/wiki[open-vsx.org wiki].
+====
++
 [IMPORTANT]
 ====
 * Using link:https://open-vsx.org[https://open-vsx.org] is not recommended in an air-gapped environment, isolated from the internet. In order to reduce the risk of malware infections and unauthorized access to your code use the embedded or self-hosted Open VSX registry with a curated set of extensions.


### PR DESCRIPTION
## Summary
Backport of #3018 to the 7.113.x release branch.

## Changes
- Added information about OpenVSX rate limits and usage tiers
- Cherry-picked from main branch (commit b87f453d)

## Original PR
- Original PR: #3018
- Author: @ibuziuk

## Test plan
- [ ] Documentation builds correctly on 7.113.x
- [ ] Changes are compatible with 7.113.x version