### PR TITLE
procedures: Update monitoring procedures for automated Prometheus resources

### DIFF
--- a/modules/administration-guide/pages/monitoring-che.adoc
+++ b/modules/administration-guide/pages/monitoring-che.adoc
@@ -1,13 +1,13 @@
 :_content-type: ASSEMBLY
-:description: Monitoring {prod-short} Server
-:keywords: administration-guide, monitoring-che
+:description: Monitoring {prod-short} Server with Prometheus
+:keywords: administration-guide, monitoring-che, prometheus, metrics
 :navtitle: Monitoring {prod-short} Server
 :page-aliases: .:monitoring-che.adoc, .:tracing-che.adoc, tracing-che.adoc
 
 [id="monitoring-{prod-id-short}"]
 = Monitoring {prod-short} Server
 
-You can configure {prod-short} to expose JVM metrics such as JVM memory and class loading for {prod-short} Server.
+You can configure {prod-short} to expose JVM metrics such as JVM memory and class loading for {prod-short} Server. The {prod-short} Operator automatically configures Prometheus integration when metrics are enabled.
 
 include::partial$proc_enabling-and-exposing-che-metrics.adoc[leveloffset=+1]
 

--- a/modules/administration-guide/pages/monitoring-the-dev-workspace-operator.adoc
+++ b/modules/administration-guide/pages/monitoring-the-dev-workspace-operator.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
-:description: Monitoring the {devworkspace} Operator
-:keywords: administration-guide, monitoring-the-dev-workspace-operator
+:description: Monitoring the {devworkspace} Operator with Prometheus
+:keywords: administration-guide, monitoring-the-dev-workspace-operator, prometheus, metrics
 :navtitle: Monitoring the {devworkspace} Operator
 :page-aliases: .:monitoring-the-dev-workspace-operator.adoc
 
@@ -8,7 +8,7 @@
 [id="monitoring-the-dev-workspace-operator"]
 = Monitoring the {devworkspace} Operator
 
-You can configure the OpenShift in-cluster monitoring stack to scrape metrics exposed by the {devworkspace} Operator.
+You can configure the OpenShift in-cluster monitoring stack to scrape metrics exposed by the {devworkspace} Operator. The {prod-short} Operator automatically configures Prometheus integration when metrics are enabled.
 
 include::partial$proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc[leveloffset=+1]
 

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -15,88 +15,14 @@ To use the in-cluster Prometheus instance to collect, store, and query JVM metri
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the {prod-short} JVM metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: che-host
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - interval: 10s <2>
-      port: metrics
-      scheme: http
-  namespaceSelector:
-    matchNames:
-      - {prod-namespace} <1>
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {prod-deployment}
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
+The {prod-short} Operator automatically creates the following resources when metrics are enabled:
 
-. Create a Role and RoleBinding to allow Prometheus to view the metrics.
+* A `ServiceMonitor` named `{prod-host}` that detects the {prod-short} JVM metrics Service
+* A `Role` named `{prod-id-short}-prometheus` that grants permissions to access services, endpoints, and pods
+* A `RoleBinding` named `{prod-id-short}-prometheus` that binds the `prometheus-k8s` ServiceAccount from the `openshift-monitoring` namespace to the Role
+* The `openshift.io/cluster-monitoring: "true"` label on the {prod-short} namespace to enable the in-cluster Prometheus instance to detect the ServiceMonitor
 
-+
-.Role
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: prometheus-k8s
-  namespace: {prod-namespace} <1>
-rules:
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - services
-      - endpoints
-      - pods
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-+
-.RoleBinding
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: view-{prod-id-short}-openshift-monitoring-prometheus-k8s
-  namespace: {prod-namespace} <1>
-subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,terminal,subs="+attributes,quotes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+No manual configuration is required. The Prometheus resources are managed automatically by the {prod-short} Operator and will be removed when the `CheCluster` is deleted.
 
 .Verification
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -14,44 +14,14 @@ To use the in-cluster Prometheus instance to collect, store, and query metrics a
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the Dev Workspace Operator metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: devworkspace-controller
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 10s <2>
-      port: metrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-      - openshift-operators
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: devworkspace-controller
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
+The {prod-short} Operator automatically creates the following resources when metrics are enabled:
 
-include::example$snip_{project-context}-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc[]
+* A `ServiceMonitor` named `devworkspace-controller` that detects the {devworkspace} Operator metrics Service
+* A `Role` named `{prod-id-short}-prometheus` that grants permissions to access services, endpoints, and pods in the `openshift-operators` namespace
+* A `RoleBinding` named `{prod-id-short}-prometheus` that binds the `prometheus-k8s` ServiceAccount from the `openshift-monitoring` namespace to the Role
+* The `openshift.io/cluster-monitoring: "true"` label on the {prod-short} namespace to enable the in-cluster Prometheus instance to detect the ServiceMonitor
 
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,subs="+attributes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+No manual configuration is required. The Prometheus resources are managed automatically by the {prod-short} Operator and will be removed when the `CheCluster` is deleted.
 
 .Verification
 


### PR DESCRIPTION
## What does this pull request change?

Updated the monitoring procedures for both Che Server and DevWorkspace Operator to reflect that Prometheus resources (ServiceMonitor, Role, and RoleBinding) are now automatically managed by the Che Operator.

**Changes made:**
- Replaced manual ServiceMonitor, Role, and RoleBinding creation steps with information about automatic resource management
- Updated assembly file descriptions to mention automated Prometheus integration
- Added prometheus keyword to metadata

The procedures now correctly document that when metrics are enabled, the operator automatically creates all necessary Prometheus monitoring resources without requiring manual configuration.

**Files updated:**
- `modules/administration-guide/pages/monitoring-che.adoc`
- `modules/administration-guide/pages/monitoring-the-dev-workspace-operator.adoc`
- `modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc`
- `modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc`

## What issues does this pull request fix or reference?

https://github.com/eclipse-che/che-operator/pull/2117

This PR implements automated management of Prometheus monitoring resources, eliminating the need for manual configuration that was previously documented in the monitoring procedures.

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.