### PR TITLE
procedures: Document GitHub Copilot Chat usage

### DIFF
--- a/modules/end-user-guide/nav.adoc
+++ b/modules/end-user-guide/nav.adoc
@@ -34,7 +34,7 @@
 * xref:devfile-introduction.adoc[]
 * xref:ides-in-workspaces.adoc[]
 ** xref:microsoft-visual-studio-code-open-source-ide.adoc[]
-** xref:using-github-copilot-chat.adoc[]
+*** xref:using-github-copilot-chat.adoc[]
 ** xref:connect-visual-studio-code-to-che-workspace.adoc[]
 ** xref:defining-a-common-ide.adoc[]
 * xref:using-credentials-and-configurations-in-workspaces.adoc[]

--- a/modules/end-user-guide/nav.adoc
+++ b/modules/end-user-guide/nav.adoc
@@ -34,6 +34,7 @@
 * xref:devfile-introduction.adoc[]
 * xref:ides-in-workspaces.adoc[]
 ** xref:microsoft-visual-studio-code-open-source-ide.adoc[]
+** xref:using-github-copilot-chat.adoc[]
 ** xref:connect-visual-studio-code-to-che-workspace.adoc[]
 ** xref:defining-a-common-ide.adoc[]
 * xref:using-credentials-and-configurations-in-workspaces.adoc[]

--- a/modules/end-user-guide/pages/microsoft-visual-studio-code-open-source-ide.adoc
+++ b/modules/end-user-guide/pages/microsoft-visual-studio-code-open-source-ide.adoc
@@ -32,6 +32,8 @@ You can automate installation of Microsoft Visual Studio Code extensions from th
 Configure IDE preferences on a per-workspace basis by invoking the link:https://code.visualstudio.com/api/ux-guidelines/command-palette[Command Palette] and selecting *Preferences: Open Workspace Settings*.
 ====
 
+TIP: To use GitHub Copilot Chat in your workspace, see xref:using-github-copilot-chat.adoc[].
+
 NOTE: You might see your organization's branding in this IDE if your organization customized it through a branded build.
 
 include::partial$proc_automating-installation-of-microsoft-visual-studio-code-extensions-at-workspace-startup.adoc[leveloffset=+1]

--- a/modules/end-user-guide/pages/using-github-copilot-chat.adoc
+++ b/modules/end-user-guide/pages/using-github-copilot-chat.adoc
@@ -12,6 +12,13 @@ You can use link:https://github.com/features/copilot[GitHub Copilot Chat] in a {
 
 * A GitHub account with an active link:https://github.com/features/copilot[GitHub Copilot] subscription.
 * A running {prod-short} workspace with the Code - OSS editor.
+* The following URLs must be accessible from the workspace (ensure they are whitelisted if you are in a restricted or air-gapped environment):
++
+--
+** `https://github.com`
+** `https://api.github.com`
+** `https://api.githubcopilot.com`
+--
 
 .Procedure
 

--- a/modules/end-user-guide/pages/using-github-copilot-chat.adoc
+++ b/modules/end-user-guide/pages/using-github-copilot-chat.adoc
@@ -1,18 +1,18 @@
 :_content-type: PROCEDURE
-:description: Using GitHub Copilot Chat in a Che workspace
+:description: Set up GitHub Copilot Chat in a Che workspace
 :keywords: copilot, github-copilot, copilot-chat, ai, extensions
-:navtitle: Using GitHub Copilot Chat
+:navtitle: Set up GitHub Copilot Chat
 
 [id="using-github-copilot-chat"]
-= Using GitHub Copilot Chat
+= Set up GitHub Copilot Chat
 
-You can use link:https://github.com/features/copilot[GitHub Copilot Chat] in a {prod-short} workspace with the Code - OSS editor by installing the link:https://open-vsx.org/extension/redhat/devspaces-copilot-chat-integration/0.36.2[Dev Spaces Copilot Chat Integration] extension (version 0.36.2) and authenticating with your GitHub account.
+To get AI-assisted coding suggestions in your {prod-short} workspace, install the link:https://open-vsx.org/extension/redhat/devspaces-copilot-chat-integration/0.36.2[Dev Spaces Copilot Chat Integration] extension (version 0.36.2) and authenticate with your GitHub account.
 
 .Prerequisites
 
 * A GitHub account with an active link:https://github.com/features/copilot[GitHub Copilot] subscription.
 * A running {prod-short} workspace with the Code - OSS editor.
-* The following URLs must be accessible from the workspace (ensure they are whitelisted if you are in a restricted or air-gapped environment):
+* The following URLs must be accessible from the workspace (ensure they are added to the allowlist if you are in a restricted or air-gapped environment):
 +
 --
 ** `https://github.com`
@@ -45,10 +45,7 @@ Use version 0.36.2 of the extension. Other versions may not be compatible with t
 +
 Press kbd:[F1] to open the Command Palette, type `GitHub: Device Authentication`, and select the command.
 +
-[IMPORTANT]
-====
-You must complete Device Authentication *before* attempting to use AI features. Initiating "Sign in to use AI Features" without a valid device authentication token causes authentication errors that require signing out and re-authenticating.
-====
+IMPORTANT: You must complete Device Authentication *before* attempting to use AI features. Initiating "Sign in to use AI Features" without a valid device authentication token causes authentication errors that require signing out and re-authenticating.
 
 . Complete the device authentication flow.
 +
@@ -60,7 +57,7 @@ After successful authentication, a notification prompts you to refresh the brows
 
 .Verification
 
-* The Copilot Chat panel opens and responds to prompts.
+* Open the Copilot Chat panel, type a prompt such as "Explain this file", and verify that a response appears.
 
 [NOTE]
 ====
@@ -74,6 +71,7 @@ If you attempted to use Copilot Chat before completing Device Authentication, th
 * Copilot Chat appears to be connected but does not respond to prompts.
 * The Copilot Chat output log contains errors such as:
 +
+[source,text]
 ----
 Failed to get copilot token. reason: NotAuthorized
 GitHub Copilot could not connect to server. Extension activation failed: "Failed to get copilot token. reason: NotAuthorized"

--- a/modules/end-user-guide/pages/using-github-copilot-chat.adoc
+++ b/modules/end-user-guide/pages/using-github-copilot-chat.adoc
@@ -1,0 +1,81 @@
+:_content-type: PROCEDURE
+:description: Using GitHub Copilot Chat in a Che workspace
+:keywords: copilot, github-copilot, copilot-chat, ai, extensions
+:navtitle: Using GitHub Copilot Chat
+
+[id="using-github-copilot-chat"]
+= Using GitHub Copilot Chat
+
+You can use link:https://github.com/features/copilot[GitHub Copilot Chat] in a {prod-short} workspace with the Code - OSS editor by installing the link:https://open-vsx.org/extension/redhat/devspaces-copilot-chat-integration/0.36.2[Dev Spaces Copilot Chat Integration] extension (version 0.36.2) and authenticating with your GitHub account.
+
+.Prerequisites
+
+* A GitHub account with an active link:https://github.com/features/copilot[GitHub Copilot] subscription.
+* A running {prod-short} workspace with the Code - OSS editor.
+
+.Procedure
+
+. Install version 0.36.2 of the *Dev Spaces Copilot Chat Integration* extension.
++
+Choose one of the following options depending on your Open VSX registry configuration:
++
+--
+* If your {prod-short} instance is configured to use the link:https://open-vsx.org[public Open VSX registry] or a standalone Open VSX registry that contains the extension:
++
+Open the Extensions view by pressing kbd:[Ctrl+Shift+X], search for `Dev Spaces Copilot Chat Integration`, select version *0.36.2*, and click *Install*.
+
+* If your {prod-short} instance uses the default embedded Open VSX registry or a registry that does not contain the extension, install it manually from a `.vsix` file:
++
+Download the `.vsix` file from the link:https://open-vsx.org/extension/redhat/devspaces-copilot-chat-integration/0.36.2[Open VSX registry], then press kbd:[F1] to open the Command Palette and run `Extensions: Install from VSIX...`.
+--
++
+[IMPORTANT]
+====
+Use version 0.36.2 of the extension. Other versions may not be compatible with the current {prod-short} editor.
+====
+
+. Authenticate using Device Authentication.
++
+Press kbd:[F1] to open the Command Palette, type `GitHub: Device Authentication`, and select the command.
++
+[IMPORTANT]
+====
+You must complete Device Authentication *before* attempting to use AI features. Initiating "Sign in to use AI Features" without a valid device authentication token causes authentication errors that require signing out and re-authenticating.
+====
+
+. Complete the device authentication flow.
++
+A notification appears with a device code. Click the link to open the GitHub device activation page in your browser, paste the code, and authorize access.
+
+. Refresh the browser page.
++
+After successful authentication, a notification prompts you to refresh the browser page. Refresh the page to apply the authentication token. Copilot Chat is authenticated automatically and ready to use.
+
+.Verification
+
+* The Copilot Chat panel opens and responds to prompts.
+
+[NOTE]
+====
+Device Authentication is a one-time step. The credentials are saved as a Kubernetes object and persist across workspaces on the same cluster.
+====
+
+.Troubleshooting
+
+If you attempted to use Copilot Chat before completing Device Authentication, the extension may enter an error state. Typical symptoms include:
+
+* Copilot Chat appears to be connected but does not respond to prompts.
+* The Copilot Chat output log contains errors such as:
++
+----
+Failed to get copilot token. reason: NotAuthorized
+GitHub Copilot could not connect to server. Extension activation failed: "Failed to get copilot token. reason: NotAuthorized"
+----
+
+This happens when *Sign in to use AI Features* is triggered before a valid Device Authentication token exists.
+
+To recover:
+
+. Click the *Accounts* icon on the left activity bar, select your account, and click *Sign Out*. A confirmation dialog appears indicating the account has been used by the Dev Spaces Copilot Chat Integration. Click *Sign Out* to confirm.
+. Press kbd:[F1] to open the Command Palette and run `GitHub: Device Authentication`. Complete the device authentication flow in the browser.
+. Refresh the browser page when prompted. Copilot Chat is now ready to use.

--- a/modules/end-user-guide/pages/using-github-copilot-chat.adoc
+++ b/modules/end-user-guide/pages/using-github-copilot-chat.adoc
@@ -2,11 +2,12 @@
 :description: Set up GitHub Copilot Chat in a Che workspace
 :keywords: copilot, github-copilot, copilot-chat, ai, extensions
 :navtitle: Set up GitHub Copilot Chat
+:copilot-ext-ver: 0.36.2
 
 [id="using-github-copilot-chat"]
 = Set up GitHub Copilot Chat
 
-To get AI-assisted coding suggestions in your {prod-short} workspace, install the link:https://open-vsx.org/extension/redhat/devspaces-copilot-chat-integration/0.36.2[Dev Spaces Copilot Chat Integration] extension (version 0.36.2) and authenticate with your GitHub account.
+To get AI-assisted coding suggestions in your {prod-short} workspace, install the link:https://open-vsx.org/extension/redhat/devspaces-copilot-chat-integration/0.36.2[Dev Spaces Copilot Chat Integration] extension (version {copilot-ext-ver}) and authenticate with your GitHub account.
 
 .Prerequisites
 
@@ -22,14 +23,14 @@ To get AI-assisted coding suggestions in your {prod-short} workspace, install th
 
 .Procedure
 
-. Install version 0.36.2 of the *Dev Spaces Copilot Chat Integration* extension.
+. Install version {copilot-ext-ver} of the *Dev Spaces Copilot Chat Integration* extension.
 +
 Choose one of the following options depending on your Open VSX registry configuration:
 +
 --
 * If your {prod-short} instance is configured to use the link:https://open-vsx.org[public Open VSX registry] or a standalone Open VSX registry that contains the extension:
 +
-Open the Extensions view by pressing kbd:[Ctrl+Shift+X], search for `Dev Spaces Copilot Chat Integration`, select version *0.36.2*, and click *Install*.
+Open the Extensions view by pressing kbd:[Ctrl+Shift+X], search for `Dev Spaces Copilot Chat Integration`, select version *{copilot-ext-ver}*, and click *Install*.
 
 * If your {prod-short} instance uses the default embedded Open VSX registry or a registry that does not contain the extension, install it manually from a `.vsix` file:
 +
@@ -38,7 +39,7 @@ Download the `.vsix` file from the link:https://open-vsx.org/extension/redhat/de
 +
 [IMPORTANT]
 ====
-Use version 0.36.2 of the extension. Other versions may not be compatible with the current {prod-short} editor.
+Use version {copilot-ext-ver} of the extension. Other versions may not be compatible with the current {prod-short} editor.
 ====
 
 . Authenticate using Device Authentication.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->


## What does this pull request change?
Adds instructions how to authenticate `GitHub Copilot Chat` using `Device Authentication` flow

<details>
<summary> Click here to see screenshots</summary>
<img width="1043" height="831" alt="image" src="https://github.com/user-attachments/assets/e408deac-246c-4538-8917-f6fd6ca6ee11" />
<img width="1043" height="798" alt="image" src="https://github.com/user-attachments/assets/536377dd-fc36-4336-9246-f5750daf9d6f" />
<img width="1043" height="589" alt="image" src="https://github.com/user-attachments/assets/0a1b0e93-54fe-4df4-8e75-3057dae80124" />


</details>

## What issues does this pull request fix or reference?
https://github.com/eclipse-che/che/issues/23536#issuecomment-4289877814

## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.

Assisted-by: Cursor AI