### PR TITLE
fix: Update workflow CLI flag from --log-failure-level=warn to error

### DIFF
--- a/.github/workflows/build-and-validate-on-pr.yaml
+++ b/.github/workflows/build-and-validate-on-pr.yaml
@@ -44,9 +44,9 @@ jobs:
           path: .cache
           key: ${{ steps.get-date.outputs.YEAR_WEEK }}
 
-      - name: Build using antora # and fail on warning
+      - name: Build using antora # and fail on error
         id: antora-build
-        run: CI=true antora generate antora-playbook-for-development.yml --stacktrace --log-failure-level=warn
+        run: CI=true antora generate antora-playbook-for-development.yml --stacktrace --log-failure-level=error
 
       - name: Store pull request details for publish-netlify
         run: |

--- a/.github/workflows/build-and-validate-on-push.yaml
+++ b/.github/workflows/build-and-validate-on-push.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build using antora
         id: antora-build
-        run: CI=true antora generate antora-playbook-for-development.yml --stacktrace --log-failure-level=warn
+        run: CI=true antora generate antora-playbook-for-development.yml --stacktrace --log-failure-level=error
 
       - name: Upload artifact doc-content
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What does this pull request change?

Updates `--log-failure-level=warn` to `--log-failure-level=error` in both CI workflow files:

- `.github/workflows/build-and-validate-on-pr.yaml`
- `.github/workflows/build-and-validate-on-push.yaml`

## Why

PR #3063 updated the Antora playbook setting to `failure_level: error`, but both workflow files pass `--log-failure-level=warn` on the CLI, which **overrides** the playbook. The build still fails on pre-existing asciidoctor errors from the Antora assembler generating invalid part structures in the monolithic output.

## What issues does this pull request fix or reference?

Completes the fix started in #3063. Unblocks #3060 and other PRs failing due to pre-existing build issues on main.

## Specify the version of the product this pull request applies to

main

## Pull Request checklist

- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.