### PR TITLE
docs: Document mount-on-start annotation to prevent workspace restarts

### DIFF
--- a/modules/administration-guide/pages/configuring-a-user-namespace.adoc
+++ b/modules/administration-guide/pages/configuring-a-user-namespace.adoc
@@ -18,6 +18,13 @@ If you make changes to a {kubernetes} resource in an {prod-namespace} namespace,
 In reverse, if a {kubernetes} resource is modified in a user namespace,
 {prod-short} will immediately revert the changes.
 
+[WARNING]
+====
+Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}.
+
+To mount the `Secret` or `ConfigMap` only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
+====
+
 .Procedure
 
 . Create the `ConfigMap` below to create and mount it into every workspace.

--- a/modules/administration-guide/pages/configuring-a-user-namespace.adoc
+++ b/modules/administration-guide/pages/configuring-a-user-namespace.adoc
@@ -20,7 +20,7 @@ In reverse, if a {kubernetes} resource is modified in a user namespace,
 
 [WARNING]
 ====
-By default, applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To prevent automatic workspace restarts when mounting resources, add the `controller.devfile.io/mount-on-start: 'true'` annotation to the resource. With this annotation, the resource is mounted only when a workspace starts.
+By default, applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To mount the resource only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
 ====
 
 .Procedure
@@ -60,14 +60,15 @@ after being deleted from {prod-namespace} namespace:
 che.eclipse.org/sync-retain-on-delete: "true"
 ----
 +
-Add the annotation below to prevent workspace restarts when the ConfigMap is mounted:
+Add the following annotation to prevent workspace restarts when the ConfigMap is mounted:
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----
 controller.devfile.io/mount-on-start: "true"
 ----
 +
-When `controller.devfile.io/mount-on-start: "true"` is set, the ConfigMap is mounted only when a workspace starts, not while it is already running. This prevents unexpected workspace restarts when administrators create or modify global configurations.
+With this annotation, the ConfigMap is mounted only at workspace start.
++
 For example, to mount a default SSH configuration into every workspace, you must create a ConfigMap:
 +
 ====
@@ -129,14 +130,14 @@ after being deleted from {prod-namespace} namespace:
 che.eclipse.org/sync-retain-on-delete: "true"
 ----
 +
-Add the annotation below to prevent workspace restarts when the Secret is mounted:
+Add the following annotation to prevent workspace restarts when the Secret is mounted:
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----
 controller.devfile.io/mount-on-start: "true"
 ----
 +
-When `controller.devfile.io/mount-on-start: "true"` is set, the Secret is mounted only when a workspace starts, not while it is already running. This prevents unexpected workspace restarts when administrators create or modify global configurations.
+With this annotation, the Secret is mounted only at workspace start.
 +
 See the link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[mounting volumes, configmaps, and secrets]
 for other possible labels and annotations.
@@ -169,14 +170,14 @@ Add the annotation below if you want the `PersistentVolumeClaim` to be deleted i
 che.eclipse.org/sync-retain-on-delete: "false"
 ----
 +
-Add the annotation below to prevent workspace restarts when the `PersistentVolumeClaim` is mounted:
+Add the following annotation to prevent workspace restarts when the `PersistentVolumeClaim` is mounted:
 +
 [source,yaml,subs="+attributes,+quotes"]
 ----
 controller.devfile.io/mount-on-start: "true"
 ----
 +
-When `controller.devfile.io/mount-on-start: "true"` is set, the `PersistentVolumeClaim` is mounted only when a workspace starts, not while it is already running. This prevents unexpected workspace restarts when administrators create or modify global configurations.
+With this annotation, the `PersistentVolumeClaim` is mounted only at workspace start.
 +
 See the link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[mounting volumes, configmaps, and secrets]
 for other possible labels and annotations.

--- a/modules/administration-guide/pages/configuring-a-user-namespace.adoc
+++ b/modules/administration-guide/pages/configuring-a-user-namespace.adoc
@@ -18,11 +18,6 @@ If you make changes to a {kubernetes} resource in an {prod-namespace} namespace,
 In reverse, if a {kubernetes} resource is modified in a user namespace,
 {prod-short} will immediately revert the changes.
 
-[WARNING]
-====
-By default, applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To mount the resource only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
-====
-
 .Procedure
 
 . Create the `ConfigMap` below to create and mount it into every workspace.
@@ -43,14 +38,6 @@ data:
 ----
 ====
 To enhance the configurability, you can customize the `ConfigMap` by adding additional labels and annotations.
-+
-Add the following labels if you do not want the ConfigMap to be mounted automatically:
-+
-[source,yaml,subs="+attributes,+quotes"]
-----
-controller.devfile.io/watch-configmap: "false"
-controller.devfile.io/mount-to-devworkspace: "false"
-----
 +
 Add the annotation below if you want the ConfigMap to be retained in a user {namespace}
 after being deleted from {prod-namespace} namespace:
@@ -113,14 +100,6 @@ stringData:
 ----
 ====
 To enhance the configurability, you can customize the `Secret` by adding additional labels and annotations.
-+
-Add the labels if you do not want the Secret to be mounted automatically:
-+
-[source,yaml,subs="+attributes,+quotes"]
-----
-controller.devfile.io/watch-secret: "false"
-controller.devfile.io/mount-to-devworkspace: "false"
-----
 +
 Add the annotation below if you want the Secret to be retained in a user {namespace}
 after being deleted from {prod-namespace} namespace:

--- a/modules/administration-guide/pages/configuring-a-user-namespace.adoc
+++ b/modules/administration-guide/pages/configuring-a-user-namespace.adoc
@@ -20,7 +20,7 @@ In reverse, if a {kubernetes} resource is modified in a user namespace,
 
 [WARNING]
 ====
-Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. Ensure that users save their work before you apply these changes.
+By default, applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To prevent automatic workspace restarts when mounting resources, add the `controller.devfile.io/mount-on-start: 'true'` annotation to the resource. With this annotation, the resource is mounted only when a workspace starts.
 ====
 
 .Procedure
@@ -59,6 +59,15 @@ after being deleted from {prod-namespace} namespace:
 ----
 che.eclipse.org/sync-retain-on-delete: "true"
 ----
++
+Add the annotation below to prevent workspace restarts when the ConfigMap is mounted:
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+controller.devfile.io/mount-on-start: "true"
+----
++
+When `controller.devfile.io/mount-on-start: "true"` is set, the ConfigMap is mounted only when a workspace starts, not while it is already running. This prevents unexpected workspace restarts when administrators create or modify global configurations.
 For example, to mount a default SSH configuration into every workspace, you must create a ConfigMap:
 +
 ====
@@ -120,6 +129,15 @@ after being deleted from {prod-namespace} namespace:
 che.eclipse.org/sync-retain-on-delete: "true"
 ----
 +
+Add the annotation below to prevent workspace restarts when the Secret is mounted:
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+controller.devfile.io/mount-on-start: "true"
+----
++
+When `controller.devfile.io/mount-on-start: "true"` is set, the Secret is mounted only when a workspace starts, not while it is already running. This prevents unexpected workspace restarts when administrators create or modify global configurations.
++
 See the link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[mounting volumes, configmaps, and secrets]
 for other possible labels and annotations.
 
@@ -150,6 +168,15 @@ Add the annotation below if you want the `PersistentVolumeClaim` to be deleted i
 ----
 che.eclipse.org/sync-retain-on-delete: "false"
 ----
++
+Add the annotation below to prevent workspace restarts when the `PersistentVolumeClaim` is mounted:
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+controller.devfile.io/mount-on-start: "true"
+----
++
+When `controller.devfile.io/mount-on-start: "true"` is set, the `PersistentVolumeClaim` is mounted only when a workspace starts, not while it is already running. This prevents unexpected workspace restarts when administrators create or modify global configurations.
 +
 See the link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[mounting volumes, configmaps, and secrets]
 for other possible labels and annotations.

--- a/modules/end-user-guide/pages/mounting-configmaps.adoc
+++ b/modules/end-user-guide/pages/mounting-configmaps.adoc
@@ -21,7 +21,7 @@ Mount {kubernetes} ConfigMaps to the `{devworkspace}` containers in the {orch-na
 
 [WARNING]
 ====
-By default, applying or modifying a `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To prevent automatic workspace restarts when mounting the ConfigMap, add the `controller.devfile.io/mount-on-start: 'true'` annotation to the ConfigMap. With this annotation, the ConfigMap is mounted only when a workspace starts.
+By default, applying or modifying a `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To mount the ConfigMap only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
 ====
 
 .Procedure
@@ -62,7 +62,7 @@ Defaults to `file`.
 
 This prevents workspace restarts when the ConfigMap is created or modified.
 
-Defaults to `false` (ConfigMap changes trigger workspace restart).
+Defaults to `false`. Without this annotation, ConfigMap changes trigger a workspace restart.
 |===
 
 .Mounting a ConfigMap as environment variables

--- a/modules/end-user-guide/pages/mounting-configmaps.adoc
+++ b/modules/end-user-guide/pages/mounting-configmaps.adoc
@@ -21,7 +21,7 @@ Mount {kubernetes} ConfigMaps to the `{devworkspace}` containers in the {orch-na
 
 [WARNING]
 ====
-By default, applying or modifying a `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To mount the ConfigMap only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
+By default, applying a `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To mount the ConfigMap only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
 ====
 
 .Procedure
@@ -60,9 +60,7 @@ Defaults to `file`.
 |`controller.devfile.io/mount-on-start:`
 | When set to `true`, the ConfigMap is mounted only when a workspace starts, not while it is already running.
 
-This prevents workspace restarts when the ConfigMap is created or modified.
-
-Defaults to `false`. Without this annotation, ConfigMap changes trigger a workspace restart.
+This prevents workspace restarts when the ConfigMap is created.
 |===
 
 .Mounting a ConfigMap as environment variables

--- a/modules/end-user-guide/pages/mounting-configmaps.adoc
+++ b/modules/end-user-guide/pages/mounting-configmaps.adoc
@@ -21,7 +21,7 @@ Mount {kubernetes} ConfigMaps to the `{devworkspace}` containers in the {orch-na
 
 [WARNING]
 ====
-Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. Ensure that users save their work before you apply these changes.
+By default, applying or modifying a `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To prevent automatic workspace restarts when mounting the ConfigMap, add the `controller.devfile.io/mount-on-start: 'true'` annotation to the ConfigMap. With this annotation, the ConfigMap is mounted only when a workspace starts.
 ====
 
 .Procedure
@@ -56,6 +56,13 @@ Defaults to `file`.
 `mount-as:subpath` mounts the keys and values within the mount path using subpath volume mounts.
 
 `mount-as:env` mounts the keys and values as environment variables in all `{devworkspace}` containers.
+
+|`controller.devfile.io/mount-on-start:`
+| When set to `true`, the ConfigMap is mounted only when a workspace starts, not while it is already running.
+
+This prevents workspace restarts when the ConfigMap is created or modified.
+
+Defaults to `false` (ConfigMap changes trigger workspace restart).
 |===
 
 .Mounting a ConfigMap as environment variables

--- a/modules/end-user-guide/pages/mounting-secrets.adoc
+++ b/modules/end-user-guide/pages/mounting-secrets.adoc
@@ -21,7 +21,7 @@ Mount {kubernetes} Secrets to the `{devworkspace}` containers in the {orch-name}
 
 [WARNING]
 ====
-Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. Ensure that users save their work before you apply these changes.
+By default, applying or modifying a `Secret` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To prevent automatic workspace restarts when mounting the Secret, add the `controller.devfile.io/mount-on-start: 'true'` annotation to the Secret. With this annotation, the Secret is mounted only when a workspace starts.
 ====
 
 .Procedure
@@ -56,6 +56,13 @@ Defaults to `file`.
 `mount-as: subpath` mounts the keys and values within the mount path using subpath volume mounts.
 
 `mount-as: env` mounts the keys and values as environment variables in all `{devworkspace}` containers.
+
+|`controller.devfile.io/mount-on-start:`
+| When set to `true`, the Secret is mounted only when a workspace starts, not while it is already running.
+
+This prevents workspace restarts when the Secret is created or modified.
+
+Defaults to `false` (Secret changes trigger workspace restart).
 |===
 
 .Mounting a Secret as a file

--- a/modules/end-user-guide/pages/mounting-secrets.adoc
+++ b/modules/end-user-guide/pages/mounting-secrets.adoc
@@ -21,7 +21,7 @@ Mount {kubernetes} Secrets to the `{devworkspace}` containers in the {orch-name}
 
 [WARNING]
 ====
-By default, applying or modifying a `Secret` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To mount the Secret only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
+By default, applying a `Secret` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To mount the Secret only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
 ====
 
 .Procedure
@@ -60,9 +60,7 @@ Defaults to `file`.
 |`controller.devfile.io/mount-on-start:`
 | When set to `true`, the Secret is mounted only when a workspace starts, not while it is already running.
 
-This prevents workspace restarts when the Secret is created or modified.
-
-Defaults to `false`. Without this annotation, Secret changes trigger a workspace restart.
+This prevents workspace restarts when the Secret is created.
 |===
 
 .Mounting a Secret as a file

--- a/modules/end-user-guide/pages/mounting-secrets.adoc
+++ b/modules/end-user-guide/pages/mounting-secrets.adoc
@@ -21,7 +21,7 @@ Mount {kubernetes} Secrets to the `{devworkspace}` containers in the {orch-name}
 
 [WARNING]
 ====
-By default, applying or modifying a `Secret` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To prevent automatic workspace restarts when mounting the Secret, add the `controller.devfile.io/mount-on-start: 'true'` annotation to the Secret. With this annotation, the Secret is mounted only when a workspace starts.
+By default, applying or modifying a `Secret` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}. To mount the Secret only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
 ====
 
 .Procedure
@@ -62,7 +62,7 @@ Defaults to `file`.
 
 This prevents workspace restarts when the Secret is created or modified.
 
-Defaults to `false` (Secret changes trigger workspace restart).
+Defaults to `false`. Without this annotation, Secret changes trigger a workspace restart.
 |===
 
 .Mounting a Secret as a file


### PR DESCRIPTION
## What does this pull request change?

This PR updates three existing articles to document the new `controller.devfile.io/mount-on-start` annotation introduced in devworkspace-operator PR #1533. This annotation prevents automatic workspace restarts when mounting ConfigMaps, Secrets, and PersistentVolumeClaims.

### Updated articles:

1. **modules/administration-guide/pages/configuring-a-user-namespace.adoc**
   - Updated the warning to explain the mount-on-start annotation
   - Added mount-on-start annotation documentation for ConfigMaps
   - Added mount-on-start annotation documentation for Secrets
   - Added mount-on-start annotation documentation for PVCs

2. **modules/end-user-guide/pages/mounting-configmaps.adoc**
   - Updated the warning to explain the mount-on-start annotation
   - Added mount-on-start to the optional annotations table

3. **modules/end-user-guide/pages/mounting-secrets.adoc**
   - Updated the warning to explain the mount-on-start annotation
   - Added mount-on-start to the optional annotations table

### Changes made:

- Updated warnings in all three articles to indicate that the `mount-on-start: 'true'` annotation prevents workspace restarts
- Added detailed explanations of how the annotation works
- Added the annotation to optional annotations tables where applicable

This addresses the user experience issue where global configuration changes cause unexpected workspace restarts.

## What issues does this pull request fix or reference?

- Source PR: https://github.com/devfile/devworkspace-operator/pull/1533
- Related issue: https://github.com/eclipse-che/che/issues/23553
- Related issue: https://github.com/eclipse-che/che/issues/22522

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.