### PR TITLE
Backport #3054: Update backup registry secret name (7.115.x)

### DIFF
--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -26,26 +26,31 @@ config:
     backupCronJob:
       enable: true
       registry:
-        authSecret: my-secret
+        authSecret: devworkspace-backup-registry-auth
         path: quay.io/my-company-org
       schedule: '0 */4 * * *'
     imagePullPolicy: Always
 ----
 <1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
 
-The `authSecret` must point to a real {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` containing credentials to access the registry.
+The `authSecret` must be named `devworkspace-backup-registry-auth`. It must reference a {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` that contains credentials to access the registry.
 The secret should be created in the installation {namespace} for the {devworkspace} operator.
 
 To create one, you can use the following command:
 
 [source,shell,subs="+attributes,+quotes"]
 ----
-kubectl create secret docker-registry my-secret --from-file=config.json
+{orch-cli} create secret docker-registry devworkspace-backup-registry-auth --from-file=config.json
 ----
 
 The secret must contain a label `controller.devfile.io/watch-secret=true` to be recognized by the {devworkspace} Operator.
 
 [source,shell,subs="+attributes,+quotes"]
 ----
-kubectl label secret my-secret controller.devfile.io/watch-secret=true
+kubectl label secret devworkspace-backup-registry-auth controller.devfile.io/watch-secret=true
 ----
+
+[WARNING]
+====
+The {devworkspace} Operator copies the `devworkspace-backup-registry-auth` secret to each {devworkspace} {namespace} so that backups from user workspaces can be pushed to the registry. If you do not want that secret copied automatically, create a `devworkspace-backup-registry-auth` secret with user-specific credentials in each {devworkspace} {namespace} instead.
+====


### PR DESCRIPTION
## What does this pull request change?

Cherry-pick of #3054 to `7.115.x`.

Renames the backup registry auth secret from `my-secret` to `devworkspace-backup-registry-auth` — a workaround for a bug where the restore init container cannot access the pull secret from a private registry (e.g., quay.io).

## What issues does this pull request fix or reference?

Backport of #3054.

## Specify the version of the product this pull request applies to

DS 3.27 (7.115.x branch).

## Pull Request checklist

- [x] Cherry-pick of merged PR, no new content.