### PR TITLE
fix: replace blocked preview sticky comment action

### DIFF
--- a/.github/workflows/preview-sticky-comment.yml
+++ b/.github/workflows/preview-sticky-comment.yml
@@ -18,10 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: create
-        uses: actions-cool/maintain-one-comment@v3
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: |
             ⚡️ Deploying pull request preview...
-            <!-- Sticky Pull Request Comment -->
-          body-include: "<!-- Sticky Pull Request Comment -->"


### PR DESCRIPTION
## Summary
- The `actions-cool/maintain-one-comment@v3` repository was [blocked by GitHub for a TOS violation](https://github.com/tos) on 2026-05-19
- All "Preview sticky comment" workflow runs have failed since that date with `Repository access blocked`
- Replaced with `marocchino/sticky-pull-request-comment@v2`, which provides the same sticky comment functionality

## Evidence
- Last successful run: 2026-05-18 (`jtbd-install-category` branch)
- First failure: 2026-05-19 (`docs-che-operator-2117-automated-prometheus` branch)
- GitHub API confirms: `{"reason": "tos", "created_at": "2026-05-19T00:34:15Z"}`

## Test plan
- [ ] Verify the "Preview sticky comment" check passes on this PR
- [ ] Verify a sticky comment is posted on the PR

Fixes: [CRW-11078](https://redhat.atlassian.net/browse/CRW-11078)

🤖 Generated with [Claude Code](https://claude.com/claude-code)