### PR TITLE
procedures: configuring direct namespace creation on OpenShift

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -41,6 +41,7 @@
 *** xref:configuring-workspace-target-namespace.adoc[]
 *** xref:provisioning-namespaces-in-advance.adoc[]
 *** xref:configuring-a-user-namespace.adoc[]
+*** xref:configuring-direct-namespace-creation-on-openshift.adoc[]
 ** xref:configuring-server-components.adoc[]
 *** xref:mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container.adoc[]
 *** xref:advanced-configuration-options-for-the-che-server-component.adoc[]

--- a/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
+++ b/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
@@ -1,0 +1,39 @@
+:_content-type: PROCEDURE
+:description: Configuring {prod-short} to create standard {orch-namespace}s instead of OpenShift projects
+:keywords: administration guide, configuring, namespace, openshift, project
+:navtitle: Configuring direct {orch-namespace} creation on OpenShift
+:page-aliases:
+
+[id="configuring-direct-namespace-creation-on-openshift"]
+= Configuring direct {orch-namespace} creation on OpenShift
+
+By default, on {ocp} clusters, {prod-short} uses the OpenShift ProjectRequest API to create user {orch-namespace}s.
+The ProjectRequest API triggers any cluster-specific Project Templates configured by the cluster administrator.
+
+If you want {prod-short} to create standard {kubernetes} {orch-namespace}s directly, bypassing the ProjectRequest API and its associated Project Templates, you can enable the `createNamespaceDirectly` option.
+
+.Prerequisites
+
+* An active `{prod-cli}` session with administrative permissions to the destination {ocp} cluster. See xref:installing-the-chectl-management-tool.adoc[].
+
+.Procedure
+
+* Configure the `CheCluster` Custom Resource. See xref:using-the-cli-to-configure-the-checluster-custom-resource.adoc[].
++
+[source,yaml,subs="+quotes,+attributes"]
+----
+spec:
+  devEnvironments:
+    defaultNamespace:
+      createNamespaceDirectly: true
+----
+
+.Verification
+
+* Start a workspace and verify that {prod-short} creates a standard {kubernetes} {orch-namespace} instead of an OpenShift project.
+
+.Additional resources
+
+* xref:configuring-namespace-provisioning.adoc[]
+
+* xref:using-the-cli-to-configure-the-checluster-custom-resource.adoc[]

--- a/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
+++ b/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
@@ -1,11 +1,11 @@
 :_content-type: PROCEDURE
-:description: Configuring {prod-short} to create standard {orch-namespace}s instead of OpenShift projects
+:description: Configuring {prod-short} to create standard {orch-namespace}s instead of {ocp} projects
 :keywords: administration guide, configuring, namespace, openshift, project
-:navtitle: Configuring direct {orch-namespace} creation on OpenShift
+:navtitle: Configuring direct {orch-namespace} creation on {ocp}
 :page-aliases:
 
 [id="configuring-direct-namespace-creation-on-openshift"]
-= Configuring direct {orch-namespace} creation on OpenShift
+= Configuring direct {orch-namespace} creation on {ocp}
 
 By default, on {ocp} clusters, {prod-short} uses the OpenShift ProjectRequest API to create user {orch-namespace}s.
 The ProjectRequest API triggers any cluster-specific Project Templates configured by the cluster administrator.
@@ -30,7 +30,7 @@ spec:
 
 .Verification
 
-* Start a workspace and verify that {prod-short} creates a standard {kubernetes} {orch-namespace} instead of an OpenShift project.
+* Start a workspace and verify that {prod-short} creates a standard {kubernetes} {orch-namespace} instead of an {ocp} project.
 
 .Additional resources
 

--- a/modules/administration-guide/pages/configuring-namespace-provisioning.adoc
+++ b/modules/administration-guide/pages/configuring-namespace-provisioning.adoc
@@ -16,3 +16,4 @@ You can modify {prod-short} behavior by:
 * xref:configuring-workspace-target-namespace.adoc[]
 * xref:provisioning-namespaces-in-advance.adoc[]
 * xref:configuring-a-user-namespace.adoc[]
+* xref:configuring-direct-namespace-creation-on-openshift.adoc[]


### PR DESCRIPTION
## What does this pull request change?

Adds a new procedure article documenting the `createNamespaceDirectly` option in the CheCluster Custom Resource. This option allows administrators to configure Che to create standard Kubernetes Namespaces directly on OpenShift clusters, bypassing the ProjectRequest API and its associated Project Templates.

Source PR: https://github.com/eclipse-che/che-operator/pull/2104

## What issues does this pull request fix or reference?

https://github.com/eclipse-che/che-operator/pull/2104
https://issues.redhat.com/browse/CRW-9951

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.