### PR TITLE
procedures: clarify conditional registry auth secret copying for DevWorkspace backups

### DIFF
--- a/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc
@@ -33,26 +33,32 @@ config:
 ----
 <1> For Red Hat OpenShift, the default installation namespace for the {devworkspace} operator is `openshift-operators`. See the xref:devworkspace-operator.adoc[{devworkspace} operator overview].
 
-The `authSecret` must be named `devworkspace-backup-registry-auth`. It must reference a {kubernetes} Secret of type `kubernetes.io/dockerconfigjson` that contains credentials to access the registry.
-The secret should be created in the installation {namespace} for the {devworkspace} operator.
+The `authSecret` field specifies the name of a {kubernetes} Secret in the {devworkspace} operator installation {namespace}. This secret must be of type `kubernetes.io/dockerconfigjson` and contain credentials to access the registry.
 
-To create one, you can use the following command:
+To create the secret in the operator installation {namespace}, use the following commands:
 
 [source,shell,subs="+attributes,+quotes"]
 ----
-{orch-cli} create secret docker-registry devworkspace-backup-registry-auth --from-file=config.json
+{orch-cli} create secret docker-registry devworkspace-backup-registry-auth \
+  --namespace $OPERATOR_INSTALL_NAMESPACE \
+  --from-file=config.json
+
+{orch-cli} label secret devworkspace-backup-registry-auth \
+  --namespace $OPERATOR_INSTALL_NAMESPACE \
+  controller.devfile.io/watch-secret=true
 ----
 
 The secret must contain a label `controller.devfile.io/watch-secret=true` to be recognized by the {devworkspace} Operator.
 
-[source,shell,subs="+attributes,+quotes"]
-----
-kubectl label secret devworkspace-backup-registry-auth controller.devfile.io/watch-secret=true
-----
+IMPORTANT: The {devworkspace} Operator conditionally copies the registry authentication secret to each {devworkspace} {namespace}. The secret is copied from the operator installation {namespace} to the workspace {namespace} with the canonical name `devworkspace-backup-registry-auth` only when all of the following conditions are met:
 
-[WARNING]
-====
-The {devworkspace} Operator copies the `devworkspace-backup-registry-auth` secret to each {devworkspace} {namespace} so that backups from user workspaces can be pushed to the registry. If you do not want that secret copied automatically, create a `devworkspace-backup-registry-auth` secret with user-specific credentials in each {devworkspace} {namespace} instead.
-====
+* The `authSecret` field is configured in the `DevWorkspaceOperatorConfig`.
+* No secret named `devworkspace-backup-registry-auth` already exists in the {devworkspace} {namespace}.
+
+The operator never overwrites existing secrets in {devworkspace} {namespaces}. If a user has already created a `devworkspace-backup-registry-auth` secret in their workspace {namespace}, that user-provided secret takes precedence and is used for backup operations.
+
+If the `authSecret` field is not configured, the backup job assumes anonymous registry access (for public registries).
+
+To use different registry credentials for specific {devworkspaces}, create a `devworkspace-backup-registry-auth` secret with user-specific credentials directly in each {devworkspace} {namespace} before the backup job runs. The operator will detect and use the user-provided secret instead of copying from the operator {namespace}.
 
 include::partial$snip_defining-dwo-namespace-for-backups.adoc[]

--- a/modules/administration-guide/pages/devworkspace-backup.adoc
+++ b/modules/administration-guide/pages/devworkspace-backup.adoc
@@ -29,7 +29,7 @@ The value for `registry.path` is the first segment of the final location. The fu
 +
 `<registry.path>/<namespace>/<devworkspace-name>:latest`
 
-* `registry.authSecret`: (Optional) The name of the Kubernetes secret that contains credentials for the OCI registry. If you do not provide a secret, the system assumes the registry is public or uses the **Red Hat OpenShift** integrated registry.
+* `registry.authSecret`: (Optional) The name of the Kubernetes secret in the {devworkspace} operator installation {namespace} that contains credentials for the OCI registry. When configured, the operator conditionally copies this secret to each {devworkspace} {namespace} (only if no user-provided secret already exists). If not configured, the backup job assumes anonymous registry access for public registries or uses the **Red Hat OpenShift** integrated registry.
 * `oras.extraArgs`: (Optional) Additional arguments for to the `oras` CLI tool during push and pull operations.
 
 


### PR DESCRIPTION
## What does this pull request change?

Updates the DevWorkspace backup documentation to accurately reflect the conditional registry authentication secret copying behavior introduced in devfile/devworkspace-operator#1618.

The key changes documented:
- The DevWorkspace operator only copies registry auth secrets from the operator namespace to workspace namespaces when the `authSecret` field is configured in `DevWorkspaceOperatorConfig`
- The operator never overwrites user-provided secrets in workspace namespaces - they always take precedence
- When no `authSecret` is configured, the backup job assumes anonymous registry access (for public registries)
- Clarified that `authSecret` specifies the secret name in the operator installation namespace, not the workspace namespace
- The secret copied to workspace namespaces always uses the canonical name `devworkspace-backup-registry-auth`

Articles updated:
- `modules/administration-guide/pages/devworkspace-backup-regular-oci-registry.adoc` - Replaced the WARNING section with a comprehensive IMPORTANT section explaining the conditional copying logic, updated command examples to include namespace specification
- `modules/administration-guide/pages/devworkspace-backup.adoc` - Clarified the `registry.authSecret` field description to explain conditional copying

## What issues does this pull request fix or reference?

- https://github.com/devfile/devworkspace-operator/pull/1618 - Source PR that implements conditional secret copying
- https://github.com/devfile/devworkspace-operator/pull/1614 - Related PR addressing credential fallback on restore
- https://github.com/devfile/devworkspace-operator/issues/1607 - Related issue about pull secret handling during restoration

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.