### PR TITLE
Add note about default DWO installation namespace

### DIFF
--- a/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
@@ -29,7 +29,7 @@ config:
       schedule: '0 */4 * * *' # cron expression with backup frequency
     imagePullPolicy: Always
 ----
-<1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} operator overview].
+<1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
 
 **Note:** The `path` field must contain the URL to your OpenShift integrated registry given by the cluster.
 

--- a/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
@@ -29,7 +29,7 @@ config:
       schedule: '0 */4 * * *' # cron expression with backup frequency
     imagePullPolicy: Always
 ----
-<1> The default {devworkspace} Operator installation namespace is `openshift-operators`. See xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} Operator overview].
+<1> For OpenShift, the default {devworkspace} Operator installation namespace is `openshift-operators`. See xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} Operator overview].
 
 **Note:** The `path` field must contain the URL to your OpenShift integrated registry given by the cluster.
 

--- a/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
@@ -29,7 +29,7 @@ config:
       schedule: '0 */4 * * *' # cron expression with backup frequency
     imagePullPolicy: Always
 ----
-<1> For OpenShift, the default {devworkspace} Operator installation namespace is `openshift-operators`. See xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} Operator overview].
+<1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} operator overview].
 
 **Note:** The `path` field must contain the URL to your OpenShift integrated registry given by the cluster.
 

--- a/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
@@ -17,7 +17,7 @@ apiVersion: controller.devfile.io/v1alpha1
 kind: DevWorkspaceOperatorConfig
 metadata:
   name: devworkspace-operator-config
-  namespace: $OPERATOR_INSTALL_NAMESPACE
+  namespace: $OPERATOR_INSTALL_NAMESPACE <1>
 config:
   routing:
     defaultRoutingClass: basic
@@ -29,6 +29,7 @@ config:
       schedule: '0 */4 * * *' # cron expression with backup frequency
     imagePullPolicy: Always
 ----
+<1> The default {devworkspace} Operator installation namespace is `openshift-operators`. See xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} Operator overview].
 
 **Note:** The `path` field must contain the URL to your OpenShift integrated registry given by the cluster.
 

--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -31,7 +31,7 @@ config:
       schedule: '0 */4 * * *'
     imagePullPolicy: Always
 ----
-<1> For OpenShift the default {devworkspace} Operator installation namespace is `openshift-operators`. See xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} Operator overview].
+<1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} operator overview].
 
 The `authSecret` must point to a real {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` containing credentials to access the registry.
 

--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -31,7 +31,7 @@ config:
       schedule: '0 */4 * * *'
     imagePullPolicy: Always
 ----
-<1> The default {devworkspace} Operator installation namespace is `openshift-operators`. See xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} Operator overview].
+<1> For OpenShift the default {devworkspace} Operator installation namespace is `openshift-operators`. See xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} Operator overview].
 
 The `authSecret` must point to a real {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` containing credentials to access the registry.
 

--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -18,7 +18,7 @@ kind: DevWorkspaceOperatorConfig
 apiVersion: controller.devfile.io/v1alpha1
 metadata:
   name: devworkspace-operator-config
-  namespace: $OPERATOR_INSTALL_NAMESPACE
+  namespace: $OPERATOR_INSTALL_NAMESPACE <1>
 config:
   routing:
     defaultRoutingClass: basic
@@ -31,6 +31,7 @@ config:
       schedule: '0 */4 * * *'
     imagePullPolicy: Always
 ----
+<1> The default {devworkspace} Operator installation namespace is `openshift-operators`. See xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} Operator overview].
 
 The `authSecret` must point to a real {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` containing credentials to access the registry.
 

--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -31,7 +31,7 @@ config:
       schedule: '0 */4 * * *'
     imagePullPolicy: Always
 ----
-<1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc#devworkspace-operator[{devworkspace} operator overview].
+<1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
 
 The `authSecret` must point to a real {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` containing credentials to access the registry.
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Adds a note mentioning the default DWO install namespace:
<img width="1258" height="770" alt="image" src="https://github.com/user-attachments/assets/1a6aeb5c-5b62-44bb-8def-c02f51cd9004" />


## What issues does this pull request fix or reference?
N/A

## Specify the version of the product this pull request applies to
DS 3.27

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
