### PR TITLE
docs: Document mount-to-devworkspace-include/exclude annotations

### DIFF
--- a/modules/administration-guide/pages/configuring-a-user-namespace.adoc
+++ b/modules/administration-guide/pages/configuring-a-user-namespace.adoc
@@ -18,6 +18,13 @@ If you make changes to a {kubernetes} resource in an {prod-namespace} namespace,
 In reverse, if a {kubernetes} resource is modified in a user namespace,
 {prod-short} will immediately revert the changes.
 
+[WARNING]
+====
+Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}.
+
+To mount the `Secret` or `ConfigMap` only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
+====
+
 .Procedure
 
 . Create the `ConfigMap` below to create and mount it into every workspace.
@@ -37,12 +44,12 @@ data:
   ...
 ----
 ====
-Optional: Use the annotations to configure how the ConfigMap is mounted.
+Optional: Use annotations to configure how the ConfigMap is mounted.
 +
 .Optional annotations
 |===
 |Annotation | Description
-,
+
 |`che.eclipse.org/sync-retain-on-delete:`
 | When set to `"true"`, the ConfigMap is retained in a user {namespace} after being deleted from {prod-namespace} namespace.
 
@@ -51,10 +58,16 @@ Optional: Use the annotations to configure how the ConfigMap is mounted.
 
 |`controller.devfile.io/mount-to-devworkspace-include:`
 | Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted only to workspaces whose names match at least one pattern.
+Patterns support exact match, prefix (name*), suffix (\*name), contains (*name*).
 
 |`controller.devfile.io/mount-to-devworkspace-exclude:`
-| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted to all workspaces except those whose names match a pattern.
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted to all workspaces except those whose names at least one pattern.
+Patterns support exact match, prefix (name*), suffix (\*name), contains (*name*).
 |===
++
+NOTE: When both annotations `controller.devfile.io/mount-to-devworkspace-include`
+and `controller.devfile.io/mount-to-devworkspace-exclude` are set, the resource is
+mounted only to workspaces that match the include pattern and do not match the exclude pattern.
 +
 For other labels and annotations, see link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Mounting volumes, configmaps, and secrets].
 +
@@ -99,7 +112,7 @@ stringData:
     ...
 ----
 ====
-Optional: Use the annotations to configure how the Secret is mounted.
+Optional: Use annotations to configure how the Secret is mounted.
 +
 .Optional annotations
 |===
@@ -112,11 +125,17 @@ Optional: Use the annotations to configure how the Secret is mounted.
 | When set to `"true"`, the Secret is mounted only at workspace start. This prevents workspace restarts when the Secret is created.
 
 |`controller.devfile.io/mount-to-devworkspace-include:`
-| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the Secret is mounted only to workspaces whose names match at least one pattern.
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted only to workspaces whose names match at least one pattern.
+Patterns support exact match, prefix (name*), suffix (\*name), contains (*name*).
 
 |`controller.devfile.io/mount-to-devworkspace-exclude:`
-| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the Secret is mounted to all workspaces except those whose names match a pattern.
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted to all workspaces except those whose names at least one pattern.
+Patterns support exact match, prefix (name*), suffix (\*name), contains (*name*).
 |===
++
+NOTE: When both annotations `controller.devfile.io/mount-to-devworkspace-include`
+and `controller.devfile.io/mount-to-devworkspace-exclude` are set, the resource is
+mounted only to workspaces that match the include pattern and do not match the exclude pattern.
 +
 For other labels and annotations, see link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Mounting volumes, configmaps, and secrets].
 
@@ -136,7 +155,7 @@ spec:
   ...
 ----
 +
-Optional: Use the annotations to configure how the `PersistentVolumeClaim` is mounted.
+Optional: Use annotations to configure how the `PersistentVolumeClaim` is mounted.
 +
 NOTE: The `PersistentVolumeClaim` is not deleted in a user {namespace} by default, if the one from {prod-namespace} is deleted.
 +
@@ -151,11 +170,17 @@ NOTE: The `PersistentVolumeClaim` is not deleted in a user {namespace} by defaul
 | When set to `"true"`, the `PersistentVolumeClaim` is mounted only at workspace start. This prevents workspace restarts when the `PersistentVolumeClaim` is created.
 
 |`controller.devfile.io/mount-to-devworkspace-include:`
-| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the `PersistentVolumeClaim` is mounted only to workspaces whose names match at least one pattern.
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted only to workspaces whose names match at least one pattern.
+Patterns support exact match, prefix (name*), suffix (\*name), contains (*name*).
 
 |`controller.devfile.io/mount-to-devworkspace-exclude:`
-| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the `PersistentVolumeClaim` is mounted to all workspaces except those whose names match a pattern.
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted to all workspaces except those whose names at least one pattern.
+Patterns support exact match, prefix (name*), suffix (\*name), contains (*name*).
 |===
++
+NOTE: When both annotations `controller.devfile.io/mount-to-devworkspace-include`
+and `controller.devfile.io/mount-to-devworkspace-exclude` are set, the resource is
+mounted only to workspaces that match the include pattern and do not match the exclude pattern.
 +
 For other labels and annotations, see link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Mounting volumes, configmaps, and secrets].
 . To leverage the OpenShift Kubernetes Engine, you can create a `Template` object to replicate all resources defined within the template across each user {orch-namespace}.

--- a/modules/administration-guide/pages/configuring-a-user-namespace.adoc
+++ b/modules/administration-guide/pages/configuring-a-user-namespace.adoc
@@ -18,13 +18,6 @@ If you make changes to a {kubernetes} resource in an {prod-namespace} namespace,
 In reverse, if a {kubernetes} resource is modified in a user namespace,
 {prod-short} will immediately revert the changes.
 
-[WARNING]
-====
-Applying or modifying a `Secret` or `ConfigMap` with the `controller.devfile.io/mount-to-devworkspace: 'true'` label restarts all running workspaces in the {namespace}.
-
-To mount the `Secret` or `ConfigMap` only at workspace start and prevent automatic restarts, add the `controller.devfile.io/mount-on-start: 'true'` annotation.
-====
-
 .Procedure
 
 . Create the `ConfigMap` below to create and mount it into every workspace.
@@ -44,24 +37,26 @@ data:
   ...
 ----
 ====
-To enhance the configurability, you can customize the `ConfigMap` by adding additional labels and annotations.
+Optional: Use the annotations to configure how the ConfigMap is mounted.
 +
-Add the annotation below if you want the ConfigMap to be retained in a user {namespace}
-after being deleted from {prod-namespace} namespace:
+.Optional annotations
+|===
+|Annotation | Description
+,
+|`che.eclipse.org/sync-retain-on-delete:`
+| When set to `"true"`, the ConfigMap is retained in a user {namespace} after being deleted from {prod-namespace} namespace.
+
+|`controller.devfile.io/mount-on-start:`
+| When set to `"true"`, the ConfigMap is mounted only at workspace start. This prevents workspace restarts when the ConfigMap is created.
+
+|`controller.devfile.io/mount-to-devworkspace-include:`
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted only to workspaces whose names match at least one pattern.
+
+|`controller.devfile.io/mount-to-devworkspace-exclude:`
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted to all workspaces except those whose names match a pattern.
+|===
 +
-[source,yaml,subs="+attributes,+quotes"]
-----
-che.eclipse.org/sync-retain-on-delete: "true"
-----
-+
-Add the following annotation to prevent workspace restarts when the ConfigMap is created:
-+
-[source,yaml,subs="+attributes,+quotes"]
-----
-controller.devfile.io/mount-on-start: "true"
-----
-+
-With this annotation, the ConfigMap is mounted only at workspace start.
+For other labels and annotations, see link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Mounting volumes, configmaps, and secrets].
 +
 For example, to mount a default SSH configuration into every workspace, you must create a ConfigMap:
 +
@@ -85,8 +80,6 @@ data:
 ====
 +
 This **ConfigMap** propagates the SSH configuration as an extension to the existing default SSH configuration by using the `Include /etc/ssh/ssh_config.d/*.conf` argument. For more information, review the link:https://man.openbsd.org/ssh_config#Include[Include] definition.
-+
-For other labels and annotations, see link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Mounting volumes, configmaps, and secrets].
 
 
 . Create the `Secret` below to create and mount it into every workspace.
@@ -106,28 +99,26 @@ stringData:
     ...
 ----
 ====
-To enhance the configurability, you can customize the `Secret` by adding additional labels and annotations.
+Optional: Use the annotations to configure how the Secret is mounted.
 +
-Add the annotation below if you want the Secret to be retained in a user {namespace}
-after being deleted from {prod-namespace} namespace:
-+
-[source,yaml,subs="+attributes,+quotes"]
-----
-che.eclipse.org/sync-retain-on-delete: "true"
-----
-+
-Add the following annotation to prevent workspace restarts when the Secret is created:
-+
-[source,yaml,subs="+attributes,+quotes"]
-----
-controller.devfile.io/mount-on-start: "true"
-----
-+
-With this annotation, the Secret is mounted only at workspace start.
-+
-See the link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[mounting volumes, configmaps, and secrets]
-for other possible labels and annotations.
+.Optional annotations
+|===
+|Annotation | Description
 
+|`che.eclipse.org/sync-retain-on-delete:`
+| When set to `"true"`, the Secret is retained in a user {namespace} after being deleted from {prod-namespace} namespace.
+
+|`controller.devfile.io/mount-on-start:`
+| When set to `"true"`, the Secret is mounted only at workspace start. This prevents workspace restarts when the Secret is created.
+
+|`controller.devfile.io/mount-to-devworkspace-include:`
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the Secret is mounted only to workspaces whose names match at least one pattern.
+
+|`controller.devfile.io/mount-to-devworkspace-exclude:`
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the Secret is mounted to all workspaces except those whose names match a pattern.
+|===
++
+For other labels and annotations, see link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Mounting volumes, configmaps, and secrets].
 
 . Create the `PersistentVolumeClaim` below to create it to every user {orch-namespace}.
 +
@@ -145,30 +136,28 @@ spec:
   ...
 ----
 +
-To enhance the configurability, you can customize the `PersistentVolumeClaim` by adding additional labels and annotations.
+Optional: Use the annotations to configure how the `PersistentVolumeClaim` is mounted.
 +
-The `PersistentVolumeClaim` is not deleted in a user {namespace} by default, if the one from {prod-namespace} is deleted.
-Add the annotation below if you want the `PersistentVolumeClaim` to be deleted in a user {namespace} as well:
+NOTE: The `PersistentVolumeClaim` is not deleted in a user {namespace} by default, if the one from {prod-namespace} is deleted.
++
+.Optional annotations
+|===
+|Annotation | Description
 
-+
-[source,yaml,subs="+attributes,+quotes"]
-----
-che.eclipse.org/sync-retain-on-delete: "false"
-----
-+
-Add the following annotation to prevent workspace restarts when the `PersistentVolumeClaim` is created:
-+
-[source,yaml,subs="+attributes,+quotes"]
-----
-controller.devfile.io/mount-on-start: "true"
-----
-+
-With this annotation, the `PersistentVolumeClaim` is mounted only at workspace start.
-+
-See the link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[mounting volumes, configmaps, and secrets]
-for other possible labels and annotations.
-+
+|`che.eclipse.org/sync-retain-on-delete:`
+| When set to `"false"`, the `PersistentVolumeClaim` is deleted in a user {namespace} when it is deleted from {prod-namespace} namespace.
 
+|`controller.devfile.io/mount-on-start:`
+| When set to `"true"`, the `PersistentVolumeClaim` is mounted only at workspace start. This prevents workspace restarts when the `PersistentVolumeClaim` is created.
+
+|`controller.devfile.io/mount-to-devworkspace-include:`
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the `PersistentVolumeClaim` is mounted only to workspaces whose names match at least one pattern.
+
+|`controller.devfile.io/mount-to-devworkspace-exclude:`
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the `PersistentVolumeClaim` is mounted to all workspaces except those whose names match a pattern.
+|===
++
+For other labels and annotations, see link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Mounting volumes, configmaps, and secrets].
 . To leverage the OpenShift Kubernetes Engine, you can create a `Template` object to replicate all resources defined within the template across each user {orch-namespace}.
 +
 Aside from the previously mentioned `ConfigMap`, `Secret`, and `PersistentVolumeClaim`, `Template` objects can include:

--- a/modules/end-user-guide/pages/mounting-configmaps.adoc
+++ b/modules/end-user-guide/pages/mounting-configmaps.adoc
@@ -92,4 +92,4 @@ When you start a workspace, the `__<env_var_1>__` and `__<env_var_2>__` environm
 ====
 
 .Additional resources
-,* link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Automatically mounting volumes, configmaps, and secrets]
+* link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Automatically mounting volumes, configmaps, and secrets]

--- a/modules/end-user-guide/pages/mounting-configmaps.adoc
+++ b/modules/end-user-guide/pages/mounting-configmaps.adoc
@@ -61,6 +61,13 @@ Defaults to `file`.
 | When set to `true`, the ConfigMap is mounted only when a workspace starts, not while it is already running.
 
 This prevents workspace restarts when the ConfigMap is created.
+
+|`controller.devfile.io/mount-to-devworkspace-include:`
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted only to workspaces whose names match at least one pattern.
+
+|`controller.devfile.io/mount-to-devworkspace-exclude:`
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the ConfigMap is mounted to all workspaces except those whose names match a pattern.
+
 |===
 
 .Mounting a ConfigMap as environment variables
@@ -83,3 +90,6 @@ data:
 
 When you start a workspace, the `__<env_var_1>__` and `__<env_var_2>__` environment variables will be available in the `{devworkspace}` containers.
 ====
+
+.Additional resources
+,* link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Automatically mounting volumes, configmaps, and secrets]

--- a/modules/end-user-guide/pages/mounting-secrets.adoc
+++ b/modules/end-user-guide/pages/mounting-secrets.adoc
@@ -61,6 +61,13 @@ Defaults to `file`.
 | When set to `true`, the Secret is mounted only when a workspace starts, not while it is already running.
 
 This prevents workspace restarts when the Secret is created.
+
+|`controller.devfile.io/mount-to-devworkspace-include:`
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the Secret is mounted only to workspaces whose names match at least one pattern.
+
+|`controller.devfile.io/mount-to-devworkspace-exclude:`
+| Specifies a comma-separated list of `{devworkspace}` name patterns. When set, the Secret is mounted to all workspaces except those whose names match a pattern.
+
 |===
 
 .Mounting a Secret as a file
@@ -91,3 +98,6 @@ $ mvn --settings /home/user/.m2/settings.xml clean install
 ----
 
 ====
+
+.Additional resources
+* link:https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets[Automatically mounting volumes, configmaps, and secrets]


### PR DESCRIPTION
## What does this pull request change?

Documents the new `controller.devfile.io/mount-to-devworkspace-include` and `controller.devfile.io/mount-to-devworkspace-exclude` annotations introduced in [devfile/devworkspace-operator#1619](https://github.com/devfile/devworkspace-operator/pull/1619). These annotations allow mounting ConfigMaps, Secrets, and PVCs only to specific DevWorkspaces by name pattern.

Updated articles:
- **mounting-secrets.adoc** — Added include/exclude annotations to the Optional annotations table
- **mounting-configmaps.adoc** — Added include/exclude annotations to the Optional annotations table
- **configuring-a-user-namespace.adoc** — Restructured annotation docs as tables (replacing inline YAML blocks) and added include/exclude annotations for ConfigMap, Secret, and PVC sections

## What issues does this pull request fix or reference?

- https://github.com/devfile/devworkspace-operator/pull/1619
- https://github.com/eclipse-che/che/issues/23829

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.