### PR TITLE
Update backup config docs to mention backoffLimit

### DIFF
--- a/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
@@ -26,10 +26,13 @@ config:
       enable: true
       registry:
         path: default-route-openshift-image-registry.apps.{cluster ID}.openshiftapps.com
+      oras:
+        extraArgs: '--insecure' <2>
       schedule: '0 */4 * * *' # cron expression with backup frequency
     imagePullPolicy: Always
 ----
 <1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
+<2> The `--insecure` flag can be required depending on the integrated registry's routing configuration.
 
 **Note:** The `path` field must contain the URL to your OpenShift integrated registry given by the cluster.
 

--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -34,17 +34,18 @@ config:
 <1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
 
 The `authSecret` must point to a real {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` containing credentials to access the registry.
+The secret should be created in the installation {namespace} for the {devworkspace} operator.
 
 To create one, you can use the following command:
 
 [source,shell,subs="+attributes,+quotes"]
 ----
-kubectl create secret docker-registry my-secret --from-file=config.json -n devworkspace-controller
+kubectl create secret docker-registry my-secret --from-file=config.json
 ----
 
 The secret must contain a label `controller.devfile.io/watch-secret=true` to be recognized by the {devworkspace} Operator.
 
 [source,shell,subs="+attributes,+quotes"]
 ----
-kubectl label secret my-secret controller.devfile.io/watch-secret=true -n devworkspace-controller
+kubectl label secret my-secret controller.devfile.io/watch-secret=true
 ----

--- a/modules/administration-guide/pages/devworkspace-backup.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup.adoc
@@ -22,6 +22,7 @@ You can configure the backup by using the `DevWorkspaceOperatorConfig` resource 
 
 * `enable`: Set to `true` to enable the backup job or `false` to disable it. The default value is `false`.
 * `schedule`: A Cron expression that defines the backup frequency. The default value is `"0 1 * * *"`.
+* `backoffLimit`: The value of the backup job's `spec.backoffLimit`, which specifies the number of retries before marking this job failed. The default value for the backups jobs is `1`.
 * `registry.path`: The base registry location for backup archives.
 +
 The value for `registry.path` is the first segment of the final location. The full path is assembled dynamically by using the workspace name and the `:latest` tag in the following pattern:

--- a/modules/end-user-guide/pages/proc-restoring-a-workspace-from-backup.adoc
+++ b/modules/end-user-guide/pages/proc-restoring-a-workspace-from-backup.adoc
@@ -7,7 +7,7 @@ Recover uncommitted changes or recreate a workspace environment by restoring fro
 .Prerequisites
 * Backups are enabled for your cluster.
 * You know which default registry or external registry backup image to use.
-. You have identified a default registry or external registry backup image to use.
+* You have identified a default registry or external registry backup image to use.
 
 .Procedure
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Updates the backup cron job config docs to mention `backoffLimit`.

## What issues does this pull request fix or reference?
N/A

## Specify the version of the product this pull request applies to
DS 3.27.

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
