### PR TITLE
fix: Backport AsciiDoc DocBook XML parsing errors to 7.113.x

### DIFF
--- a/modules/administration-guide/pages/configuring-proxy.adoc
+++ b/modules/administration-guide/pages/configuring-proxy.adoc
@@ -60,7 +60,7 @@ EOF
 
 . Start a workspace
 
-. Verify that the workspace pod contains `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy` and `https_proxy` environment variables, each set to `__<protocol>__://<user>:<password@<domain>:<port>`.
+. Verify that the workspace pod contains `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy` and `https_proxy` environment variables, each set to `<protocol>://<user>:<password>@<domain>:<port>`.
 
 . Verify that the workspace pod contains `NO_PROXY` and `no_proxy` environment variables, each set to comma-separated list of non-proxy hosts.
 

--- a/modules/administration-guide/partials/proc_configuring-number-of-replicas.adoc
+++ b/modules/administration-guide/partials/proc_configuring-number-of-replicas.adoc
@@ -25,7 +25,7 @@ spec:
     name: __<deployment_name>__ <1>
   ...
 ----
-<1> The `__<deployment_name>__` corresponds to the one following deployments:
+<1> The `<deployment_name>` corresponds to the one following deployments:
 * `{prod-deployment}`
 * `che-gateway`
 * `{prod-deployment}-dashboard`

--- a/modules/administration-guide/partials/proc_creating-lets-encrypt-certificate-for-che-on-amazon-elastic-kubernetes-service.adoc
+++ b/modules/administration-guide/partials/proc_creating-lets-encrypt-certificate-for-che-on-amazon-elastic-kubernetes-service.adoc
@@ -121,7 +121,7 @@ spec:
                 name: cert-manager-acme-dns01-route53
 EOF
 ----
-<1> Replace `__<email_address>__` with your email address.
+<1> Replace `<email_address>` with your email address.
 
 . Create the {prod-namespace} namespace:
 +

--- a/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
+++ b/modules/administration-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc
@@ -45,11 +45,11 @@ openssl rand -base64 24 > bitbucket-shared-secret
 
 . Paste the content of the `bitbucket-shared-secret` file as the *Shared secret*.
 
-. Enter `__<bitbucket_server_url>__/plugins/servlet/oauth/request-token` as the *Request Token URL*.
+. Enter `<bitbucket_server_url>/plugins/servlet/oauth/request-token` as the *Request Token URL*.
 
-. Enter `__<bitbucket_server_url>__/plugins/servlet/oauth/access-token` as the *Access token URL*.
+. Enter `<bitbucket_server_url>/plugins/servlet/oauth/access-token` as the *Access token URL*.
 
-. Enter `__<bitbucket_server_url>__/plugins/servlet/oauth/authorize` as the *Authorize URL*.
+. Enter `<bitbucket_server_url>/plugins/servlet/oauth/authorize` as the *Authorize URL*.
 
 . Check the *Create incoming link* checkbox and click *Continue*.
 


### PR DESCRIPTION
## Summary
- Backport of PR #3017 to 7.113.x
- Fixes AsciiDoc DocBook XML parsing errors that cause build failures with stricter validators

## Changes
This commit fixes multiple AsciiDoc formatting issues that cause DocBook XML parsing errors:

1. [configuring-proxy.adoc](modules/administration-guide/pages/configuring-proxy.adoc) - Fixed missing '>' after '<password' placeholder and removed nested formatting
2. [proc_configuring-number-of-replicas.adoc](modules/administration-guide/partials/proc_configuring-number-of-replicas.adoc) - Removed double underscores inside backticks
3. [proc_creating-lets-encrypt-certificate-for-che-on-amazon-elastic-kubernetes-service.adoc](modules/installation-guide/partials/proc_creating-lets-encrypt-certificate-for-che-on-amazon-elastic-kubernetes-service.adoc) - Removed double underscores inside backticks
4. [proc_setting-up-an-application-link-on-the-bitbucket-server.adoc](modules/end-user-guide/partials/proc_setting-up-an-application-link-on-the-bitbucket-server.adoc) - Removed double underscores inside backticks

The pattern \`__<placeholder>__\` creates improperly nested XML tags causing build failures.