### PR TITLE
Document automatic Prometheus resource management

### DIFF
--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -3,7 +3,7 @@
 [id="collecting-{prod-id-short}-metrics-with-prometheus"]
 = Collecting {prod-short} Server metrics with Prometheus
 
-To use the in-cluster Prometheus instance to collect, store, and query JVM metrics for {prod-short} Server:
+The {prod-short} Operator automatically manages the Prometheus resources required to collect {prod-short} Server metrics when metrics are enabled.
 
 .Prerequisites
 
@@ -15,88 +15,13 @@ To use the in-cluster Prometheus instance to collect, store, and query JVM metri
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the {prod-short} JVM metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: che-host
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - interval: 10s <2>
-      port: metrics
-      scheme: http
-  namespaceSelector:
-    matchNames:
-      - {prod-namespace} <1>
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {prod-deployment}
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
+The {prod-short} Operator automatically creates and manages the following resources:
 
-. Create a Role and RoleBinding to allow Prometheus to view the metrics.
+* A `ServiceMonitor` for detecting the {prod-short} Server metrics Service (`che-host`)
+* A `Role` and `RoleBinding` to allow the `prometheus-k8s` ServiceAccount to scrape metrics
+* The `openshift.io/cluster-monitoring: "true"` label on the {prod-short} namespace to enable OpenShift monitoring
 
-+
-.Role
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: prometheus-k8s
-  namespace: {prod-namespace} <1>
-rules:
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - services
-      - endpoints
-      - pods
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-+
-.RoleBinding
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: view-{prod-id-short}-openshift-monitoring-prometheus-k8s
-  namespace: {prod-namespace} <1>
-subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,terminal,subs="+attributes,quotes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+No manual configuration is required. To enable metrics collection, ensure that metrics are enabled in the `CheCluster` Custom Resource. See xref:enabling-and-exposing-{prod-id-short}-metrics[Enabling and exposing {prod-short} server JVM metrics].
 
 .Verification
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -2,7 +2,7 @@
 = Collecting {devworkspace} Operator metrics
 
 [role="_abstract"]
-To use the in-cluster Prometheus instance to collect, store, and query metrics about the {devworkspace} Operator:
+The {prod-short} Operator automatically manages the Prometheus resources required to collect {devworkspace} Operator metrics.
 
 .Prerequisites
 
@@ -14,44 +14,13 @@ To use the in-cluster Prometheus instance to collect, store, and query metrics a
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the Dev Workspace Operator metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: devworkspace-controller
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 10s <2>
-      port: metrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-      - openshift-operators
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: devworkspace-controller
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
+The {prod-short} Operator automatically creates and manages the following resources:
 
-include::example$snip_{project-context}-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc[]
+* A `ServiceMonitor` for detecting the {devworkspace} Operator metrics Service (`devworkspace-controller`)
+* A `Role` and `RoleBinding` to allow the `prometheus-k8s` ServiceAccount to scrape metrics
+* The `openshift.io/cluster-monitoring: "true"` label on the {prod-short} namespace to enable OpenShift monitoring
 
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,subs="+attributes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+No manual configuration is required. Metrics collection is enabled by default.
 
 .Verification
 

--- a/modules/administration-guide/partials/proc_enabling-and-exposing-che-metrics.adoc
+++ b/modules/administration-guide/partials/proc_enabling-and-exposing-che-metrics.adoc
@@ -4,7 +4,7 @@
 = Enabling and exposing {prod-short} Server metrics
 
 {prod-short} exposes the JVM metrics on port `8087` of the `che-host` Service.
-You can configure this behaviour.
+When metrics are enabled, the {prod-short} Operator automatically creates and manages the Prometheus `ServiceMonitor` and RBAC resources required for metrics collection.
 
 .Procedure
 
@@ -17,4 +17,4 @@ spec:
     metrics:
       enable: __<boolean>__ <1>
 ----
-<1> `true` to enable, `false` to disable.
+<1> `true` to enable metrics and automatic Prometheus integration (default), `false` to disable.


### PR DESCRIPTION
## Summary
- Updated documentation to reflect that the che-operator now automatically manages Prometheus resources
- Removed manual setup procedures for ServiceMonitor, Role, and RoleBinding
- Clarified that metrics collection happens automatically when metrics are enabled

## Related PR
https://github.com/eclipse-che/che-operator/pull/2117

## Test plan
- [ ] Review documentation changes
- [ ] Verify procedures are accurate after che-operator PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)