### PR TITLE
fix: Pin @antora/pdf-extension to 1.0.0-beta.14

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -82,7 +82,7 @@ RUN set -x \
     && npm install --no-save --global @antora/cli \
     && npm install --no-save --global @antora/collector-extension \
     && npm install --no-save --global @antora/lunr-extension \
-    && npm install --no-save --global @antora/pdf-extension \
+    && npm install --no-save --global @antora/pdf-extension@1.0.0-beta.14 \
     && npm install --no-save --global @antora/site-generator \
     && npm install --no-save --global asciidoctor-emoji \
     && npm install --no-save --global asciidoctor-kroki \


### PR DESCRIPTION
## What does this pull request change?

Pins `@antora/pdf-extension` to `1.0.0-beta.14` in the `Containerfile`, matching the version pin already present on the `main` branch.

The "Build and verify container" CI job on PRs targeting `7.115.x` (e.g. #3053) fails with:

```
FATAL (antora): Cannot destructure property 'logCommand' of 'undefined' as it is undefined.
    at GeneratorContext.convert (@antora/pdf-extension/lib/converter.js:9:65)
```

**Root cause:** `@antora/assembler` is pinned to `1.0.0-beta.14`, but `@antora/pdf-extension` has no version pin and installs the latest version, which is incompatible. The `main` branch already pins both packages to the same version.

## What issues does this pull request fix or reference?

Unblocks #3053.

## Specify the version of the product this pull request applies to

DS 3.27 (7.115.x branch).

## Pull Request checklist

- [x] No content changes — build infrastructure fix only.