### PR TITLE
procedures: Update OpenShift Keycloak OIDC installation to reflect automatic detection

### DIFF
--- a/modules/administration-guide/pages/proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc
+++ b/modules/administration-guide/pages/proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc
@@ -1,6 +1,6 @@
 :_content-type: PROCEDURE
-:description: To manage user authentication through a centralized identity provider, deploy {prod-short} on OpenShift with {keycloak} as the external OIDC provider.
-:keywords: install, openshift, keycloak, oidc, identity provider
+:description: To manage user authentication through a centralized identity provider, deploy {prod-short} on OpenShift with {keycloak} as the external OIDC provider. {prod-short} automatically detects and configures OIDC settings from the OpenShift cluster authentication configuration.
+:keywords: install, openshift, keycloak, oidc, identity provider, automatic detection
 :navtitle: Install {prod-short} on OpenShift with {keycloak} as external identity provider
 :page-aliases: installing-che-on-openshift-with-keycloak-as-oidc.adoc
 
@@ -8,7 +8,7 @@
 = Install {prod-short} on OpenShift with {keycloak} as external identity provider
 
 [role="_abstract"]
-To manage user authentication through a centralized identity provider, deploy {prod-short} on an {orch-name} cluster with {keycloak} as the external OpenID Connect (OIDC) provider.
+To manage user authentication through a centralized identity provider, deploy {prod-short} on an {orch-name} cluster with {keycloak} as the external OpenID Connect (OIDC) provider. {prod-short} automatically detects and configures OIDC settings from the OpenShift cluster authentication configuration.
 
 .Prerequisites
 
@@ -17,17 +17,6 @@ To manage user authentication through a centralized identity provider, deploy {p
 * You have {keycloak} configured as an external identity provider for {orch-name}. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/authentication_and_authorization/external-auth[Enabling direct authentication with an external OIDC identity provider].
 
 .Procedure
-
-. Define the environment variables:
-+
-[source,bash,subs="+quotes,+attributes"]
-----
-# The {keycloak} realm used for {orch-name} authentication:
-OPENSHIFT_REALM=__<realm>__
-
-# The {keycloak} URL:
-KEYCLOAK_URL=__<keycloak_url>__
-----
 
 . Create a `{prod-id-short}` client in the {keycloak} Admin Console:
 +
@@ -103,25 +92,6 @@ where:
 +
 `__<client_secret>__`:: The client secret value from the `{prod-id-short}` client in {keycloak}.
 
-. Optional: Create the `ConfigMap` with a {keycloak} certificate in the `{prod-namespace}` namespace. If {keycloak} uses a certificate that is already trusted by {orch-name}, skip this step.
-+
-[source,bash,subs="+attributes"]
-----
-openssl s_client \
-  -connect "$(echo "$KEYCLOAK_URL" | sed 's|https://||'):443" \
-  -showcerts < /dev/null \
-| sed -n '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' \
-> keycloak-ca.crt
-
-{orch-cli} create configmap keycloak-certs \
-    --from-file=keycloak-ca.crt=keycloak-ca.crt \
-    -n {prod-namespace} && \
-{orch-cli} label configmap keycloak-certs \
-    app.kubernetes.io/part-of=che.eclipse.org \
-    app.kubernetes.io/component=ca-bundle \
-    -n {prod-namespace}
-----
-
 . Prepare the `CheCluster` patch:
 +
 [source,bash,subs="+attributes"]
@@ -134,7 +104,6 @@ spec:
     auth:
       oAuthClientName: {prod-id-short}
       oAuthSecret: oauth-secret
-      identityProviderURL: "$KEYCLOAK_URL/realms/$OPENSHIFT_REALM"
       gateway:
         oAuthProxy:
           cookieExpireSeconds: 300
@@ -144,37 +113,10 @@ spec:
               env:
                 - name: OAUTH2_PROXY_CODE_CHALLENGE_METHOD
                   value: S256
-                - name: OAUTH2_PROXY_BACKEND_LOGOUT_URL
-                  value: "$KEYCLOAK_URL/realms/$OPENSHIFT_REALM/protocol/openid-connect/logout?id_token_hint=\{id_token}"
-  components:
-    cheServer:
-      extraProperties:
-        CHE_OIDC_GROUPS__CLAIM: '<GROUPS_CLAIM>'
-        CHE_OIDC_GROUPS__PREFIX: '<GROUPS_PREFIX>'
-        CHE_OIDC_USERNAME__CLAIM: '<USERNAME_CLAIM>'
-        CHE_OIDC_USERNAME__PREFIX: '<USERNAME_PREFIX>'
 EOF
 ----
 +
-where:
-+
-`CHE_OIDC_GROUPS__CLAIM`:: The claim to use for extracting user groups.
-+
-`CHE_OIDC_GROUPS__PREFIX`:: The prefix to add to group names. Empty string means no prefix.
-+
-`CHE_OIDC_USERNAME__CLAIM`:: The claim to use for extracting the username.
-+
-`CHE_OIDC_USERNAME__PREFIX`:: The prefix to add to usernames. Empty string means no prefix.
-+
-[NOTE]
-====
-These values must match the corresponding claim and prefix settings configured in the `authentication.config/cluster` resource. To view the current cluster configuration, run:
-
-[source,bash,subs="+attributes"]
-----
-{orch-cli} get authentication.config/cluster -o yaml
-----
-====
+NOTE: {prod-short} automatically detects the identity provider URL, issuer certificate, and claim mappings from the OpenShift cluster authentication configuration. No manual configuration is required.
 
 . Create the {prod-short} instance with `{prod-cli}`:
 +


### PR DESCRIPTION
## What does this pull request change?

This PR updates the procedure for installing Eclipse Che on OpenShift with Keycloak as an external OIDC provider to reflect the automatic detection capabilities added in https://github.com/eclipse-che/che-operator/pull/2127.

The procedure has been simplified by removing manual configuration steps that are now automatically detected from the OpenShift cluster authentication configuration:
- Removed manual environment variable setup (KEYCLOAK_URL, OPENSHIFT_REALM)
- Removed manual certificate ConfigMap creation (now auto-detected from authentication.config/cluster)
- Removed manual claim mapping configuration (CHE_OIDC_GROUPS__CLAIM, CHE_OIDC_GROUPS__PREFIX, CHE_OIDC_USERNAME__CLAIM, CHE_OIDC_USERNAME__PREFIX)
- Simplified CheCluster patch to only include required OAuth client configuration

The operator now automatically reads authentication configuration from the OpenShift cluster's authentication.config/cluster resource, eliminating the need for manual configuration of issuer URL, CA certificates, and claim mappings.

## What issues does this pull request fix or reference?

- https://github.com/eclipse-che/che-operator/pull/2127
- https://github.com/eclipse-che/che/issues/23831

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.