### PR TITLE
Update backup registry secret name

### DIFF
--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -49,3 +49,8 @@ The secret must contain a label `controller.devfile.io/watch-secret=true` to be 
 ----
 kubectl label secret devworkspace-backup-registry-auth controller.devfile.io/watch-secret=true
 ----
+
+[WARNING]
+====
+The {devworkspace} Operator copies the `devworkspace-backup-registry-auth` secret to each {devworkspace} {namespace} so that backups from user workspaces can be pushed to the registry. If you do not want that secret copied automatically, create a `devworkspace-backup-registry-auth` secret with user-specific credentials in each {devworkspace} {namespace} instead.
+====

--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -40,7 +40,7 @@ To create one, you can use the following command:
 
 [source,shell,subs="+attributes,+quotes"]
 ----
-kubectl create secret docker-registry devworkspace-backup-registry-auth --from-file=config.json
+{orch-cli} create secret docker-registry devworkspace-backup-registry-auth --from-file=config.json
 ----
 
 The secret must contain a label `controller.devfile.io/watch-secret=true` to be recognized by the {devworkspace} Operator.

--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -26,26 +26,26 @@ config:
     backupCronJob:
       enable: true
       registry:
-        authSecret: my-secret
+        authSecret: devworkspace-backup-registry-auth
         path: quay.io/my-company-org
       schedule: '0 */4 * * *'
     imagePullPolicy: Always
 ----
 <1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
 
-The `authSecret` must point to a real {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` containing credentials to access the registry.
+The `authSecret` must be named `devworkspace-backup-registry-auth` and point to a real {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` containing credentials to access the registry.
 The secret should be created in the installation {namespace} for the {devworkspace} operator.
 
 To create one, you can use the following command:
 
 [source,shell,subs="+attributes,+quotes"]
 ----
-kubectl create secret docker-registry my-secret --from-file=config.json
+kubectl create secret docker-registry devworkspace-backup-registry-auth --from-file=config.json
 ----
 
 The secret must contain a label `controller.devfile.io/watch-secret=true` to be recognized by the {devworkspace} Operator.
 
 [source,shell,subs="+attributes,+quotes"]
 ----
-kubectl label secret my-secret controller.devfile.io/watch-secret=true
+kubectl label secret devworkspace-backup-registry-auth controller.devfile.io/watch-secret=true
 ----

--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -33,7 +33,7 @@ config:
 ----
 <1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
 
-The `authSecret` must be named `devworkspace-backup-registry-auth` and point to a real {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` containing credentials to access the registry.
+The `authSecret` must be named `devworkspace-backup-registry-auth`. It must reference a {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` that contains credentials to access the registry.
 The secret should be created in the installation {namespace} for the {devworkspace} operator.
 
 To create one, you can use the following command:


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
A bug was discovered when trying to restore from a private quay.io repo, where the pull secret was not accessible to the restore init container. 

A workaround is to have the pull secret be named `devworkspace-backup-registry-auth`.

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to
DS 3.27.

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
