### PR TITLE
Backport #3041: improve removing-extensions page (7.113.x)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -82,7 +82,7 @@ RUN set -x \
     && npm install --no-save --global @antora/cli \
     && npm install --no-save --global @antora/collector-extension \
     && npm install --no-save --global @antora/lunr-extension \
-    && npm install --no-save --global @antora/pdf-extension \
+    && npm install --no-save --global @antora/pdf-extension@1.0.0-beta.14 \
     && npm install --no-save --global @antora/site-generator \
     && npm install --no-save --global asciidoctor-emoji \
     && npm install --no-save --global asciidoctor-kroki \

--- a/modules/administration-guide/partials/proc_adding-or-removing-extensions-in-a-workspace.adoc
+++ b/modules/administration-guide/partials/proc_adding-or-removing-extensions-in-a-workspace.adoc
@@ -21,8 +21,6 @@ The embedded plugin registry is deprecated. Setting up an internal, on-premises 
 
 .Procedure
 
-. Open a terminal in your workspace.
-
 . Identify the publisher and extension name for each extension you want to add:
 .. Find the extension on the link:https://open-vsx.org/[Open VSX registry website].
 .. Copy the URL of the extension's listing page.
@@ -40,7 +38,7 @@ If the extension is only available from link:https://marketplace.visualstudio.co
 If the extension publisher is unavailable or unwilling to publish the extension to link:https://open-vsx.org[open-vsx.org], and if there is no Open VSX equivalent of the extension, consider link:https://github.com/open-vsx/publish-extensions/issues[reporting an issue] to the Open VSX team.
 ====
 
-. Open the `openvsx-sync.json` file in the repository.
+. Open the `openvsx-sync.json` file in the workspace.
 
 . Add or remove extensions using the following JSON syntax:
 +

--- a/modules/administration-guide/partials/proc_adding-or-removing-extensions-on-linux.adoc
+++ b/modules/administration-guide/partials/proc_adding-or-removing-extensions-on-linux.adoc
@@ -18,7 +18,7 @@ You can build and publish a custom plugin registry using the Linux command line.
 
 . Clone the plugin registry repository:
 +
-[source,bash]
+[source,bash,subs="+attributes"]
 ----
 $ git clone {plugin-registry-repo-url}.git
 ----


### PR DESCRIPTION
Backport of #3041 to 7.113.x for downstream Dev Spaces 3.26.

Changes:
- Remove unnecessary "Open a terminal" step from workspace procedure
- Change "in the repository" → "in the workspace" for clarity
- Add `subs="+attributes"` to source block so `{plugin-registry-repo-url}` resolves

Cherry-picked from merge commit fcde66e2.