### PR TITLE
fix: escape shell variables in Open VSX source blocks

### DIFF
--- a/modules/administration-guide/pages/proc_configure-internal-open-vsx-access.adoc
+++ b/modules/administration-guide/pages/proc_configure-internal-open-vsx-access.adoc
@@ -33,7 +33,7 @@ Restrict your Open VSX registry to internal cluster traffic by removing the publ
 export CHECLUSTER_NAME="$({orch-cli} get checluster --all-namespaces -o json | jq -r '.items[0].metadata.name')" &&
 export CHECLUSTER_NAMESPACE="$({orch-cli} get checluster --all-namespaces -o json | jq -r '.items[0].metadata.namespace')" &&
 export PATCH='{"spec":{"components":{"pluginRegistry":{"openVSXURL":"http://openvsx-server.openvsx.svc:8080"}}}}' &&
-{orch-cli} patch checluster "${CHECLUSTER_NAME}" --type=merge --patch "${PATCH}" -n "${CHECLUSTER_NAMESPACE}"
+{orch-cli} patch checluster "$\{CHECLUSTER_NAME}" --type=merge --patch "$\{PATCH}" -n "$\{CHECLUSTER_NAMESPACE}"
 ----
 
 . Restart any running workspaces to apply the new registry URL.

--- a/modules/administration-guide/pages/proc_deploy-open-vsx-from-source.adoc
+++ b/modules/administration-guide/pages/proc_deploy-open-vsx-from-source.adoc
@@ -47,12 +47,12 @@ cd openvsx/deploy/openshift
 export REGISTRY=__<registry_hostname>__
 export NAMESPACE=__<registry_namespace>__
 export OPENVSX_VERSION=__<openvsx_version>__
-export OPENVSX_SERVER_IMAGE=${REGISTRY}/${NAMESPACE}/openvsx-server:${OPENVSX_VERSION}
+export OPENVSX_SERVER_IMAGE=$\{REGISTRY}/$\{NAMESPACE}/openvsx-server:$\{OPENVSX_VERSION}
 
-podman build -t "${OPENVSX_SERVER_IMAGE}" \
-  --build-arg "OPENVSX_VERSION=${OPENVSX_VERSION}" -f openvsx.Dockerfile . &&
-podman login "${REGISTRY}" &&
-podman push "${OPENVSX_SERVER_IMAGE}"
+podman build -t "$\{OPENVSX_SERVER_IMAGE}" \
+  --build-arg "OPENVSX_VERSION=$\{OPENVSX_VERSION}" -f openvsx.Dockerfile . &&
+podman login "$\{REGISTRY}" &&
+podman push "$\{OPENVSX_SERVER_IMAGE}"
 ----
 +
 where:
@@ -73,11 +73,11 @@ Ensure that the image is publicly accessible or that the cluster can pull from t
 [source,bash,subs="+attributes,+quotes",options="nowrap"]
 ----
 export OPENVSX_CLI_VERSION=__<cli_version>__
-export OPENVSX_CLI_IMAGE=${REGISTRY}/${NAMESPACE}/openvsx-cli:${OPENVSX_CLI_VERSION}
+export OPENVSX_CLI_IMAGE=$\{REGISTRY}/$\{NAMESPACE}/openvsx-cli:$\{OPENVSX_CLI_VERSION}
 
-podman build -t "${OPENVSX_CLI_IMAGE}" \
-  --build-arg "OVSX_VERSION=${OPENVSX_CLI_VERSION}" -f cli.Dockerfile . &&
-podman push "${OPENVSX_CLI_IMAGE}"
+podman build -t "$\{OPENVSX_CLI_IMAGE}" \
+  --build-arg "OVSX_VERSION=$\{OPENVSX_CLI_VERSION}" -f cli.Dockerfile . &&
+podman push "$\{OPENVSX_CLI_IMAGE}"
 ----
 +
 where:
@@ -89,8 +89,8 @@ where:
 [source,bash,subs="+attributes,+quotes",options="nowrap"]
 ----
 {orch-cli} process -f openvsx-deployment.yml \
-  -p OPENVSX_SERVER_IMAGE="${OPENVSX_SERVER_IMAGE}" \
-  -p OPENVSX_CLI_IMAGE="${OPENVSX_CLI_IMAGE}" \
+  -p OPENVSX_SERVER_IMAGE="$\{OPENVSX_SERVER_IMAGE}" \
+  -p OPENVSX_CLI_IMAGE="$\{OPENVSX_CLI_IMAGE}" \
   | {orch-cli} apply -f -
 ----
 
@@ -99,7 +99,7 @@ where:
 [source,bash,subs="+attributes,+quotes",options="nowrap"]
 ----
 {orch-cli} get pods -n openvsx \
-  -o jsonpath='{range .items[*]}{@.metadata.name}{"\t"}{@.status.phase}{"\t"}{.status.containerStatuses[*].ready}{"\n"}{end}'
+  -o jsonpath='{range .items[*]}{@.metadata.name}{"\t"}{@.status.phase}{"\t"}{.status.containerStatuses[*].ready}{"\n"}\{end}'
 ----
 
 . Add an Open VSX user with a Personal Access Token (PAT) to the database.
@@ -141,7 +141,7 @@ export CHECLUSTER_NAME="$({orch-cli} get checluster --all-namespaces -o json | j
 export CHECLUSTER_NAMESPACE="$({orch-cli} get checluster --all-namespaces -o json | jq -r '.items[0].metadata.namespace')" &&
 export OPENVSX_ROUTE_URL="$({orch-cli} get route internal -n openvsx -o jsonpath='{.spec.host}')" &&
 export PATCH='{"spec":{"components":{"pluginRegistry":{"openVSXURL":"https://'"$OPENVSX_ROUTE_URL"'"}}}}' &&
-{orch-cli} patch checluster "${CHECLUSTER_NAME}" --type=merge --patch "${PATCH}" -n "${CHECLUSTER_NAMESPACE}"
+{orch-cli} patch checluster "$\{CHECLUSTER_NAME}" --type=merge --patch "$\{PATCH}" -n "$\{CHECLUSTER_NAMESPACE}"
 ----
 
 . Publish a Visual Studio Code extension from a `.vsix` file. The Open VSX registry does not provide any extension by default.
@@ -150,35 +150,35 @@ export PATCH='{"spec":{"components":{"pluginRegistry":{"openVSXURL":"https://'"$
 +
 [source,bash,subs="+attributes,+quotes",options="nowrap"]
 ----
-export OVSX_POD_NAME=$({orch-cli} get pods -n openvsx -o jsonpath="{.items[*].metadata.name}" | tr ' ' '\n' | grep ^openvsx-server)
+export OVSX_POD_NAME=$({orch-cli} get pods -n openvsx -o jsonpath="\{.items[*].metadata.name}" | tr ' ' '\n' | grep ^openvsx-server)
 ----
 
 .. Download the `.vsix` extension:
 +
 [source,bash,subs="+attributes,+quotes",options="nowrap"]
 ----
-{orch-cli} exec -n openvsx "${OVSX_POD_NAME}" -- bash -c "wget -O /tmp/extension.vsix __<EXTENSION_DOWNLOAD_URL>__"
+{orch-cli} exec -n openvsx "$\{OVSX_POD_NAME}" -- bash -c "wget -O /tmp/extension.vsix __<EXTENSION_DOWNLOAD_URL>__"
 ----
 
 .. Create an extension namespace:
 +
 [source,bash,subs="+attributes,+quotes",options="nowrap"]
 ----
-{orch-cli} exec -n openvsx "${OVSX_POD_NAME}" -- bash -c "ovsx create-namespace __<EXTENSION_NAMESPACE_NAME>__" || true
+{orch-cli} exec -n openvsx "$\{OVSX_POD_NAME}" -- bash -c "ovsx create-namespace __<EXTENSION_NAMESPACE_NAME>__" || true
 ----
 
 .. Publish the extension:
 +
 [source,bash,subs="+attributes,+quotes",options="nowrap"]
 ----
-{orch-cli} exec -n openvsx "${OVSX_POD_NAME}" -- bash -c "ovsx publish /tmp/extension.vsix"
+{orch-cli} exec -n openvsx "$\{OVSX_POD_NAME}" -- bash -c "ovsx publish /tmp/extension.vsix"
 ----
 
 .. Delete the downloaded extension file:
 +
 [source,bash,subs="+attributes,+quotes",options="nowrap"]
 ----
-{orch-cli} exec -n openvsx "${OVSX_POD_NAME}" -- bash -c "rm /tmp/extension.vsix"
+{orch-cli} exec -n openvsx "$\{OVSX_POD_NAME}" -- bash -c "rm /tmp/extension.vsix"
 ----
 
 . Optional: Publish multiple extensions from a list. Update the `deploy/openshift/extensions.txt` file with the download URLs of each `.vsix` file, then publish all listed extensions:
@@ -186,7 +186,7 @@ export OVSX_POD_NAME=$({orch-cli} get pods -n openvsx -o jsonpath="{.items[*].me
 [source,bash,subs="+attributes,+quotes",options="nowrap"]
 ----
 while IFS= read -r url; do
-  {orch-cli} exec -n openvsx "${OVSX_POD_NAME}" -- bash -c "wget -O /tmp/extension.vsix '$url' && ovsx publish /tmp/extension.vsix && rm /tmp/extension.vsix"
+  {orch-cli} exec -n openvsx "$\{OVSX_POD_NAME}" -- bash -c "wget -O /tmp/extension.vsix '$url' && ovsx publish /tmp/extension.vsix && rm /tmp/extension.vsix"
 done < deploy/openshift/extensions.txt
 ----
 


### PR DESCRIPTION
## Summary

- Escape shell variable references (`${VAR}` → `$\{VAR}`) in source blocks with `subs="+attributes"` to prevent Asciidoctor from treating them as unresolved AsciiDoc attributes
- Also escape jsonpath `{end}` template keyword in a `kubectl get pods` source block

The publication builder playbook uses `failure_level: warn`, so the 20 "skipping reference to missing attribute" warnings from PR #3078 cause the build to exit with code 1. Real AsciiDoc attributes like `{orch-cli}` remain unescaped and resolve correctly.

**Files:**
- `proc_configure-internal-open-vsx-access.adoc` — 3 shell variables
- `proc_deploy-open-vsx-from-source.adoc` — 17 shell variables + 1 jsonpath keyword

## Test plan

- [ ] Publication builder CI passes (0 Asciidoctor warnings from these files)
- [ ] Rendered source blocks display correct `${VAR}` syntax (backslash consumed by Asciidoctor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)