### PR TITLE
procedures: Update Prometheus monitoring procedures for automated ServiceMonitor management

### DIFF
--- a/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-che-metrics-with-prometheus.adoc
@@ -3,7 +3,7 @@
 [id="collecting-{prod-id-short}-metrics-with-prometheus"]
 = Collecting {prod-short} Server metrics with Prometheus
 
-To use the in-cluster Prometheus instance to collect, store, and query JVM metrics for {prod-short} Server:
+The {prod-operator} automatically creates and manages a ServiceMonitor resource and the required RBAC permissions to enable the in-cluster Prometheus instance to collect, store, and query JVM metrics for {prod-short} Server.
 
 .Prerequisites
 
@@ -15,88 +15,14 @@ To use the in-cluster Prometheus instance to collect, store, and query JVM metri
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the {prod-short} JVM metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: che-host
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - interval: 10s <2>
-      port: metrics
-      scheme: http
-  namespaceSelector:
-    matchNames:
-      - {prod-namespace} <1>
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {prod-deployment}
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
-
-. Create a Role and RoleBinding to allow Prometheus to view the metrics.
-
-+
-.Role
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: prometheus-k8s
-  namespace: {prod-namespace} <1>
-rules:
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - services
-      - endpoints
-      - pods
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
-+
-.RoleBinding
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: view-{prod-id-short}-openshift-monitoring-prometheus-k8s
-  namespace: {prod-namespace} <1>
-subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: openshift-monitoring
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-====
-
 . Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
 +
 [source,terminal,subs="+attributes,quotes"]
 ----
 $ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
 ----
++
+NOTE: The {prod-operator} automatically creates the `che-host` ServiceMonitor and the required RBAC resources (Role and RoleBinding) to grant the `prometheus-k8s` service account permission to scrape metrics.
 
 .Verification
 

--- a/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
+++ b/modules/administration-guide/partials/proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc
@@ -2,7 +2,7 @@
 = Collecting {devworkspace} Operator metrics
 
 [role="_abstract"]
-To use the in-cluster Prometheus instance to collect, store, and query metrics about the {devworkspace} Operator:
+The {prod-operator} automatically creates and manages a ServiceMonitor resource and the required RBAC permissions to enable the in-cluster Prometheus instance to collect, store, and query metrics about the {devworkspace} Operator.
 
 .Prerequisites
 
@@ -14,44 +14,14 @@ To use the in-cluster Prometheus instance to collect, store, and query metrics a
 
 .Procedure
 
-. Create the ServiceMonitor for detecting the Dev Workspace Operator metrics Service.
-+
-.ServiceMonitor
-====
-[source,yaml,subs="+quotes,+attributes,+macros"]
-----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: devworkspace-controller
-  namespace: {prod-namespace} <1>
-spec:
-  endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 10s <2>
-      port: metrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-      - openshift-operators
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: devworkspace-controller
-----
-<1> The {prod-short} namespace. The default is `{prod-namespace}`.
-<2> The rate at which a target is scraped.
-====
-
-include::example$snip_{project-context}-create-a-role-and-rolebinding-for-prometheus-to-view-metrics.adoc[]
-
 . Allow the in-cluster Prometheus instance to detect the ServiceMonitor in the {prod-short} namespace. The default {prod-short} namespace is `{prod-namespace}`.
 +
 [source,subs="+attributes"]
 ----
 $ oc label namespace {prod-namespace} openshift.io/cluster-monitoring=true
 ----
++
+NOTE: The {prod-operator} automatically creates the `devworkspace-controller` ServiceMonitor and the required RBAC resources (Role and RoleBinding) in the `openshift-operators` namespace to grant the `prometheus-k8s` service account permission to scrape metrics.
 
 .Verification
 


### PR DESCRIPTION
## What does this pull request change?

This PR updates the Prometheus monitoring procedures to reflect that the che-operator now automatically manages ServiceMonitor resources and RBAC permissions. The changes simplify the monitoring setup process by removing manual resource creation steps.

**Specific changes:**
- Updated `proc_collecting-che-metrics-with-prometheus.adoc`: Removed manual ServiceMonitor and RBAC creation steps for Che Server metrics
- Updated `proc_collecting-dev-workspace-operator-metrics-with-prometheus.adoc`: Removed manual ServiceMonitor and RBAC creation steps for DevWorkspace Operator metrics
- Both procedures now explain that the operator automatically creates these resources
- Retained the namespace labeling requirement (`openshift.io/cluster-monitoring=true`) which is still a manual step

**Source PR:** https://github.com/eclipse-che/che-operator/pull/2117

This operator PR introduces automatic management of:
- ServiceMonitor for Che Server (`che-host`)
- ServiceMonitor for DevWorkspace Operator (`devworkspace-controller`)
- Role and RoleBinding granting prometheus-k8s service account permission to scrape metrics

## What issues does this pull request fix or reference?

- https://github.com/eclipse-che/che-operator/pull/2117

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.