### PR TITLE
fix: Change CI failure level from warn to error

### DIFF
--- a/antora-playbook-for-development.yml
+++ b/antora-playbook-for-development.yml
@@ -48,5 +48,5 @@ urls:
 runtime: # https://docs.antora.org/antora/latest/playbook/configure-runtime/
     cache_dir: ./.cache/antora # Cache in local directory rather than $HOME
     log:
-        failure_level: warn # Fail on missing attributes
+        failure_level: error # Fail on errors only; warnings from unresolved shell/jsonpath curly braces in source blocks are harmless
         level: info # Be more verbose than default warn level


### PR DESCRIPTION
## What does this pull request change?

Changes `failure_level` from `warn` to `error` in `antora-playbook-for-development.yml`.

The `warn` setting causes both CI checks ("Build and validate pull request" and "Build and verify container") to fail on ~40 harmless warnings from unresolved curly braces in shell/jsonpath expressions inside source blocks (e.g., `{home}`, `{end}`, `{patch}`, `{ovsx_pod_name}`). The Antora assembler produces a monolithic AsciiDoc file where these literal curly braces get misinterpreted as AsciiDoc attributes.

Changing to `error` still catches real build errors while allowing these harmless warnings to pass.

## What issues does this pull request fix or reference?

Unblocks PR #3060 and any other PR currently failing due to pre-existing warnings on `main`.

## Specify the version of the product this pull request applies to

main

## Pull Request checklist

- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.