### PR TITLE
docs: Update Prometheus monitoring to reflect automated resource management

### DIFF
--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -3,7 +3,7 @@
 [id="collecting-{prod-id-short}-metrics-with-prometheus"]
 = Collecting {prod-short} Server metrics with Prometheus
 
-To use the in-cluster Prometheus instance to collect, store, and query JVM metrics for {prod-short} Server:
+The {prod-short} Operator automatically configures the in-cluster Prometheus instance to collect, store, and query JVM metrics for {prod-short} Server.
 
 .Prerequisites
 
@@ -13,9 +13,9 @@ To use the in-cluster Prometheus instance to collect, store, and query JVM metri
 
 * {prod-short} is exposing metrics on port `8087`. See xref:enabling-and-exposing-{prod-id-short}-metrics[Enabling and exposing {prod-short} server JVM metrics].
 
-.Procedure
+The {prod-short} Operator automatically creates the following resources when metrics are enabled:
 
-. Create the ServiceMonitor for detecting the {prod-short} JVM metrics Service.
+* *ServiceMonitor* for detecting the {prod-short} JVM metrics Service
 +
 .ServiceMonitor
 ====
@@ -42,8 +42,7 @@ spec:
 <2> The rate at which a target is scraped.
 ====
 
-. Create a Role and RoleBinding to allow Prometheus to view the metrics.
-
+* *Role and RoleBinding* to allow Prometheus to view the metrics
 +
 .Role
 ====
@@ -68,7 +67,6 @@ rules:
 ----
 <1> The {prod-short} namespace. The default is `{prod-namespace}`.
 ====
-
 +
 .RoleBinding
 ====
@@ -91,11 +89,11 @@ roleRef:
 <1> The {prod-short} namespace. The default is `{prod-namespace}`.
 ====
 
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
+* *Namespace label* to allow the in-cluster Prometheus instance to detect the ServiceMonitor
 +
-[source,terminal,subs="+attributes,quotes"]
+[source,yaml,subs="+attributes,quotes"]
 ----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
+openshift.io/cluster-monitoring: "true"
 ----
 
 .Verification

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -2,7 +2,7 @@
 = Collecting {devworkspace} Operator metrics
 
 [role="_abstract"]
-To use the in-cluster Prometheus instance to collect, store, and query metrics about the {devworkspace} Operator:
+The {prod-short} Operator automatically configures the in-cluster Prometheus instance to collect, store, and query metrics about the {devworkspace} Operator.
 
 .Prerequisites
 
@@ -12,9 +12,9 @@ To use the in-cluster Prometheus instance to collect, store, and query metrics a
 
 * The `devworkspace-controller-metrics` Service is exposing metrics on port `8443`. This is preconfigured by default.
 
-.Procedure
+The {prod-short} Operator automatically creates the following resources:
 
-. Create the ServiceMonitor for detecting the Dev Workspace Operator metrics Service.
+* *ServiceMonitor* for detecting the {devworkspace} Operator metrics Service
 +
 .ServiceMonitor
 ====
@@ -44,13 +44,16 @@ spec:
 <2> The rate at which a target is scraped.
 ====
 
+* *Role and RoleBinding* to allow Prometheus to view the metrics
+
++
 include::example$snip_{project-context}-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc[]
 
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
+* *Namespace label* to allow the in-cluster Prometheus instance to detect the ServiceMonitor
 +
-[source,subs="+attributes"]
+[source,yaml,subs="+attributes,quotes"]
 ----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
+openshift.io/cluster-monitoring: "true"
 ----
 
 .Verification

--- a/modules/administration-guide/partials/proc_enabling-and-exposing-che-metrics.adoc
+++ b/modules/administration-guide/partials/proc_enabling-and-exposing-che-metrics.adoc
@@ -6,6 +6,8 @@
 {prod-short} exposes the JVM metrics on port `8087` of the `che-host` Service.
 You can configure this behaviour.
 
+When metrics are enabled, the {prod-short} Operator automatically creates the Prometheus ServiceMonitor and RBAC resources required for the in-cluster Prometheus instance to collect metrics.
+
 .Procedure
 
 * Configure the `CheCluster` Custom Resource. See xref:using-the-cli-to-configure-the-checluster-custom-resource.adoc[].


### PR DESCRIPTION
## What does this pull request change?

This PR updates the Prometheus monitoring documentation to reflect that the Che Operator now automatically creates and manages Prometheus resources (ServiceMonitor, RBAC, and namespace labels) when metrics are enabled.

The following procedures have been updated:
- **proc_collecting-che-metrics-with-prometheus.adoc**: Changed from manual step-by-step instructions to document that resources are automatically created
- **proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc**: Changed from manual step-by-step instructions to document that resources are automatically created
- **proc_enabling-and-exposing-che-metrics.adoc**: Added note that enabling metrics triggers automatic Prometheus resource creation

The updated procedures now explain that the operator automatically manages these resources while still providing reference examples of the ServiceMonitor, Role, and RoleBinding configurations for users who want to understand what gets created.

## What issues does this pull request fix or reference?

- https://github.com/eclipse-che/che-operator/pull/2117
- https://redhat.atlassian.net/browse/CRW-8629
- https://redhat.atlassian.net/browse/CRW-8589
- https://redhat.atlassian.net/browse/CRW-8315

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.