### PR TITLE
procedures: Update metrics collection to reflect automated Prometheus resource management

### DIFF
--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -3,100 +3,23 @@
 [id="collecting-{prod-id-short}-metrics-with-prometheus"]
 = Collecting {prod-short} Server metrics with Prometheus
 
-To use the in-cluster Prometheus instance to collect, store, and query JVM metrics for {prod-short} Server:
+The {prod-short} Operator automatically manages the Prometheus resources required to collect {prod-short} Server metrics when metrics are enabled.
 
 .Prerequisites
 
 * Your organization's instance of {prod-short} is installed and running in Red Hat OpenShift.
 
-* An active `oc` session with administrative permissions to the destination OpenShift cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI].
-
-* {prod-short} is exposing metrics on port `8087`. See xref:enabling-and-exposing-{prod-id-short}-metrics[Enabling and exposing {prod-short} server JVM metrics].
+* {prod-short} metrics are enabled. See xref:enabling-and-exposing-{prod-id-short}-metrics[Enabling and exposing {prod-short} server JVM metrics].
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the {prod-short} JVM metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: che-host
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - interval: 10s <2>
-      port: metrics
-      scheme: http
-  namespaceSelector:
-    matchNames:
-      - {prod-namespace} <1>
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {prod-deployment}
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
+The {prod-short} Operator automatically creates and manages the following resources when `spec.components.metrics.enable` is set to `true`:
 
-. Create a Role and RoleBinding to allow Prometheus to view the metrics.
+* A `ServiceMonitor` object named `che-host` to scrape metrics from the {prod-short} Server
+* A `Role` and `RoleBinding` to grant the `prometheus-k8s` service account permission to scrape metrics
+* The `openshift.io/cluster-monitoring=true` label on the {prod-short} namespace to enable discovery by the in-cluster Prometheus instance
 
-+
-.Role
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: prometheus-k8s
-  namespace: {prod-namespace} <1>
-rules:
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - services
-      - endpoints
-      - pods
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-+
-.RoleBinding
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: view-{prod-id-short}-openshift-monitoring-prometheus-k8s
-  namespace: {prod-namespace} <1>
-subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,terminal,subs="+attributes,quotes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+No manual configuration is required.
 
 .Verification
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -2,56 +2,31 @@
 = Collecting {devworkspace} Operator metrics
 
 [role="_abstract"]
-To use the in-cluster Prometheus instance to collect, store, and query metrics about the {devworkspace} Operator:
+The {prod-short} Operator automatically manages the Prometheus resources required to collect {devworkspace} Operator metrics when metrics are enabled.
 
 .Prerequisites
 
 * Your organization's instance of {prod-short} is installed and running in Red Hat OpenShift.
 
-* An active `oc` session with administrative permissions to the destination OpenShift cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI].
-
-* The `devworkspace-controller-metrics` Service is exposing metrics on port `8443`. This is preconfigured by default.
-
 .Procedure
 
-. Create the ServiceMonitor for detecting the Dev Workspace Operator metrics Service.
+. Configure the `CheCluster` Custom Resource to enable {devworkspace} Operator metrics collection. See xref:using-the-cli-to-configure-the-checluster-custom-resource.adoc[].
 +
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
+[source,yaml,subs="+attributes,+quotes"]
 ----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: devworkspace-controller
-  namespace: {prod-namespace} <1>
 spec:
-  endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 10s <2>
-      port: metrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-      - openshift-operators
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: devworkspace-controller
+  devEnvironments:
+    metrics: __<boolean>__ <1>
 ----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
+<1> `true` to enable, `false` to disable. Defaults to `true`.
 
-include::example$snip_{project-context}-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc[]
+The {prod-short} Operator automatically creates and manages the following resources when `spec.devEnvironments.metrics` is set to `true`:
 
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,subs="+attributes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+* A `ServiceMonitor` object named `devworkspace-controller` to scrape metrics from the {devworkspace} Operator
+* A `Role` and `RoleBinding` to grant the `prometheus-k8s` service account permission to scrape metrics
+* The `openshift.io/cluster-monitoring=true` label on the {prod-short} namespace to enable discovery by the in-cluster Prometheus instance
+
+No manual configuration is required.
 
 .Verification
 

--- a/modules/administration-guide/partials/proc_enabling-and-exposing-che-metrics.adoc
+++ b/modules/administration-guide/partials/proc_enabling-and-exposing-che-metrics.adoc
@@ -18,3 +18,5 @@ spec:
       enable: __<boolean>__ <1>
 ----
 <1> `true` to enable, `false` to disable.
+
+NOTE: When metrics are enabled, the {prod-short} Operator automatically creates the necessary Prometheus resources (ServiceMonitor, Role, and RoleBinding) and adds the `openshift.io/cluster-monitoring=true` label to the {prod-short} namespace to enable metrics collection by the in-cluster Prometheus instance.


### PR DESCRIPTION
Documentation updates generated from PR https://github.com/eclipse-che/che-operator/pull/2117

Updated procedures to reflect automated Prometheus ServiceMonitor and PodMonitor resource management introduced in che-operator.

**Changes:**
- Updated proc_enabling-and-exposing-che-metrics.adoc - Added note about automatic resource creation
- Updated proc_collecting-che-metrics.adoc - Removed manual steps, documented automation
- Updated proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc - Added spec.devEnvironments.metrics configuration field

Fixes documentation for automated metrics collection without manual CRD creation.