### PR TITLE
fix: Add missing workspaces-config label to vscode-editor-configurations ConfigMap

### DIFF
--- a/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
+++ b/modules/administration-guide/pages/editor-configurations-for-microsoft-visual-studio-code.adoc
@@ -43,6 +43,7 @@ kind: ConfigMap
 metadata:
   name: vscode-editor-configurations
   labels:
+     app.kubernetes.io/component: workspaces-config
      app.kubernetes.io/part-of: che.eclipse.org
 data:
   extensions.json: |


### PR DESCRIPTION
## What does this pull request change?

Adds the missing `app.kubernetes.io/component: workspaces-config` label to the `vscode-editor-configurations` ConfigMap example in the editor-configurations-for-microsoft-visual-studio-code.adoc file.

## What issues does this pull request fix or reference?

This fixes an inconsistency in the documentation where the ConfigMap example was missing a required label. Without the `app.kubernetes.io/component: workspaces-config` label, the ConfigMap does not propagate correctly to user namespaces, preventing the editor configurations from being applied across workspaces.

## Specify the version of the product this pull request applies to

This applies to the main branch (next version).

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.