### PR TITLE
docs: Automatic Prometheus monitoring resource management

### DIFF
--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -9,93 +9,24 @@ To use the in-cluster Prometheus instance to collect, store, and query JVM metri
 
 * Your organization's instance of {prod-short} is installed and running in Red Hat OpenShift.
 
-* An active `oc` session with administrative permissions to the destination OpenShift cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI].
+* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 
 * {prod-short} is exposing metrics on port `8087`. See xref:enabling-and-exposing-{prod-id-short}-metrics[Enabling and exposing {prod-short} server JVM metrics].
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the {prod-short} JVM metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: che-host
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - interval: 10s <2>
-      port: metrics
-      scheme: http
-  namespaceSelector:
-    matchNames:
-      - {prod-namespace} <1>
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {prod-deployment}
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
+The {prod-operator} automatically creates the following resources when metrics are enabled:
 
-. Create a Role and RoleBinding to allow Prometheus to view the metrics.
+* A `ServiceMonitor` resource named `{prod-host}` for detecting the {prod-short} JVM metrics Service
+* A `Role` and `RoleBinding` granting the `prometheus-k8s` service account permission to scrape metrics endpoints in the {prod-namespace} namespace
 
-+
-.Role
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: prometheus-k8s
-  namespace: {prod-namespace} <1>
-rules:
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - services
-      - endpoints
-      - pods
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-+
-.RoleBinding
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: view-{prod-id-short}-openshift-monitoring-prometheus-k8s
-  namespace: {prod-namespace} <1>
-subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
+To complete the monitoring configuration:
 
 . Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
 +
 [source,terminal,subs="+attributes,quotes"]
 ----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
+$ {orch-cli} label namespace {prod-namespace} openshift.io/cluster-monitoring=true
 ----
 
 .Verification

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -8,49 +8,24 @@ To use the in-cluster Prometheus instance to collect, store, and query metrics a
 
 * Your organization's instance of {prod-short} is installed and running in Red Hat OpenShift.
 
-* An active `oc` session with administrative permissions to the destination OpenShift cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI].
+* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 
 * The `devworkspace-controller-metrics` Service is exposing metrics on port `8443`. This is preconfigured by default.
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the Dev Workspace Operator metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: devworkspace-controller
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 10s <2>
-      port: metrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-      - openshift-operators
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: devworkspace-controller
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
+The {prod-operator} automatically creates the following resources when metrics are enabled:
 
-include::example$snip_{project-context}-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc[]
+* A `ServiceMonitor` resource named `devworkspace` for detecting the {devworkspace} Operator metrics Service
+* A `Role` and `RoleBinding` granting the `prometheus-k8s` service account permission to scrape metrics endpoints in the `openshift-operators` namespace
+
+To complete the monitoring configuration:
 
 . Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
 +
 [source,subs="+attributes"]
 ----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
+$ {orch-cli} label namespace {prod-namespace} openshift.io/cluster-monitoring=true
 ----
 
 .Verification


### PR DESCRIPTION
## What does this pull request change?

Updated the monitoring procedures for both Che Server and DevWorkspace Operator to reflect that Prometheus resources (ServiceMonitor, Role, and RoleBinding) are now automatically managed by the Che Operator when metrics are enabled.

**Changes made:**
- Removed manual ServiceMonitor creation steps from both procedures
- Removed manual Role and RoleBinding creation steps from both procedures
- Added clarification that these resources are now automatically created by the operator
- Updated prerequisites to use attribute variables instead of hardcoded values

The procedures now correctly document that when metrics are enabled, the operator automatically creates all necessary Prometheus monitoring resources without requiring manual configuration of ServiceMonitors or RBAC.

**Files updated:**
- `modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc`
- `modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc`

## What issues does this pull request fix or reference?

https://github.com/eclipse-che/che-operator/pull/2117

This PR implements automated management of Prometheus monitoring resources, eliminating the need for manual configuration that was previously documented in the monitoring procedures.

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.