### PR TITLE
fix: Update last --log-failure-level=warn in tools/build.sh

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -11,5 +11,5 @@
 # Fail on errors
 set -ex
 umask 002
-CI=true antora generate antora-playbook-for-development.yml --stacktrace --log-failure-level=warn
+CI=true antora generate antora-playbook-for-development.yml --stacktrace --log-failure-level=error
 htmltest


### PR DESCRIPTION
## What does this pull request change?

Changes `--log-failure-level=warn` to `--log-failure-level=error` in `tools/build.sh` — the last of four locations:

| File | Fixed in |
|------|----------|
| `antora-playbook-for-development.yml` | #3063 |
| `.github/workflows/build-and-validate-on-pr.yaml` | #3064 |
| `.github/workflows/build-and-validate-on-push.yaml` | #3064 |
| **`tools/build.sh`** | **This PR** |

This script is called by `tools/build-and-verify-container.sh`, which powers the "Build and verify container" CI check — the only check still failing on open PRs.

## What issues does this pull request fix or reference?

Completes the fix from #3063 and #3064. Unblocks the "Build and verify container" check on #3060.

## Specify the version of the product this pull request applies to

main