### PR TITLE
procedures: Update backup registry auth secret documentation

### DIFF
--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -7,10 +7,7 @@
 [id="devworkspace-backup-regular-oci-registry"]
 = Configuring backup with a regular OCI-compatible registry
 
-To use a regular OCI-compatible registry for backups, you need to provide registry credentials. Depending on your
-RBAC policy, the token can be provided via a secret in the Operator {namespace} or in each {devworkspace} {namespace}.
-Having the secret in the {devworkspace} {namespace} allows for using different registry accounts per {namespace} with more
-granular access control.
+To use a regular OCI-compatible registry for backups, you need to provide registry credentials. You can configure the {devworkspace} operator to automatically copy a registry authentication secret from the operator {namespace} to {devworkspace} {namespaces}, or you can manually create secrets in each {devworkspace} {namespace}. Having separate secrets in each {devworkspace} {namespace} allows for using different registry accounts per {namespace} with more granular access control.
 
 [source,yaml,subs="+attributes,+quotes"]
 ----
@@ -25,34 +22,58 @@ config:
   workspace:
     backupCronJob:
       enable: true
+      copyOperatorAuthSecret: true <2>
       registry:
-        authSecret: devworkspace-backup-registry-auth
+        authSecret: my-registry-auth <3>
         path: quay.io/my-company-org
       schedule: '0 */4 * * *'
     imagePullPolicy: Always
 ----
 <1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
+<2> Set to `true` to enable automatic copying of the registry authentication secret from the operator {namespace} to {devworkspace} {namespaces}. The default value is `false`.
+<3> The name of the secret in the operator {namespace} that contains registry credentials. This secret will be copied to {devworkspace} {namespaces} with the canonical name `devworkspace-backup-registry-auth`.
 
-The `authSecret` must be named `devworkspace-backup-registry-auth`. It must reference a {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` that contains credentials to access the registry.
-The secret should be created in the installation {namespace} for the {devworkspace} operator.
+== Configuring automatic secret copying
 
-To create one, you can use the following command:
+When `copyOperatorAuthSecret` is set to `true`, the operator automatically copies the registry authentication secret from the operator {namespace} to each {devworkspace} {namespace}.
 
-[source,shell,subs="+attributes,+quotes"]
-----
-{orch-cli} create secret docker-registry devworkspace-backup-registry-auth --from-file=config.json
-----
+The `authSecret` field specifies the name of the secret in the operator {namespace}. This secret must be of type `kubernetes.io/dockerconfigjson` and contain credentials to access the registry.
 
-The secret must contain a label `controller.devfile.io/watch-secret=true` to be recognized by the {devworkspace} Operator.
+To create the secret in the operator {namespace}, use the following command:
 
 [source,shell,subs="+attributes,+quotes"]
 ----
-kubectl label secret devworkspace-backup-registry-auth controller.devfile.io/watch-secret=true
+{orch-cli} create secret docker-registry my-registry-auth \
+  --namespace $OPERATOR_INSTALL_NAMESPACE \
+  --from-file=config.json
 ----
 
-[WARNING]
-====
-The {devworkspace} Operator copies the `devworkspace-backup-registry-auth` secret to each {devworkspace} {namespace} so that backups from user workspaces can be pushed to the registry. If you do not want that secret copied automatically, create a `devworkspace-backup-registry-auth` secret with user-specific credentials in each {devworkspace} {namespace} instead.
-====
+The secret must contain a label `controller.devfile.io/watch-secret=true` to be recognized by the {devworkspace} Operator:
+
+[source,shell,subs="+attributes,+quotes"]
+----
+{orch-cli} label secret my-registry-auth \
+  --namespace $OPERATOR_INSTALL_NAMESPACE \
+  controller.devfile.io/watch-secret=true
+----
+
+The operator will copy this secret to each {devworkspace} {namespace} with the canonical name `devworkspace-backup-registry-auth`.
+
+== Manually creating secrets in workspace namespaces
+
+If `copyOperatorAuthSecret` is set to `false` (the default), the operator will not automatically copy secrets. Instead, you must manually create a secret named `devworkspace-backup-registry-auth` in each {devworkspace} {namespace}.
+
+To create the secret in a {devworkspace} {namespace}, use the following command:
+
+[source,shell,subs="+attributes,+quotes"]
+----
+{orch-cli} create secret docker-registry devworkspace-backup-registry-auth \
+  --namespace <workspace-namespace> \
+  --from-file=config.json
+----
+
+This approach allows you to use different registry credentials for different {devworkspace} {namespaces}.
+
+IMPORTANT: If a secret named `devworkspace-backup-registry-auth` already exists in a {devworkspace} {namespace}, the operator will never overwrite it, even when `copyOperatorAuthSecret` is set to `true`. This ensures that user-provided secrets are always respected.
 
 include::partial$snip_defining-dwo-namespace-for-backups.adoc[]


### PR DESCRIPTION
## What does this pull request change?

Updates the "Configuring backup with a regular OCI-compatible registry" article to reflect the new behavior introduced by devfile/devworkspace-operator#1618.

### Key changes:

- Adds documentation for the new `copyOperatorAuthSecret` configuration field (defaults to `false`)
- Clarifies that `authSecret` can be any name in the operator namespace
- Documents that the secret in workspace namespace always uses the canonical name `devworkspace-backup-registry-auth`
- Splits the article into two approaches:
  - Automatic copying (when `copyOperatorAuthSecret: true`)
  - Manual creation in each workspace namespace (when `copyOperatorAuthSecret: false`)
- Updates the IMPORTANT note to reflect the non-overwriting behavior
- Updates YAML example to show the new configuration option

## What issues does this pull request fix or reference?

- devfile/devworkspace-operator#1618 - refactor (backup): conditionally copy registry auth secret from operator namespace to workspace namespace for backup/restore
- Related: devfile/devworkspace-operator#1614 - fix: fall back to canonical backup auth secret name on restore

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.