### PR TITLE
docs: Update Prometheus metrics management procedures

### DIFF
--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -3,100 +3,25 @@
 [id="collecting-{prod-id-short}-metrics-with-prometheus"]
 = Collecting {prod-short} Server metrics with Prometheus
 
-To use the in-cluster Prometheus instance to collect, store, and query JVM metrics for {prod-short} Server:
+The {prod-short} Operator automatically manages Prometheus resources to enable metric collection when {prod-short} Server metrics are enabled.
 
 .Prerequisites
 
 * Your organization's instance of {prod-short} is installed and running in Red Hat OpenShift.
 
-* An active `oc` session with administrative permissions to the destination OpenShift cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI].
+* An active `oc` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 
-* {prod-short} is exposing metrics on port `8087`. See xref:enabling-and-exposing-{prod-id-short}-metrics[Enabling and exposing {prod-short} server JVM metrics].
+* {prod-short} Server metrics are enabled. See xref:enabling-and-exposing-{prod-id-short}-metrics[].
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the {prod-short} JVM metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: che-host
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - interval: 10s <2>
-      port: metrics
-      scheme: http
-  namespaceSelector:
-    matchNames:
-      - {prod-namespace} <1>
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {prod-deployment}
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
+When `spec.components.metrics.enable` is set to `true` in the `CheCluster` Custom Resource, the {prod-short} Operator automatically creates and manages the following resources:
 
-. Create a Role and RoleBinding to allow Prometheus to view the metrics.
+* A `ServiceMonitor` resource named `che-host` that configures Prometheus to scrape JVM metrics from the {prod-short} Server
+* A `Role` and `RoleBinding` that grant the `prometheus-k8s` service account permission to access the metrics endpoints
+* The `openshift.io/cluster-monitoring=true` label on the {prod-short} namespace to enable the in-cluster Prometheus instance to discover the `ServiceMonitor`
 
-+
-.Role
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: prometheus-k8s
-  namespace: {prod-namespace} <1>
-rules:
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - services
-      - endpoints
-      - pods
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-+
-.RoleBinding
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: view-{prod-id-short}-openshift-monitoring-prometheus-k8s
-  namespace: {prod-namespace} <1>
-subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,terminal,subs="+attributes,quotes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+NOTE: These resources are managed by the {prod-short} Operator. Manual modifications to these resources will be overwritten during reconciliation.
 
 .Verification
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -2,56 +2,42 @@
 = Collecting {devworkspace} Operator metrics
 
 [role="_abstract"]
-To use the in-cluster Prometheus instance to collect, store, and query metrics about the {devworkspace} Operator:
+The {prod-short} Operator automatically manages Prometheus resources to enable metric collection for the {devworkspace} Operator.
 
 .Prerequisites
 
 * Your organization's instance of {prod-short} is installed and running in Red Hat OpenShift.
 
-* An active `oc` session with administrative permissions to the destination OpenShift cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI].
+* An active `oc` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 
 * The `devworkspace-controller-metrics` Service is exposing metrics on port `8443`. This is preconfigured by default.
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the Dev Workspace Operator metrics Service.
+. Enable {devworkspace} Operator metrics collection by configuring the `CheCluster` Custom Resource:
 +
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
+[source,shell,subs="+quotes,+attributes,+macros"]
 ----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: devworkspace-controller
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 10s <2>
-      port: metrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-      - openshift-operators
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: devworkspace-controller
+{orch-cli} patch checluster {prod-checluster} \
+  --namespace {prod-namespace} \
+  --type merge \
+  --patch '{
+    "spec": {
+      "devEnvironments": {
+        "metrics": true <1>
+      }
+    }
+  }'
 ----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
-
-include::example$snip_{project-context}-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc[]
-
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
+<1> Set to `true` to enable metrics collection (default), or `false` to disable.
 +
-[source,subs="+attributes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+When `spec.devEnvironments.metrics` is set to `true`, the {prod-short} Operator automatically creates and manages the following resources:
++
+* A `ServiceMonitor` resource named `devworkspace-controller` that configures Prometheus to scrape metrics from the {devworkspace} Operator
+* A `Role` and `RoleBinding` that grant the `prometheus-k8s` service account permission to access the metrics endpoints
+* The `openshift.io/cluster-monitoring=true` label on the {prod-short} namespace to enable the in-cluster Prometheus instance to discover the `ServiceMonitor`
++
+NOTE: These resources are managed by the {prod-short} Operator. Manual modifications to these resources will be overwritten during reconciliation.
 
 .Verification
 

--- a/modules/administration-guide/partials/proc_enabling-and-exposing-che-metrics.adoc
+++ b/modules/administration-guide/partials/proc_enabling-and-exposing-che-metrics.adoc
@@ -17,4 +17,6 @@ spec:
     metrics:
       enable: __<boolean>__ <1>
 ----
-<1> `true` to enable, `false` to disable.
+<1> Set to `true` to enable metrics exposure and automatic Prometheus resource management, or `false` to disable (default: `true`).
++
+When enabled, the {prod-short} Operator automatically creates a `ServiceMonitor`, `Role`, and `RoleBinding` to allow Prometheus to scrape the metrics. See xref:collecting-{prod-id-short}-metrics-with-prometheus[].


### PR DESCRIPTION
## What does this pull request change?

Updates existing procedures for Prometheus metrics collection to reflect the automated resource management introduced in [che-operator PR #2117](https://github.com/eclipse-che/che-operator/pull/2117).

The Eclipse Che operator now automatically manages ServiceMonitor, Role, and RoleBinding resources when metrics are enabled, eliminating the need for manual creation by administrators.

**Specific changes:**
- **proc_collecting-che-metrics-with-prometheus.adoc**: Removed manual ServiceMonitor/RBAC creation steps and documented automatic resource management by the operator
- **proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc**: Added documentation for the new `spec.devEnvironments.metrics` field, removed manual resource creation steps, and documented automatic resource management
- **proc_enabling-and-exposing-che-metrics.adoc**: Added note that Prometheus resources are automatically created when metrics are enabled

## What issues does this pull request fix or reference?

- https://github.com/eclipse-che/che-operator/pull/2117

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *\`Validate language on files added or modified\`* step reports no vale warnings.