### PR TITLE
docs: describe how to remove extensions from the private openvsx registry

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -110,6 +110,7 @@
 * xref:managing-ide-extensions.adoc[]
 ** xref:extensions-for-microsoft-visual-studio-code-open-source.adoc[]
 ** xref:running-the-open-vsx-on-premises.adoc[]
+** xref:deleting-extension-from-the-open-vsx-on-premises.adoc[]
 ** xref:configuring-the-open-vsx-registry-url.adoc[]
 * xref:configuring-visual-studio-code.adoc[]
 ** xref:configuring-single-and-multiroot-workspaces.adoc[]

--- a/modules/administration-guide/pages/deleting-extension-from-the-open-vsx-on-premises.adoc
+++ b/modules/administration-guide/pages/deleting-extension-from-the-open-vsx-on-premises.adoc
@@ -1,11 +1,11 @@
 :_content-type: PROCEDURE
-:description: Deleting Extension from Open VSX On-Premises
+:description: Deleting Extensions from Open VSX On-Premises
 :keywords: administration guide, configuring, openvsx, registry
-:navtitle: Deleting Extension from Open VSX On-Premises
+:navtitle: Deleting Extensions from Open VSX On-Premises
 :page-aliases:
 
 [id="deleting-extension-from-the-open-vsx-on-premises"]
-= Delete Extensions from the Open VSX registry
+= Deleting Extensions from the Open VSX registry
 
 You can remove extensions from your private Open VSX registry by using one of the following methods:
 

--- a/modules/administration-guide/pages/deleting-extension-from-the-open-vsx-on-premises.adoc
+++ b/modules/administration-guide/pages/deleting-extension-from-the-open-vsx-on-premises.adoc
@@ -1,0 +1,17 @@
+:_content-type: PROCEDURE
+:description: Deleting Extension from Open VSX On-Premises
+:keywords: administration guide, configuring, openvsx, registry
+:navtitle: Deleting Extension from Open VSX On-Premises
+:page-aliases:
+
+[id="deleting-extension-from-the-open-vsx-on-premises"]
+= Delete Extensions from the Open VSX registry
+
+You can remove extensions from your private Open VSX registry by using one of the following methods:
+
+* Use the Open VSX administrator API (recommended).
+* Delete the extension data directly in the PostgreSQL database.
+
+include::partial$proc_deleting-extension-using-openvsx-admin-api.adoc[leveloffset=+1]
+
+include::partial$proc_deleting-extension-from-postgresql-database.adoc[leveloffset=+1]

--- a/modules/administration-guide/pages/managing-ide-extensions.adoc
+++ b/modules/administration-guide/pages/managing-ide-extensions.adoc
@@ -11,5 +11,6 @@ IDEs use extensions or plugins to extend their functionality, and the mechanism 
 
 * xref:extensions-for-microsoft-visual-studio-code-open-source.adoc[]
 * xref:running-the-open-vsx-on-premises.adoc[]
+* xref:deleting-extension-from-the-open-vsx-on-premises.adoc[]
 * xref:configuring-the-open-vsx-registry-url.adoc[]
 

--- a/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
+++ b/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
@@ -156,3 +156,14 @@ oc patch checluster "${CHECLUSTER_NAME}" --type=merge --patch "${PATCH}" -n "${C
 .Additional resources
 * link:https://github.com/eclipse/openvsx/[Eclipse Open VSX sources]
 * link:https://github.com/eclipse/openvsx/wiki/[Eclipse Open VSX documentation]
+
+== Delete Extensions in a Private OpenVSX Registry
+
+You can remove extensions from your private OpenVSX registry by using one of the following methods:
+
+* Use the OpenVSX administrator API (recommended).
+* Delete the extension data directly in the PostgreSQL database.
+
+include::partial$proc_deleting-extension-using-openvsx-admin-api.adoc[leveloffset=+1]
+
+include::partial$proc_deleting-extension-from-postgresql-database.adoc[leveloffset=+1]

--- a/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
+++ b/modules/administration-guide/pages/running-the-open-vsx-on-premises.adoc
@@ -156,14 +156,3 @@ oc patch checluster "${CHECLUSTER_NAME}" --type=merge --patch "${PATCH}" -n "${C
 .Additional resources
 * link:https://github.com/eclipse/openvsx/[Eclipse Open VSX sources]
 * link:https://github.com/eclipse/openvsx/wiki/[Eclipse Open VSX documentation]
-
-== Delete Extensions in a Private OpenVSX Registry
-
-You can remove extensions from your private OpenVSX registry by using one of the following methods:
-
-* Use the OpenVSX administrator API (recommended).
-* Delete the extension data directly in the PostgreSQL database.
-
-include::partial$proc_deleting-extension-using-openvsx-admin-api.adoc[leveloffset=+1]
-
-include::partial$proc_deleting-extension-from-postgresql-database.adoc[leveloffset=+1]

--- a/modules/administration-guide/partials/proc_deleting-extension-from-postgresql-database.adoc
+++ b/modules/administration-guide/partials/proc_deleting-extension-from-postgresql-database.adoc
@@ -1,0 +1,114 @@
+:_mod-docs-content-type: PROCEDURE
+[id="proc_deleting-extension-from-postgresql-database_{context}"]
+== Deleting an extension from the PostgreSQL database directly
+[role="_abstract"]
+Remove extension records and related data directly in the PostgreSQL database when the administrator API is not available or when you must clean up specific data. If the extension uses local storage, you must also remove its files from the OpenVSX server pod.
+
+.Prerequisites
+
+* You have access to the OpenShift cluster where OpenVSX is deployed (namespace `openvsx`).
+* You know the namespace name and extension name that you want to delete.
+
+.Procedure
+
+. Open a command prompt in the PostgreSQL pod and connect to the database:
++
+[source,bash,options="nowrap"]
+----
+export POSTGRESQL_POD_NAME=$(oc get pods -n openvsx \
+   -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep '^postgresql' | head -n 1)
+oc exec -it $POSTGRESQL_POD_NAME -n openvsx -- /bin/bash
+----
++
+Inside the pod, run `psql`:
++
+[source,terminal,options="nowrap"]
+----
+psql
+----
++
+At the `postgres=#` prompt, connect to the database:
++
+[source,terminal,options="nowrap"]
+----
+\c openvsx
+----
++
+You are now connected to the `openvsx` database as the `postgres` user.
+. Find the namespace ID and extension ID:
++
+Identify the `namespace` ID. Replace `__<namespace_name>__` with the actual `namespace`:
++
+[source,sql,subs="+quotes",options="nowrap"]
+----
+SELECT id, name FROM namespace WHERE name = '__<namespace_name>__';
+----
++
+Identify the extension ID. Replace `__<namespace_id>__` and `__<extension_name>__` with the values from the previous query:
++
+[source,sql,subs="+quotes",options="nowrap"]
+----
+SELECT id, name, namespace_id FROM extension WHERE namespace_id = __<namespace_id>__ AND name = '__<extension_name>__';
+----
++
+Note the ID of the extension to use as `__<extension_id>__` in the next steps.
+. Optional: Preview extension versions and file resources:
++
+Preview the versions:
++
+[source,sql,subs="+quotes",options="nowrap"]
+----
+SELECT id, version, pre_release, semver_pre_release, semver_is_pre_release FROM extension_version WHERE extension_id = __<extension_id>__ ORDER BY timestamp DESC;
+----
++
+Preview the file resources:
++
+[source,sql,subs="+quotes",options="nowrap"]
+----
+SELECT id, name, type, storage_type FROM file_resource WHERE extension_id = __<extension_id>__ ORDER BY id;
+----
++
+If the `storage_type` value is `local`, you must also remove the extension files from the file system on the OpenVSX server pod.
+. Delete the extension from the database:
++
+Run the following commands in a single transaction. Replace `__<extension_id>__` with the extension ID from step 2.
++
+[source,sql,subs="+quotes",options="nowrap"]
+----
+BEGIN;
+-- 1. Delete all file resources for the extension
+DELETE FROM file_resource WHERE extension_id = __<extension_id>__;
+-- 2. Delete all extension reviews
+DELETE FROM extension_review WHERE extension_id = __<extension_id>__;
+-- 3. Delete all versions of the extension
+DELETE FROM extension_version WHERE extension_id = __<extension_id>__;
+-- 4. Delete the extension entry itself
+DELETE FROM extension WHERE id = __<extension_id>__;
+COMMIT;
+----
++
+[IMPORTANT]
+====
+Run these commands in order within one transaction. Do not skip the `COMMIT` command, or the system does not apply the changes.
+====
+. If applicable, remove the extension files from local storage:
++
+If the extension used local storage, remove its files from the OpenVSX server pod.
++
+Get the OpenVSX server pod name:
++
+[source,bash,options="nowrap"]
+----
+export OPENVSX_POD_NAME=$(oc get pods -n openvsx -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep '^openvsx-server' | head -n 1)
+----
++
+Access the pod and delete the extension folder for the publisher and extension you removed:
++
+[source,bash,subs="+quotes",options="nowrap"]
+----
+oc exec -it $OPENVSX_POD_NAME -n openvsx -- /bin/bash -c "rm -rf /tmp/extensions/__<publisher>__/__<extension>__"
+----
+
+.Verification
+
+* Refresh your OpenVSX registry and verify that the extension no longer appears in the gallery.

--- a/modules/administration-guide/partials/proc_deleting-extension-from-postgresql-database.adoc
+++ b/modules/administration-guide/partials/proc_deleting-extension-from-postgresql-database.adoc
@@ -37,7 +37,7 @@ At the `postgres=#` prompt, connect to the database:
 You are now connected to the `openvsx` database as the `postgres` user.
 . Find the namespace ID and extension ID:
 +
-Identify the namespace ID. Replace `__<namespace_name>__` with the actual namespace:
+Identify the `namespace` ID. Replace `__<namespace_name>__` with the actual `namespace`:
 +
 [source,sql,subs="+quotes",options="nowrap"]
 ----

--- a/modules/administration-guide/partials/proc_deleting-extension-from-postgresql-database.adoc
+++ b/modules/administration-guide/partials/proc_deleting-extension-from-postgresql-database.adoc
@@ -2,11 +2,11 @@
 [id="proc_deleting-extension-from-postgresql-database_{context}"]
 == Deleting an extension from the PostgreSQL database directly
 [role="_abstract"]
-Remove extension records and related data directly in the PostgreSQL database when the administrator API is not available or when you must clean up specific data. If the extension uses local storage, you must also remove its files from the OpenVSX server pod.
+Remove extension records and related data directly in the PostgreSQL database when the administrator API is not available or when you must clean up specific data. If the extension uses local storage, you must also remove its files from the Open VSX server pod.
 
 .Prerequisites
 
-* You have access to the OpenShift cluster where OpenVSX is deployed (namespace `openvsx`).
+* You have access to the OpenShift cluster where Open VSX is deployed (namespace `openvsx`).
 * You know the namespace name and extension name that you want to delete.
 
 .Procedure
@@ -37,7 +37,7 @@ At the `postgres=#` prompt, connect to the database:
 You are now connected to the `openvsx` database as the `postgres` user.
 . Find the namespace ID and extension ID:
 +
-Identify the `namespace` ID. Replace `__<namespace_name>__` with the actual `namespace`:
+Identify the namespace ID. Replace `__<namespace_name>__` with the actual namespace:
 +
 [source,sql,subs="+quotes",options="nowrap"]
 ----
@@ -68,7 +68,7 @@ Preview the file resources:
 SELECT id, name, type, storage_type FROM file_resource WHERE extension_id = __<extension_id>__ ORDER BY id;
 ----
 +
-If the `storage_type` value is `local`, you must also remove the extension files from the file system on the OpenVSX server pod.
+If the `storage_type` value is `local`, you must also remove the extension files from the file system on the Open VSX server pod.
 . Delete the extension from the database:
 +
 Run the following commands in a single transaction. Replace `__<extension_id>__` with the extension ID from step 2.
@@ -93,9 +93,9 @@ Run these commands in order within one transaction. Do not skip the `COMMIT` com
 ====
 . If applicable, remove the extension files from local storage:
 +
-If the extension used local storage, remove its files from the OpenVSX server pod.
+If the extension used local storage, remove its files from the Open VSX server pod.
 +
-Get the OpenVSX server pod name:
+Get the Open VSX server pod name:
 +
 [source,bash,options="nowrap"]
 ----
@@ -111,4 +111,4 @@ oc exec -it $OPENVSX_POD_NAME -n openvsx -- /bin/bash -c "rm -rf /tmp/extensions
 
 .Verification
 
-* Refresh your OpenVSX registry and verify that the extension no longer appears in the gallery.
+* Refresh your Open VSX registry and verify that the extension no longer appears in the gallery.

--- a/modules/administration-guide/partials/proc_deleting-extension-from-postgresql-database.adoc
+++ b/modules/administration-guide/partials/proc_deleting-extension-from-postgresql-database.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="proc_deleting-extension-from-postgresql-database_{context}"]
-== Deleting an extension from the PostgreSQL database directly
+= Deleting an extension from the PostgreSQL database directly
 [role="_abstract"]
 Remove extension records and related data directly in the PostgreSQL database when the administrator API is not available or when you must clean up specific data. If the extension uses local storage, you must also remove its files from the Open VSX server pod.
 

--- a/modules/administration-guide/partials/proc_deleting-extension-using-openvsx-admin-api.adoc
+++ b/modules/administration-guide/partials/proc_deleting-extension-using-openvsx-admin-api.adoc
@@ -1,0 +1,75 @@
+:_mod-docs-content-type: PROCEDURE
+[id="proc_deleting-extension-using-openvsx-admin-api_{context}"]
+== Deleting an extension by using the OpenVSX administrator API
+[role="_abstract"]
+Delete an extension from your private OpenVSX registry by calling the administrator API with an administrator user and a personal access token (PAT).
+
+.Prerequisites
+
+* You have access to the OpenShift cluster where OpenVSX is deployed (namespace `openvsx`).
+
+.Procedure
+
+. Add the OpenVSX administrator user and PAT to the database:
++
+Get the PostgreSQL pod name:
++
+[source,bash,options="nowrap"]
+----
+export POSTGRESQL_POD_NAME=$(oc get pods -n openvsx \
+   -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep '^postgresql' | head -n 1)
+----
++
+Add the administrator user:
++
+[source,bash,options="nowrap"]
+----
+oc exec -n openvsx "$POSTGRESQL_POD_NAME" -- bash -c \
+   "psql -d openvsx -c \"INSERT INTO user_data (id, login_name, role) VALUES (1002, 'openvsx-admin', 'admin');\""
+----
++
+Add the administrator PAT:
++
+[source,bash,options="nowrap"]
+----
+oc exec -n openvsx "$POSTGRESQL_POD_NAME" -- bash -c \
+   "psql -d openvsx -c \"INSERT INTO personal_access_token (id, user_data, value, active, created_timestamp, accessed_timestamp, description) VALUES (1002, 1002, 'openvsx_admin_token', true, current_timestamp, current_timestamp, 'Admin API Token');\""
+----
++
+[NOTE]
+====
+Use a strong, unique value instead of `openvsx_admin_token` for production. The system passes the PAT in the API request URL.
+====
+. To delete an extension and all of its published versions, use the `curl` command with the following endpoint:
++
+`POST /admin/api/extension/__<publisher>__/__<extension>__/delete`
++
+[source,bash,subs="+quotes",options="nowrap"]
+----
+curl -X POST \
+  "https://__<your-openvsx-server-url>__/admin/api/extension/__<publisher>__/__<extension>__/delete?token=__<your-admin-pat>__"
+----
++
+Replace the following placeholders:
++
+* `__<your-openvsx-server-url>__`: The URL of your OpenVSX registry.
+* `__<publisher>__`: The namespace of the extension (for example, `redhat`).
+* `__<extension>__`: The name of the extension (for example, `vscode-yaml`).
+* `__<your-admin-pat>__`: The PAT you created for the `openvsx-admin` user.
+. To delete a specific version of an extension, send a JSON body in the same `POST` request:
++
+To remove only certain versions and target platforms instead of the entire extension, include an array that specifies a `version` and `targetPlatform` (for example, `linux-x64`, `darwin-arm64`, or `win32-x64`).
++
+[source,bash,subs="+quotes",options="nowrap"]
+----
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '[{"version": "1.3.0", "targetPlatform": "linux-x64"}]' \
+  "https://__<your-openvsx-server-url>__/admin/api/extension/__<publisher>__/__<extension>__/delete?token=__<your-admin-pat>__"
+----
++
+Use the same placeholders that are listed in the previous step. You can list multiple version and platform pairs in the JSON array to delete several targets in one request.
+
+.Verification
+
+* Refresh your OpenVSX registry and verify that the extension no longer appears in the gallery.

--- a/modules/administration-guide/partials/proc_deleting-extension-using-openvsx-admin-api.adoc
+++ b/modules/administration-guide/partials/proc_deleting-extension-using-openvsx-admin-api.adoc
@@ -1,16 +1,16 @@
 :_mod-docs-content-type: PROCEDURE
 [id="proc_deleting-extension-using-openvsx-admin-api_{context}"]
-== Deleting an extension by using the OpenVSX administrator API
+== Deleting an extension by using the Open VSX administrator API
 [role="_abstract"]
-Delete an extension from your private OpenVSX registry by calling the administrator API with an administrator user and a personal access token (PAT).
+Delete an extension from your private Open VSX registry by calling the administrator API with an administrator user and a personal access token (PAT).
 
 .Prerequisites
 
-* You have access to the OpenShift cluster where OpenVSX is deployed (namespace `openvsx`).
+* You have access to the OpenShift cluster where Open VSX is deployed (namespace `openvsx`).
 
 .Procedure
 
-. Add the OpenVSX administrator user and PAT to the database:
+. Add the Open VSX administrator user and PAT to the database:
 +
 Get the PostgreSQL pod name:
 +
@@ -52,7 +52,7 @@ curl -X POST \
 +
 Replace the following placeholders:
 +
-* `__<your-openvsx-server-url>__`: The URL of your OpenVSX registry.
+* `__<your-openvsx-server-url>__`: The URL of your Open VSX registry.
 * `__<publisher>__`: The namespace of the extension (for example, `redhat`).
 * `__<extension>__`: The name of the extension (for example, `vscode-yaml`).
 * `__<your-admin-pat>__`: The PAT you created for the `openvsx-admin` user.
@@ -72,4 +72,4 @@ Use the same placeholders that are listed in the previous step. You can list mul
 
 .Verification
 
-* Refresh your OpenVSX registry and verify that the extension no longer appears in the gallery.
+* Refresh your Open VSX registry and verify that the extension no longer appears in the gallery.

--- a/modules/administration-guide/partials/proc_deleting-extension-using-openvsx-admin-api.adoc
+++ b/modules/administration-guide/partials/proc_deleting-extension-using-openvsx-admin-api.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="proc_deleting-extension-using-openvsx-admin-api_{context}"]
-== Deleting an extension by using the Open VSX administrator API
+= Deleting an extension by using the Open VSX administrator API
 [role="_abstract"]
 Delete an extension from your private Open VSX registry by calling the administrator API with an administrator user and a personal access token (PAT).
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Adds an additional section to the Running the Open VSX On-Premises documentation describing how to remove extensions from the Open VSX registry.

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/CRW-10109

## Specify the version of the product this pull request applies to
Dev Spaces 3.27.0

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
