### PR TITLE
docs: Add article for configuring direct namespace creation on OpenShift

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -41,6 +41,7 @@
 *** xref:configuring-workspace-target-namespace.adoc[]
 *** xref:provisioning-namespaces-in-advance.adoc[]
 *** xref:configuring-a-user-namespace.adoc[]
+*** xref:configuring-direct-namespace-creation-on-openshift.adoc[]
 ** xref:configuring-server-components.adoc[]
 *** xref:mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container.adoc[]
 *** xref:advanced-configuration-options-for-the-che-server-component.adoc[]

--- a/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
+++ b/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
@@ -1,0 +1,52 @@
+:_content-type: PROCEDURE
+:description: Configuring {prod-short} to create standard {orch-namespace}s directly on OpenShift instead of using the ProjectRequest API
+:keywords: administration-guide, configuring, namespace, openshift, project, direct
+:navtitle: Configuring direct namespace creation on OpenShift
+:page-aliases:
+
+[id="configuring-direct-namespace-creation-on-openshift"]
+= Configuring direct namespace creation on OpenShift
+
+By default, on OpenShift, {prod-short} uses the ProjectRequest API to create user namespaces. This triggers any cluster-specific Project Templates configured by the OpenShift administrator.
+
+If you want {prod-short} to create standard {orch-namespace}s directly, bypassing the ProjectRequest API and Project Templates, you can enable direct namespace creation. This is useful when Project Templates are not needed or when you want to avoid the overhead of the ProjectRequest workflow.
+
+NOTE: This setting applies only to OpenShift clusters and has no effect on {orch-name}.
+
+.Prerequisites
+
+* An active `{orch-cli}` session with administrative permissions to the OpenShift cluster. See {orch-cli-link}.
+
+* An existing {prod} installation.
+
+.Procedure
+
+. Set the `createNamespaceDirectly` field to `true` in the `spec.devEnvironments.defaultNamespace` section of the CheCluster custom resource.
++
+====
+[source,yaml,subs="+quotes,+attributes"]
+----
+kind: CheCluster
+apiVersion: org.eclipse.che/v2
+spec:
+  devEnvironments:
+    defaultNamespace:
+      createNamespaceDirectly: true
+----
+====
+
+.Verification
+
+* Start a new workspace and verify that the user {orch-namespace} is created as a standard {orch-namespace} rather than an OpenShift Project.
++
+[subs="+attributes,+quotes"]
+----
+$ {orch-cli} get namespace __<user-namespace>__ -o jsonpath='{.metadata.labels}'
+----
++
+A directly created {orch-namespace} will not contain OpenShift Project-specific labels.
+
+.Additional resources
+
+* xref:configuring-namespace-provisioning.adoc[]
+* xref:configuring-workspace-target-namespace.adoc[]


### PR DESCRIPTION
## Summary
- Adds a new procedure article documenting the `createNamespaceDirectly` CheCluster CR field introduced in [che-operator#2104](https://github.com/eclipse-che/che-operator/pull/2104)
- This field allows administrators to create standard Kubernetes Namespaces directly on OpenShift instead of using the ProjectRequest API
- Updates the administration guide navigation to include the new article under "Configuring namespace provisioning"

## Test plan
- [ ] Build docs locally and verify the new page renders correctly
- [ ] Verify navigation link appears under "Configuring namespace provisioning"
- [ ] Review article content for accuracy against the PR changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)