### PR TITLE
docs: Update persistent user home to reflect enabled-by-default

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -85,7 +85,7 @@
 *** xref:configuring-storage-classes.adoc[]
 *** xref:configuring-the-storage-strategy.adoc[]
 *** xref:configuring-storage-sizes.adoc[]
-*** xref:about-persistent-user-home.adoc[]
+*** xref:con_persistent-user-home.adoc[]
 ** xref:configuring-dashboard.adoc[]
 *** xref:configuring-getting-started-samples.adoc[]
 *** xref:configuring-editors-definitions.adoc[]

--- a/modules/administration-guide/pages/about-persistent-user-home.adoc
+++ b/modules/administration-guide/pages/about-persistent-user-home.adoc
@@ -1,5 +1,5 @@
 :_content-type: CONCEPT
-:description: About persistent user home
+:description: Persistent user home preserves the /home/user directory across workspace restarts
 :keywords: administration guide, about, {prod-id-short}, persistent, user, home
 :navtitle: Persistent user home
 :page-aliases:
@@ -9,17 +9,26 @@
 
 
 {prod} provides a persistent home directory feature that allows each non-ephemeral workspace to have their `/home/user` directory be persisted across workspace restarts.
-You can enable this feature in the CheCluster by setting `spec.devEnvironments.persistUserHome.enabled` to `true`.
 
-For newly started workspaces, this feature creates a PVC mounted to the `/home/user` path of the tools container.
+This feature is enabled by default. To disable it, set `spec.devEnvironments.persistUserHome.enabled` to `false` in the CheCluster custom resource:
+
+[source,shell,subs="+quotes,+attributes"]
+----
+{orch-cli} patch checluster {prod-checluster} \
+  --namespace {prod-namespace} \
+  --type merge \
+  --patch '{"spec":{"devEnvironments":{"persistUserHome":{"enabled":false}}}}'
+----
+
+For newly started workspaces, this feature creates a persistent volume claim (PVC) mounted to the `/home/user` path of the tools container.
 In this documentation, a "tools container" will be used to refer to the first container in the devfile.
 This container is the container that includes the project source code by default.
 
-When the PVC is mounted for the first time, the persistent volume's content are empty and therefore must be populated with the `/home/user` directory content.
+When the PVC is mounted for the first time, the persistent volume's contents are empty and therefore must be populated with the `/home/user` directory content.
 
 By default, the `persistUserHome` feature creates an init container for each new workspace pod named `init-persistent-home`.
-This init container is created with the tools container image and is responsible for running a `stow` command to create symbolic links
-in the persistent volume to populate the `/home/user` directory.
+This init container is created with the tools container image.
+It runs a `stow` command to create symbolic links in the persistent volume, populating the `/home/user` directory.
 
 NOTE: For files that cannot be symbolically linked to the `/home/user` directory such as the `.viminfo` and `.bashrc` file, `cp` is used instead of `stow`.
 
@@ -31,19 +40,19 @@ stow -t /home/user/ -d /home/tooling/ --no-folding
 
 The command above creates symbolic links in `/home/user` for files and directories located in `/home/tooling`. This populates the persistent volume with symbolic links to the content in `/home/tooling`. As a result, the `persistUserHome` feature expects the tooling image to have its `/home/user/` content within `/home/tooling`.
 
-For example, if the tools container image contains files in the `home/tooling` directory such as `.config` and `.config-folder/another-file`, stow will create symbolic links in the persistent volume in the following manner:
+For example, if the tools container image contains `.config` and `.config-folder/another-file` in the `/home/tooling` directory, `stow` creates symbolic links as follows:
 
 .Tools container with `persistUserHome` enabled
 image::persistent-user-home/tools-container-example.png[Persistent user home example scenario]
 
-The init container writes the output of the `stow` command to `/home/user/.stow.log` and will only run `stow` the first time the persistent volume is mounted to the workspace. 
+The init container writes the output of the `stow` command to `/home/user/.stow.log` and only runs `stow` the first time the persistent volume is mounted to the workspace.
 
 Using the `stow` command to populate `/home/user` content in the persistent volume provides two main advantages:
 
 . Creating symbolic links is faster and consumes less storage than creating copies of the `/home/user` directory content in the persistent volume. To put it differently, the persistent volume in this case contains symbolic links and not the actual files themselves.
-. If the tools image is updated with newer versions of existing binaries, configs, and files, the init container does not need to `stow` the new versions, as the existing symbolic links will link to the newer versions in `/home/tooling` already.
+. If the tools image is updated with newer versions of existing binaries, configs, and files, the init container does not need to rerun `stow`. The existing symbolic links already point to the newer versions in `/home/tooling`.
 
-NOTE: If the tooling image is updated with additional binaries or files, they won't be symbolically linked to the `/home/user` directory since the `stow` command won't be run again. In this case, the user must delete the `/home/user/.stow_completed` file and restart the workspace to rerun `stow`.
+NOTE: If the tooling image is updated with additional binaries or files, they are not symbolically linked to the `/home/user` directory because the `stow` command does not run again. To rerun `stow`, delete the `/home/user/.stow_completed` file and restart the workspace.
 
 .`persistUserHome` tools image requirements
 

--- a/modules/administration-guide/pages/con_persistent-user-home.adoc
+++ b/modules/administration-guide/pages/con_persistent-user-home.adoc
@@ -1,16 +1,17 @@
 :_content-type: CONCEPT
 :description: Persistent user home preserves the /home/user directory across workspace restarts
-:keywords: administration guide, about, {prod-id-short}, persistent, user, home
+:keywords: administration guide, {prod-id-short}, persistent, user, home
 :navtitle: Persistent user home
-:page-aliases:
+:page-aliases: about-persistent-user-home.adoc
 
-[id="about-persistent-user-home"]
+[id="persistent-user-home"]
 = Persistent user home
 
 
-{prod} provides a persistent home directory feature that allows each non-ephemeral workspace to have their `/home/user` directory be persisted across workspace restarts.
+[role="_abstract"]
+{prod} preserves the `/home/user` directory across workspace restarts for each non-ephemeral workspace, so that user-specific configurations, shell history, and tooling settings persist between sessions.
 
-This feature is enabled by default. To disable it, set `spec.devEnvironments.persistUserHome.enabled` to `false` in the CheCluster custom resource:
+This feature is enabled by default. To disable it, patch the CheCluster custom resource:
 
 [source,shell,subs="+quotes,+attributes"]
 ----
@@ -21,8 +22,8 @@ This feature is enabled by default. To disable it, set `spec.devEnvironments.per
 ----
 
 For newly started workspaces, this feature creates a persistent volume claim (PVC) mounted to the `/home/user` path of the tools container.
-In this documentation, a "tools container" will be used to refer to the first container in the devfile.
-This container is the container that includes the project source code by default.
+In this documentation, "tools container" refers to the first container in the devfile.
+This is the container that includes the project source code by default.
 
 When the PVC is mounted for the first time, the persistent volume's contents are empty and therefore must be populated with the `/home/user` directory content.
 
@@ -30,15 +31,19 @@ By default, the `persistUserHome` feature creates an init container for each new
 This init container is created with the tools container image.
 It runs a `stow` command to create symbolic links in the persistent volume, populating the `/home/user` directory.
 
-NOTE: For files that cannot be symbolically linked to the `/home/user` directory such as the `.viminfo` and `.bashrc` file, `cp` is used instead of `stow`.
+[NOTE]
+====
+For files that cannot be symbolically linked to the `/home/user` directory, such as `.viminfo` and `.bashrc`, `cp` is used instead of `stow`.
+====
 
 The primary function of the `stow` command is to run:
-[subs="+quotes,attributes"]
+
+[source,bash,subs="+quotes,+attributes"]
 ----
 stow -t /home/user/ -d /home/tooling/ --no-folding
 ----
 
-The command above creates symbolic links in `/home/user` for files and directories located in `/home/tooling`. This populates the persistent volume with symbolic links to the content in `/home/tooling`. As a result, the `persistUserHome` feature expects the tooling image to have its `/home/user/` content within `/home/tooling`.
+This command creates symbolic links in `/home/user` for files and directories located in `/home/tooling`. This populates the persistent volume with symbolic links to the content in `/home/tooling`. As a result, the `persistUserHome` feature expects the tooling image to have its `/home/user/` content within `/home/tooling`.
 
 For example, if the tools container image contains `.config` and `.config-folder/another-file` in the `/home/tooling` directory, `stow` creates symbolic links as follows:
 
@@ -49,26 +54,31 @@ The init container writes the output of the `stow` command to `/home/user/.stow.
 
 Using the `stow` command to populate `/home/user` content in the persistent volume provides two main advantages:
 
-. Creating symbolic links is faster and consumes less storage than creating copies of the `/home/user` directory content in the persistent volume. To put it differently, the persistent volume in this case contains symbolic links and not the actual files themselves.
+. Creating symbolic links is faster and consumes less storage than creating copies of the `/home/user` directory content in the persistent volume. The persistent volume contains symbolic links, not the actual files.
 . If the tools image is updated with newer versions of existing binaries, configs, and files, the init container does not need to rerun `stow`. The existing symbolic links already point to the newer versions in `/home/tooling`.
 
-NOTE: If the tooling image is updated with additional binaries or files, they are not symbolically linked to the `/home/user` directory because the `stow` command does not run again. To rerun `stow`, delete the `/home/user/.stow_completed` file and restart the workspace.
+[NOTE]
+====
+If the tooling image is updated with additional binaries or files, they are not symbolically linked to the `/home/user` directory. The `stow` command does not run again automatically.
 
-.`persistUserHome` tools image requirements
+To rerun `stow`, delete the `/home/user/.stow_completed` file and restart the workspace.
+====
+
+== `persistUserHome` tools image requirements
 
 The `persistUserHome` depends on the tools image used for the workspace. By default {prod-short} uses the Universal Developer Image (UDI) for sample workspaces, which supports `persistUserHome` out of the box.
 
-If you are using a custom image, there are three requirements that should be met to support the `persistUserHome` feature.
+If you are using a custom image, the tools image must meet three requirements to support the `persistUserHome` feature.
 
-. The tools image should contain `stow` version >= 2.4.0.
+. The tools image must contain `stow` version >= 2.4.0.
 . The `$HOME` environment variable is set to `/home/user`.
 . In the tools image, the directory that is intended to contain the `/home/user` content is `/home/tooling`.
 
-Due to requirement three, the default UDI image for example adds the `/home/user` content to `/home/tooling` instead, and runs:
+Because the `/home/user` content must reside in `/home/tooling`, the default UDI image for example adds the `/home/user` content to `/home/tooling` instead, and runs:
 
-[subs="+quotes,attributes"]
+[source,bash,subs="+quotes,+attributes"]
 ----
-RUN stow -t /home/user/ -d /home/tooling/ --no-folding 
+RUN stow -t /home/user/ -d /home/tooling/ --no-folding
 ----
 
 in the Dockerfile so that files in `/home/tooling` are accessible from `/home/user` even when not using the `persistUserHome` feature.

--- a/modules/administration-guide/pages/con_persistent-user-home.adoc
+++ b/modules/administration-guide/pages/con_persistent-user-home.adoc
@@ -7,22 +7,13 @@
 [id="persistent-user-home"]
 = Persistent user home
 
-
 [role="_abstract"]
 {prod} preserves the `/home/user` directory across workspace restarts for each non-ephemeral workspace, so that user-specific configurations, shell history, and tooling settings persist between sessions.
 
-This feature is enabled by default. To disable it, patch the CheCluster custom resource:
-
-[source,shell,subs="+quotes,+attributes"]
-----
-{orch-cli} patch checluster {prod-checluster} \
-  --namespace {prod-namespace} \
-  --type merge \
-  --patch '{"spec":{"devEnvironments":{"persistUserHome":{"enabled":false}}}}'
-----
+This feature is enabled by default. To disable it, set `spec.devEnvironments.persistUserHome.enabled` to `false` in the CheCluster custom resource.
 
 For newly started workspaces, this feature creates a persistent volume claim (PVC) mounted to the `/home/user` path of the tools container.
-In this documentation, "tools container" refers to the first container in the devfile.
+The tools container is the first container defined in the devfile.
 This is the container that includes the project source code by default.
 
 When the PVC is mounted for the first time, the persistent volume's contents are empty and therefore must be populated with the `/home/user` directory content.
@@ -70,15 +61,15 @@ The `persistUserHome` depends on the tools image used for the workspace. By defa
 
 If you are using a custom image, the tools image must meet three requirements to support the `persistUserHome` feature.
 
-. The tools image must contain `stow` version >= 2.4.0.
-. The `$HOME` environment variable is set to `/home/user`.
-. In the tools image, the directory that is intended to contain the `/home/user` content is `/home/tooling`.
+* The tools image must contain `stow` version >= 2.4.0.
+* The `$HOME` environment variable is set to `/home/user`.
+* The directory intended to contain the `/home/user` content is `/home/tooling`.
 
 Because the `/home/user` content must reside in `/home/tooling`, the default UDI image for example adds the `/home/user` content to `/home/tooling` instead, and runs:
 
-[source,bash,subs="+quotes,+attributes"]
+[source,dockerfile,subs="+quotes,+attributes"]
 ----
 RUN stow -t /home/user/ -d /home/tooling/ --no-folding
 ----
 
-in the Dockerfile so that files in `/home/tooling` are accessible from `/home/user` even when not using the `persistUserHome` feature.
+This `RUN` instruction in the Dockerfile ensures that files in `/home/tooling` are accessible from `/home/user` even when the `persistUserHome` feature is not enabled.

--- a/modules/administration-guide/pages/configuring-storage.adoc
+++ b/modules/administration-guide/pages/configuring-storage.adoc
@@ -25,4 +25,4 @@ To overcome these stability and quota issues, it is recommended to use certified
 * xref:configuring-storage-classes.adoc[]
 * xref:configuring-the-storage-strategy.adoc[]
 * xref:configuring-storage-sizes.adoc[]
-* xref:about-persistent-user-home.adoc[]
+* xref:con_persistent-user-home.adoc[]

--- a/modules/administration-guide/pages/configuring-storage.adoc
+++ b/modules/administration-guide/pages/configuring-storage.adoc
@@ -7,10 +7,10 @@
 [id="configuring-storage"]
 = Configuring storage
 
+[role="_abstract"]
+Configure storage classes, strategies, sizes, and persistent user home to control how {prod-short} workspaces store project files and user data.
+
 [IMPORTANT]
-
-.Understanding supported storage protocols and requirements
-
 ====
 {prod} workspaces require storage with **volumeMode: FileSystem** because the development environment is designed to store project files, code, and configurations in a standard, hierarchical directory structure (such as /projects).
 


### PR DESCRIPTION
## What does this pull request change?

Updates the persistent user home concept article (`about-persistent-user-home.adoc`) to reflect that the `persistUserHome` feature is now enabled by default in the CheCluster CR. Adds a `kubectl patch` command to disable the feature and improves editorial quality.

Source PR: https://github.com/eclipse-che/che-operator/pull/2119

**Key changes:**
- Updated introduction to state the feature is enabled by default
- Added `kubectl patch` command to disable the feature
- Expanded PVC acronym at first use
- Fixed grammar ("content are" → "contents are")
- Removed contractions and future tense per Red Hat style guide
- Improved sentence scannability (split sentences >30 words)

## What issues does this pull request fix or reference?

- https://github.com/eclipse-che/che-operator/pull/2119

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.