### PR TITLE
fix: Backport fix link format in backup doc to 7.115.x

### DIFF
--- a/modules/administration-guide/pages/devworkspace-backup.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup.adoc
@@ -9,7 +9,7 @@
 
 The {devworkspace} backup job provides periodic backups of {devworkspace} data to a specified location.
 After you enable and configure the job, it runs at defined intervals to create backups of {devworkspace} data.
-The backup controller requires an OCI-compliant registry, such as the e.g.,https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/registry/registry-overview#registry-integrated-openshift-registry_registry-overview[OpenShift build-in registry]
+The backup controller requires an OCI-compliant registry, such as the e.g., link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/registry/registry-overview#registry-integrated-openshift-registry_registry-overview[Red Hat OpenShift built-in registry]
 integrated registry or link:https://quay.io[Quay.io], to store backup archives as image artifacts.
 
 The backup makes a snapshot of *stopped* Workspace PVCs and stores them as tar.gz archives in the specified OCI registry.


### PR DESCRIPTION
## Summary
- Backport of PR #3033 to 7.115.x
- Fixes link format in backup doc
- Adds "Red Hat" to the OpenShift name