### PR TITLE
procedures: document direct namespace creation on OpenShift

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -41,6 +41,7 @@
 *** xref:configuring-workspace-target-namespace.adoc[]
 *** xref:provisioning-namespaces-in-advance.adoc[]
 *** xref:configuring-a-user-namespace.adoc[]
+*** xref:configuring-direct-namespace-creation-on-openshift.adoc[]
 ** xref:configuring-server-components.adoc[]
 *** xref:mounting-a-secret-as-a-file-or-an-environment-variable-into-a-container.adoc[]
 *** xref:advanced-configuration-options-for-the-che-server-component.adoc[]

--- a/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
+++ b/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
@@ -7,9 +7,9 @@
 [id="configuring-direct-namespace-creation-on-openshift"]
 = Configuring direct namespace creation on OpenShift
 
-By default, on {ocp} clusters, {prod-short} uses the ProjectRequest API to create user namespaces. This triggers cluster-specific link:https://docs.openshift.com/container-platform/latest/applications/projects/configuring-project-creation.html[Project Templates], which may apply additional resources or policies to newly created projects.
+By default, on {ocp} clusters, {prod-short} uses the ProjectRequest API to create user namespaces. This triggers cluster-specific link:https://docs.openshift.com/container-platform/latest/applications/projects/configuring-project-creation.html[Project Templates], which can apply additional resources or policies to newly created projects.
 
-In some environments, you may want to bypass Project Templates and create standard {kubernetes} Namespaces directly. For example, this is useful when Project Templates introduce unwanted side effects or when you need consistent namespace provisioning behavior across {kubernetes} and {ocp} clusters.
+In some environments, you can bypass Project Templates and create standard {kubernetes} Namespaces directly. For example, this is useful when Project Templates introduce unwanted side effects or when you need consistent {orch-namespace} provisioning behavior across {kubernetes} and {ocp} clusters.
 
 .Prerequisites
 

--- a/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
+++ b/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
@@ -1,0 +1,44 @@
+:_content-type: PROCEDURE
+:description: Configuring {prod-short} to create standard {kubernetes} Namespaces directly on {ocp} instead of using the ProjectRequest API
+:keywords: administration guide, configuring, namespace, openshift, project, projectrequest
+:navtitle: Configuring direct namespace creation on OpenShift
+:page-aliases:
+
+[id="configuring-direct-namespace-creation-on-openshift"]
+= Configuring direct namespace creation on OpenShift
+
+By default, on {ocp} clusters, {prod-short} uses the ProjectRequest API to create user namespaces. This triggers cluster-specific link:https://docs.openshift.com/container-platform/latest/applications/projects/configuring-project-creation.html[Project Templates], which may apply additional resources or policies to newly created projects.
+
+In some environments, you may want to bypass Project Templates and create standard {kubernetes} Namespaces directly. For example, this is useful when Project Templates introduce unwanted side effects or when you need consistent namespace provisioning behavior across {kubernetes} and {ocp} clusters.
+
+.Prerequisites
+
+* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
+
+.Procedure
+
+. Set the `createNamespaceDirectly` field to `true`:
++
+[source,shell,subs="+quotes,+attributes,+macros"]
+----
+{orch-cli} patch checluster {prod-checluster} \
+  --namespace {prod-namespace} \
+  --type merge \
+  --patch '{
+    "spec": {
+      "devEnvironments": {
+        "defaultNamespace": {
+          "createNamespaceDirectly": true
+        }
+      }
+    }
+  }'
+----
+
+NOTE: This setting applies only to {ocp} clusters. On {kubernetes} clusters, Namespaces are always created directly regardless of this setting.
+
+.Additional resources
+
+* xref:configuring-namespace-provisioning.adoc[]
+* xref:configuring-a-user-namespace.adoc[]
+* link:https://docs.openshift.com/container-platform/latest/applications/projects/configuring-project-creation.html[Configuring OpenShift project creation]

--- a/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
+++ b/modules/administration-guide/pages/configuring-direct-namespace-creation-on-openshift.adoc
@@ -7,9 +7,9 @@
 [id="configuring-direct-namespace-creation-on-openshift"]
 = Configuring direct namespace creation on OpenShift
 
-By default, on {ocp} clusters, {prod-short} uses the ProjectRequest API to create user namespaces. This triggers cluster-specific link:https://docs.openshift.com/container-platform/latest/applications/projects/configuring-project-creation.html[Project Templates], which can apply additional resources or policies to newly created projects.
+By default, on {ocp} clusters, {prod-short} uses the ProjectRequest API to create projects. This triggers cluster-specific link:https://docs.openshift.com/container-platform/latest/applications/projects/configuring-project-creation.html[Project Templates], which can apply additional resources or policies.
 
-In some environments, you can bypass Project Templates and create standard {kubernetes} Namespaces directly. For example, this is useful when Project Templates introduce unwanted side effects or when you need consistent {orch-namespace} provisioning behavior across {kubernetes} and {ocp} clusters.
+On {ocp}, you can bypass Project Templates and create standard {kubernetes} Namespaces directly. For example, this is useful when Project Templates introduce unwanted side effects.
 
 .Prerequisites
 


### PR DESCRIPTION
## What does this pull request change?

Adds a new procedure documenting the `createNamespaceDirectly` CheCluster CR field introduced in [eclipse-che/che-operator#2104](https://github.com/eclipse-che/che-operator/pull/2104). This field allows administrators to configure the operator to create standard Kubernetes Namespaces directly on OpenShift instead of using the ProjectRequest API.

## What issues does this pull request fix or reference?

https://github.com/eclipse-che/che-operator/pull/2104

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.