### PR TITLE
docs: add warning for workspace restarts on automount changes (CRW-9859)

### DIFF
--- a/modules/administration-guide/pages/configuring-a-user-namespace.adoc
+++ b/modules/administration-guide/pages/configuring-a-user-namespace.adoc
@@ -18,6 +18,11 @@ If you make changes to a {kubernetes} resource in an {prod-namespace} namespace,
 In reverse, if a {kubernetes} resource is modified in a user namespace,
 {prod-short} will immediately revert the changes.
 
+[WARNING]
+====
+Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. Ensure that users save their work before you apply these changes.
+====
+
 .Procedure
 
 . Create the `ConfigMap` below to create and mount it into every workspace.

--- a/modules/end-user-guide/pages/mounting-configmaps.adoc
+++ b/modules/end-user-guide/pages/mounting-configmaps.adoc
@@ -19,6 +19,11 @@ Mount {kubernetes} ConfigMaps to the `{devworkspace}` containers in the {orch-na
 
 * In your user {orch-namespace}, you created a new ConfigMap or determined an existing ConfigMap to mount to all `{devworkspace}` containers.
 
+[WARNING]
+====
+Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. Ensure that users save their work before you apply these changes.
+====
+
 .Procedure
 
 . Add the labels, which are required for mounting the ConfigMap, to the ConfigMap.

--- a/modules/end-user-guide/pages/mounting-secrets.adoc
+++ b/modules/end-user-guide/pages/mounting-secrets.adoc
@@ -19,6 +19,11 @@ Mount {kubernetes} Secrets to the `{devworkspace}` containers in the {orch-name}
 
 * In your user {orch-namespace}, you created a new Secret or determined an existing Secret to mount to all `{devworkspace}` containers.
 
+[WARNING]
+====
+Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. Ensure that users save their work before you apply these changes.
+====
+
 .Procedure
 
 . Add the labels, which are required for mounting the Secret, to the Secret.


### PR DESCRIPTION
## What does this pull request change?
This PR adds a WARNING block to the Secret and ConfigMap mounting procedures. It informs users and administrators that applying or modifying resources with the `controller.devfile.io/mount-to-devworkspace: 'true'` label triggers an immediate restart of all running workspaces in the affected namespace to apply the configuration.

## What issues does this pull request fix or reference?
Referenced Jira: https://issues.redhat.com/browse/CRW-9859

## Specify the version of the product this pull request applies to
Eclipse Che (Upstream)

## Pull Request checklist
- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - [ ] Propagate the URL change in:
    - [ ] Dashboard [default branding data]
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *Validate language on files added or modified* step reports no vale warnings.