### PR TITLE
procedures: Document mount-on-start annotation to prevent workspace restarts

### DIFF
--- a/modules/administration-guide/pages/configuring-a-user-namespace.adoc
+++ b/modules/administration-guide/pages/configuring-a-user-namespace.adoc
@@ -21,6 +21,8 @@ In reverse, if a {kubernetes} resource is modified in a user namespace,
 [WARNING]
 ====
 Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. Ensure that users save their work before you apply these changes.
+
+To prevent workspace restarts when creating new resources, use the `controller.devfile.io/mount-on-start: "true"` annotation. Resources with this annotation will only be mounted when a workspace starts, not when created while a workspace is already running. This is useful for administrators applying global configurations to user namespaces without disrupting active workspaces.
 ====
 
 .Procedure
@@ -59,6 +61,15 @@ after being deleted from {prod-namespace} namespace:
 ----
 che.eclipse.org/sync-retain-on-delete: "true"
 ----
++
+Add the annotation below to prevent workspace restarts when the ConfigMap is created or modified:
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+controller.devfile.io/mount-on-start: "true"
+----
++
+NOTE: When set to `"true"`, the ConfigMap will only be mounted when a workspace starts. If the ConfigMap is created while a workspace is already running, it will not be automatically mounted until the workspace is restarted. This prevents unwanted workspace restarts caused by newly created or modified automount resources.
 For example, to mount a default SSH configuration into every workspace, you must create a ConfigMap:
 +
 ====
@@ -120,6 +131,17 @@ after being deleted from {prod-namespace} namespace:
 che.eclipse.org/sync-retain-on-delete: "true"
 ----
 +
+Add the annotation below to prevent workspace restarts when the Secret is created or modified:
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+controller.devfile.io/mount-on-start: "true"
+----
++
+NOTE: When set to `"true"`, the Secret will only be mounted when a workspace starts, preventing unwanted workspace restarts.
++
+IMPORTANT: For git credential Secrets (labelled with `controller.devfile.io/git-credential`), the `mount-on-start` annotation works collectively: since all git credentials are merged into a single mounted secret, if at least one git credential Secret lacks the `mount-on-start` annotation, all git credentials will be mounted, including those marked with `mount-on-start`. The same applies to git TLS ConfigMaps (labelled with `controller.devfile.io/git-tls-credential`).
++
 See the link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[mounting volumes, configmaps, and secrets]
 for other possible labels and annotations.
 
@@ -150,6 +172,15 @@ Add the annotation below if you want the `PersistentVolumeClaim` to be deleted i
 ----
 che.eclipse.org/sync-retain-on-delete: "false"
 ----
++
+Add the annotation below to prevent workspace restarts when the `PersistentVolumeClaim` is created or modified:
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+controller.devfile.io/mount-on-start: "true"
+----
++
+NOTE: When set to `"true"`, the `PersistentVolumeClaim` will only be mounted when a workspace starts, preventing unwanted workspace restarts.
 +
 See the link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[mounting volumes, configmaps, and secrets]
 for other possible labels and annotations.

--- a/modules/end-user-guide/pages/mounting-configmaps.adoc
+++ b/modules/end-user-guide/pages/mounting-configmaps.adoc
@@ -22,6 +22,8 @@ Mount {kubernetes} ConfigMaps to the `{devworkspace}` containers in the {orch-na
 [WARNING]
 ====
 Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. Ensure that users save their work before you apply these changes.
+
+To prevent workspace restarts when creating new resources, use the `controller.devfile.io/mount-on-start: "true"` annotation. Resources with this annotation will only be mounted when a workspace starts, not when created while a workspace is already running.
 ====
 
 .Procedure
@@ -57,6 +59,27 @@ Defaults to `file`.
 
 `mount-as:env` mounts the keys and values as environment variables in all `{devworkspace}` containers.
 |===
+
+. Optional: Prevent workspace restarts when creating new ConfigMaps.
++
+To avoid restarting running workspaces when creating or modifying a ConfigMap, add the `controller.devfile.io/mount-on-start: "true"` annotation. Resources with this annotation will only be mounted when a workspace starts. If the ConfigMap is created while a workspace is already running, it will not be automatically mounted until the workspace is restarted.
++
+[source,yaml,subs="+quotes,+attributes"]
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: my-configmap
+  labels:
+    controller.devfile.io/mount-to-devworkspace: 'true'
+    controller.devfile.io/watch-configmap: 'true'
+  annotations:
+    controller.devfile.io/mount-on-start: "true"
+data:
+  key: value
+----
++
+NOTE: ConfigMaps with the `mount-on-start` annotation will not trigger workspace restarts when created or modified while workspaces are running. The ConfigMap will be mounted only when the workspace starts or restarts.
 
 .Mounting a ConfigMap as environment variables
 ====

--- a/modules/end-user-guide/pages/mounting-secrets.adoc
+++ b/modules/end-user-guide/pages/mounting-secrets.adoc
@@ -22,6 +22,8 @@ Mount {kubernetes} Secrets to the `{devworkspace}` containers in the {orch-name}
 [WARNING]
 ====
 Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. Ensure that users save their work before you apply these changes.
+
+To prevent workspace restarts when creating new resources, use the `controller.devfile.io/mount-on-start: "true"` annotation. Resources with this annotation will only be mounted when a workspace starts, not when created while a workspace is already running.
 ====
 
 .Procedure
@@ -56,7 +58,36 @@ Defaults to `file`.
 `mount-as: subpath` mounts the keys and values within the mount path using subpath volume mounts.
 
 `mount-as: env` mounts the keys and values as environment variables in all `{devworkspace}` containers.
+
+|`controller.devfile.io/mount-on-start:`
+| When set to `"true"`, the Secret will only be mounted when a workspace starts.
+
+If the Secret is created while a workspace is already running, it will not be automatically mounted until the workspace is restarted.
+
+This prevents unwanted workspace restarts caused by newly created Secrets.
 |===
+
+. Optional: Prevent workspace restarts when creating new Secrets.
++
+To avoid restarting running workspaces when creating or modifying a Secret, add the `controller.devfile.io/mount-on-start: "true"` annotation.
++
+[source,yaml,subs="+quotes,+attributes"]
+----
+kind: Secret
+apiVersion: v1
+metadata:
+  name: my-secret
+  labels:
+    controller.devfile.io/mount-to-devworkspace: 'true'
+    controller.devfile.io/watch-secret: 'true'
+  annotations:
+    controller.devfile.io/mount-on-start: "true"
+stringData:
+  username: admin
+  password: secret123
+----
++
+IMPORTANT: For git credential Secrets (labelled with `controller.devfile.io/git-credential`), the `mount-on-start` annotation works collectively: since all git credentials are merged into a single mounted secret, if at least one git credential Secret lacks the `mount-on-start` annotation, all git credentials will be mounted, including those marked with `mount-on-start`.
 
 .Mounting a Secret as a file
 ====


### PR DESCRIPTION
## What does this pull request change?

This PR updates existing documentation to explain the new `controller.devfile.io/mount-on-start` annotation introduced in devfile/devworkspace-operator#1533. This annotation allows administrators and users to mount ConfigMaps, Secrets, and PVCs to workspaces without triggering unwanted workspace restarts.

**Articles updated:**
- `mounting-configmaps.adoc` - Added documentation for the mount-on-start annotation with usage examples
- `mounting-secrets.adoc` - Added mount-on-start annotation documentation including special handling for git credential Secrets
- `configuring-a-user-namespace.adoc` - Updated administrator guidance for preventing workspace restarts when applying global configurations

**Key changes:**
- Updated warnings to mention the mount-on-start annotation as a solution
- Added new procedure steps explaining how to use the annotation
- Documented special collective behavior for git credential Secrets and TLS ConfigMaps
- Added code examples showing proper annotation usage

## What issues does this pull request fix or reference?

Source PR: https://github.com/devfile/devworkspace-operator/pull/1533
Related issue: https://github.com/eclipse-che/che/issues/23553

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)