### PR TITLE
docs: Update monitoring docs for automated Prometheus resource management

### DIFF
--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -3,100 +3,15 @@
 [id="collecting-{prod-id-short}-metrics-with-prometheus"]
 = Collecting {prod-short} Server metrics with Prometheus
 
-To use the in-cluster Prometheus instance to collect, store, and query JVM metrics for {prod-short} Server:
+When the Prometheus Operator is available on the cluster and {prod-short} Server metrics are enabled, {prod-short} Operator automatically creates and manages the Prometheus resources required to collect {prod-short} Server JVM metrics. This includes the `ServiceMonitor`, `Role`, and `RoleBinding` resources, and the `openshift.io/cluster-monitoring` label on the {prod-short} namespace.
 
 .Prerequisites
 
 * Your organization's instance of {prod-short} is installed and running in Red Hat OpenShift.
 
-* An active `oc` session with administrative permissions to the destination OpenShift cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI].
+* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 
-* {prod-short} is exposing metrics on port `8087`. See xref:enabling-and-exposing-{prod-id-short}-metrics[Enabling and exposing {prod-short} server JVM metrics].
-
-.Procedure
-
-. Create the ServiceMonitor for detecting the {prod-short} JVM metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: che-host
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - interval: 10s <2>
-      port: metrics
-      scheme: http
-  namespaceSelector:
-    matchNames:
-      - {prod-namespace} <1>
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {prod-deployment}
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
-
-. Create a Role and RoleBinding to allow Prometheus to view the metrics.
-
-+
-.Role
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: prometheus-k8s
-  namespace: {prod-namespace} <1>
-rules:
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - services
-      - endpoints
-      - pods
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-+
-.RoleBinding
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: view-{prod-id-short}-openshift-monitoring-prometheus-k8s
-  namespace: {prod-namespace} <1>
-subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,terminal,subs="+attributes,quotes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+* {prod-short} Server metrics are enabled. See xref:enabling-and-exposing-{prod-id-short}-metrics[Enabling and exposing {prod-short} Server metrics].
 
 .Verification
 
@@ -127,7 +42,6 @@ $ oc logs --tail=20 __<prometheus_pod_name>__ -c prometheus -n openshift-monitor
 
 [role="_additional-resources"]
 .Additional resources
-
 
 * link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus]
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -2,56 +2,30 @@
 = Collecting {devworkspace} Operator metrics
 
 [role="_abstract"]
-To use the in-cluster Prometheus instance to collect, store, and query metrics about the {devworkspace} Operator:
+When the Prometheus Operator is available on the cluster, {prod-short} Operator automatically creates and manages the Prometheus resources required to collect {devworkspace} Operator metrics. This includes the `ServiceMonitor`, `Role`, and `RoleBinding` resources, and the `openshift.io/cluster-monitoring` label on the {prod-short} namespace.
+
+The `spec.devEnvironments.metrics` field in the CheCluster custom resource controls {devworkspace} Operator metrics collection. The default value is `true`.
 
 .Prerequisites
 
 * Your organization's instance of {prod-short} is installed and running in Red Hat OpenShift.
 
-* An active `oc` session with administrative permissions to the destination OpenShift cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI].
+* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 
 * The `devworkspace-controller-metrics` Service is exposing metrics on port `8443`. This is preconfigured by default.
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the Dev Workspace Operator metrics Service.
+* Configure the `spec.devEnvironments.metrics` field:
 +
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
+[source,shell,subs="+quotes,+attributes,+macros"]
 ----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: devworkspace-controller
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 10s <2>
-      port: metrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-      - openshift-operators
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: devworkspace-controller
+{orch-cli} patch checluster {prod-checluster} \
+  --namespace {prod-namespace} \
+  --type merge \
+  --patch '{"spec":{"devEnvironments":{"metrics": __<boolean>__}}}' <1>
 ----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
-
-include::example$snip_{project-context}-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc[]
-
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,subs="+attributes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+<1> `true` to enable, `false` to disable. The default is `true`.
 
 .Verification
 

--- a/modules/administration-guide/partials/proc_enabling-and-exposing-che-metrics.adoc
+++ b/modules/administration-guide/partials/proc_enabling-and-exposing-che-metrics.adoc
@@ -4,7 +4,9 @@
 = Enabling and exposing {prod-short} Server metrics
 
 {prod-short} exposes the JVM metrics on port `8087` of the `che-host` Service.
-You can configure this behaviour.
+You can configure this behavior.
+
+When enabled and the Prometheus Operator is available on the cluster, {prod-short} Operator automatically creates and manages the `ServiceMonitor`, `Role`, and `RoleBinding` resources required to collect the metrics.
 
 .Procedure
 
@@ -17,4 +19,4 @@ spec:
     metrics:
       enable: __<boolean>__ <1>
 ----
-<1> `true` to enable, `false` to disable.
+<1> `true` to enable, `false` to disable. The default is `true`.


### PR DESCRIPTION
## What does this pull request change?

Updates the existing monitoring documentation to reflect that the che-operator now automatically creates and manages Prometheus resources (ServiceMonitor, Role, RoleBinding) for metrics collection. Removes manual resource creation steps that are no longer needed.

Source PR: https://github.com/eclipse-che/che-operator/pull/2117

## What issues does this pull request fix or reference?

https://github.com/eclipse-che/che-operator/pull/2117

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)