### PR TITLE
procedures: Update monitoring procedures for automated Prometheus resources

### DIFF
--- a/modules/administration-guide/pages/monitoring-che.adoc
+++ b/modules/administration-guide/pages/monitoring-che.adoc
@@ -1,13 +1,13 @@
 :_content-type: ASSEMBLY
 :description: Monitoring {prod-short} Server
-:keywords: administration-guide, monitoring-che
+:keywords: administration-guide, monitoring-che, prometheus, metrics
 :navtitle: Monitoring {prod-short} Server
 :page-aliases: .:monitoring-che.adoc, .:tracing-che.adoc, tracing-che.adoc
 
 [id="monitoring-{prod-id-short}"]
 = Monitoring {prod-short} Server
 
-You can configure {prod-short} to expose JVM metrics such as JVM memory and class loading for {prod-short} Server.
+You can configure {prod-short} to expose JVM metrics such as JVM memory and class loading for {prod-short} Server. The {prod-short} Operator automatically configures Prometheus monitoring resources when metrics are enabled.
 
 include::partial$proc_enabling-and-exposing-che-metrics.adoc[leveloffset=+1]
 

--- a/modules/administration-guide/pages/monitoring-the-dev-workspace-operator.adoc
+++ b/modules/administration-guide/pages/monitoring-the-dev-workspace-operator.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 :description: Monitoring the {devworkspace} Operator
-:keywords: administration-guide, monitoring-the-dev-workspace-operator
+:keywords: administration-guide, monitoring-the-dev-workspace-operator, prometheus, metrics
 :navtitle: Monitoring the {devworkspace} Operator
 :page-aliases: .:monitoring-the-dev-workspace-operator.adoc
 
@@ -8,7 +8,7 @@
 [id="monitoring-the-dev-workspace-operator"]
 = Monitoring the {devworkspace} Operator
 
-You can configure the OpenShift in-cluster monitoring stack to scrape metrics exposed by the {devworkspace} Operator.
+The {prod-short} Operator automatically configures the OpenShift in-cluster monitoring stack to scrape metrics exposed by the {devworkspace} Operator.
 
 include::partial$proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc[leveloffset=+1]
 

--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -3,100 +3,34 @@
 [id="collecting-{prod-id-short}-metrics-with-prometheus"]
 = Collecting {prod-short} Server metrics with Prometheus
 
-To use the in-cluster Prometheus instance to collect, store, and query JVM metrics for {prod-short} Server:
+The {prod-short} Operator automatically configures Prometheus monitoring when {prod-short} Server metrics are enabled. The operator creates a ServiceMonitor, RBAC resources, and applies the necessary namespace labels for the in-cluster Prometheus instance to collect, store, and query JVM metrics.
 
 .Prerequisites
 
 * Your organization's instance of {prod-short} is installed and running in Red Hat OpenShift.
 
-* An active `oc` session with administrative permissions to the destination OpenShift cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI].
+* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 
 * {prod-short} is exposing metrics on port `8087`. See xref:enabling-and-exposing-{prod-id-short}-metrics[Enabling and exposing {prod-short} server JVM metrics].
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the {prod-short} JVM metrics Service.
+. Verify that metrics are enabled in the `CheCluster` Custom Resource:
 +
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
+[source,yaml,subs="+attributes,+quotes"]
 ----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: che-host
-  namespace: {prod-namespace} <1>
 spec:
-  endpoints:
-    - interval: 10s <2>
-      port: metrics
-      scheme: http
-  namespaceSelector:
-    matchNames:
-      - {prod-namespace} <1>
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {prod-deployment}
+  components:
+    metrics:
+      enable: true
 ----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
-
-. Create a Role and RoleBinding to allow Prometheus to view the metrics.
-
 +
-.Role
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: prometheus-k8s
-  namespace: {prod-namespace} <1>
-rules:
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - services
-      - endpoints
-      - pods
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
+The {prod-short} Operator automatically creates the following resources in the `{prod-namespace}` namespace:
 +
-.RoleBinding
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: view-{prod-id-short}-openshift-monitoring-prometheus-k8s
-  namespace: {prod-namespace} <1>
-subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,terminal,subs="+attributes,quotes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+* ServiceMonitor named `{prod-host}` for scraping {prod-short} Server metrics
+* Role named `{prod-id-short}-prometheus` granting permissions to read services, endpoints, and pods
+* RoleBinding named `{prod-id-short}-prometheus` binding the `prometheus-k8s` service account from the `openshift-monitoring` namespace
+* Namespace label `openshift.io/cluster-monitoring=true` to enable cluster monitoring
 
 .Verification
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -2,56 +2,24 @@
 = Collecting {devworkspace} Operator metrics
 
 [role="_abstract"]
-To use the in-cluster Prometheus instance to collect, store, and query metrics about the {devworkspace} Operator:
+The {prod-short} Operator automatically configures Prometheus monitoring for the {devworkspace} Operator. The operator creates a ServiceMonitor, RBAC resources, and applies the necessary namespace labels for the in-cluster Prometheus instance to collect, store, and query metrics.
 
 .Prerequisites
 
 * Your organization's instance of {prod-short} is installed and running in Red Hat OpenShift.
 
-* An active `oc` session with administrative permissions to the destination OpenShift cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI].
+* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
 
 * The `devworkspace-controller-metrics` Service is exposing metrics on port `8443`. This is preconfigured by default.
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the Dev Workspace Operator metrics Service.
+. Verify that {prod-short} is installed. The {prod-short} Operator automatically creates the following resources in the `{prod-namespace}` namespace:
 +
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: devworkspace-controller
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 10s <2>
-      port: metrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-      - openshift-operators
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: devworkspace-controller
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
-
-include::example$snip_{project-context}-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc[]
-
-. Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
-+
-[source,subs="+attributes"]
-----
-$ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
-----
+* ServiceMonitor named `devworkspace` for scraping {devworkspace} Operator metrics from the `openshift-operators` namespace
+* Role named `{prod-id-short}-prometheus` granting permissions to read services, endpoints, and pods in the `openshift-operators` namespace
+* RoleBinding named `{prod-id-short}-prometheus` binding the `prometheus-k8s` service account from the `openshift-monitoring` namespace
+* Namespace label `openshift.io/cluster-monitoring=true` to enable cluster monitoring
 
 .Verification
 


### PR DESCRIPTION
## What does this pull request change?

This PR updates the monitoring procedures for both Che Server and DevWorkspace Operator to reflect the automated Prometheus resource management introduced in eclipse-che/che-operator#2117.

The Che Operator now automatically creates and manages ServiceMonitor, Role, and RoleBinding resources when metrics are enabled, eliminating the need for manual YAML creation and application.

**Updated procedures:**
- `proc_collecting-che-metrics-with-prometheus.adoc` - Removed manual ServiceMonitor/RBAC creation steps for Che Server
- `proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc` - Removed manual ServiceMonitor/RBAC creation steps for DevWorkspace Operator
- `monitoring-che.adoc` - Updated assembly description and added prometheus keyword
- `monitoring-the-dev-workspace-operator.adoc` - Updated assembly description and added prometheus keyword

**Key changes:**
- Removed all manual ServiceMonitor YAML creation steps
- Removed all manual Role and RoleBinding YAML creation steps
- Removed manual namespace labeling command (now automatic)
- Added verification steps explaining what resources are automatically created
- Updated prerequisites to use attribute variables (`{orch-cli}`, `{orch-cli-link}`)

## What issues does this pull request fix or reference?

- https://github.com/eclipse-che/che-operator/pull/2117
- https://redhat.atlassian.net/browse/CRW-8629
- https://redhat.atlassian.net/browse/CRW-8589
- https://redhat.atlassian.net/browse/CRW-8315

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.