### PR TITLE
docs: mention DWO_NAMESPACE env var in backup docs

### DIFF
--- a/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-integrated-openshift-registry.adoc
@@ -45,3 +45,5 @@ echo "https://$(oc get route default-route -n openshift-image-registry --templat
 
 Once the backup job is finished, the backup archives will be available in the {devworkspace} {namespace} under a repository
 with a matching {devworkspace} name.
+
+include::partial$snip_defining-dwo-namespace-for-backups.adoc[]

--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -33,6 +33,8 @@ config:
 ----
 <1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
 
+include::partial$snip_defining-dwo-namespace-for-backups.adoc[]
+
 The `authSecret` must be named `devworkspace-backup-registry-auth`. It must reference a {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` that contains credentials to access the registry.
 The secret should be created in the installation {namespace} for the {devworkspace} operator.
 

--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -33,8 +33,6 @@ config:
 ----
 <1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
 
-include::partial$snip_defining-dwo-namespace-for-backups.adoc[]
-
 The `authSecret` must be named `devworkspace-backup-registry-auth`. It must reference a {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` that contains credentials to access the registry.
 The secret should be created in the installation {namespace} for the {devworkspace} operator.
 
@@ -56,3 +54,5 @@ kubectl label secret devworkspace-backup-registry-auth controller.devfile.io/wat
 ====
 The {devworkspace} Operator copies the `devworkspace-backup-registry-auth` secret to each {devworkspace} {namespace} so that backups from user workspaces can be pushed to the registry. If you do not want that secret copied automatically, create a `devworkspace-backup-registry-auth` secret with user-specific credentials in each {devworkspace} {namespace} instead.
 ====
+
+include::partial$snip_defining-dwo-namespace-for-backups.adoc[]

--- a/modules/administration-guide/partials/snip_defining-dwo-namespace-for-backups.adoc
+++ b/modules/administration-guide/partials/snip_defining-dwo-namespace-for-backups.adoc
@@ -1,6 +1,8 @@
 :_content-type: SNIPPET
 
-**Note:** If the installation {namespace} for the {devworkspace} operator is not `openshift-operators`, you must define it as an environment variable for the {prod} dashboard in the `CheCluster` Custom Resource.
+[NOTE]
+====
+If the installation {namespace} for the {devworkspace} operator is not `openshift-operators`, you must define it as an environment variable for the {prod} dashboard in the `CheCluster` Custom Resource.
 
 [source,yaml,subs="+attributes,+quotes"]
 ----
@@ -13,6 +15,8 @@ spec:
         containers:
           - env:
               - name: DWO_NAMESPACE
-                value: $OPERATOR_INSTALL_NAMESPACE
+                value: $OPERATOR_INSTALL_NAMESPACE <1>
             name: che-dashboard
 ----
+<1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
+====

--- a/modules/administration-guide/partials/snip_defining-dwo-namespace-for-backups.adoc
+++ b/modules/administration-guide/partials/snip_defining-dwo-namespace-for-backups.adoc
@@ -1,0 +1,18 @@
+:_content-type: SNIPPET
+
+**Note:** If the installation {namespace} for the {devworkspace} operator is not `openshift-operators`, you must define it as an environment variable for the {prod} dashboard in the `CheCluster` Custom Resource.
+
+[source,yaml,subs="+attributes,+quotes"]
+----
+apiVersion: org.eclipse.che/v2
+kind: CheCluster
+spec:
+  components:
+    dashboard:
+      deployment:
+        containers:
+          - env:
+              - name: DWO_NAMESPACE
+                value: $OPERATOR_INSTALL_NAMESPACE
+            name: che-dashboard
+----


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Adds a notice about the DWO_NAMESPACE env var which is needed for the dashboard to detect backup status. This is needed only when the DWO install namespace is not openshift-operators.

## What issues does this pull request fix or reference?

## Specify the version of the product this pull request applies to
DS 3.27.

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
