### PR TITLE
fix: Pin @antora/pdf-extension to match assembler version

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -82,7 +82,7 @@ RUN set -x \
     && npm install --no-save --global @antora/cli \
     && npm install --no-save --global @antora/collector-extension \
     && npm install --no-save --global @antora/lunr-extension \
-    && npm install --no-save --global @antora/pdf-extension \
+    && npm install --no-save --global @antora/pdf-extension@1.0.0-beta.14 \
     && npm install --no-save --global @antora/site-generator \
     && npm install --no-save --global asciidoctor-emoji \
     && npm install --no-save --global asciidoctor-kroki \


### PR DESCRIPTION
## Summary
- Pins `@antora/pdf-extension` to `1.0.0-beta.14` to match the already-pinned `@antora/assembler@1.0.0-beta.14`
- Both packages are released in lockstep and must be at the same version
- The unpinned pdf-extension was pulling latest (`beta.19`) which expects an API (`logCommand`) not present in assembler `beta.14`

## What issues does this fix?
Fixes container build failures on all PRs with:
```
FATAL (antora): Cannot destructure property 'logCommand' of 'undefined' as it is undefined.
    at GeneratorContext.convert (@antora/pdf-extension/lib/converter.js:9:65)
    at @antora/assembler/lib/assemble-content.js:80:16
```