### PR TITLE
fix: Update Source Code link to point to che-docs repository

### DIFF
--- a/.asciidoctor/docinfo.html
+++ b/.asciidoctor/docinfo.html
@@ -17,7 +17,7 @@
       <div class="navbar-end">
         <a class="navbar-item" href="https://www.eclipse.org/che/">Home</a>
         <a class="navbar-item" href="https://che.eclipseprojects.io/">Blog</a>
-        <a class="navbar-item" href="https://github.com/eclipse/che">Source Code</a>
+        <a class="navbar-item" href="https://github.com/eclipse-che/che-docs">Source Code</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## What does this pull request change?

Updates the "Source Code" link in the documentation header (.asciidoctor/docinfo.html) to point to the correct repository location.

## What issues does this pull request fix or reference?

The "Source Code" link was pointing to `https://github.com/eclipse/che` but should point to `https://github.com/eclipse-che/che-docs` as this is the actual location of the documentation source code.

## Specify the version of the product this pull request applies to

This applies to the main branch (next version).

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [x] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.