### PR TITLE
fix: replace blocked action in publish-netlify workflow

### DIFF
--- a/.github/workflows/publish-netlify.yml
+++ b/.github/workflows/publish-netlify.yml
@@ -47,11 +47,9 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
       - name: Update status comment
-        uses: actions-cool/maintain-one-comment@v3
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            🎊 Navigate the preview: ${{ steps.netlify-publish.outputs.NETLIFY_URL }} 🎊
-            <!-- Sticky Pull Request Comment -->
-          body-include: "<!-- Sticky Pull Request Comment -->"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.vars.outputs.pr_number }}
+          message: |
+            🎊 Navigate the preview: ${{ steps.netlify-publish.outputs.NETLIFY_URL }} 🎊


### PR DESCRIPTION
## Summary
- The `publish-netlify.yml` workflow also uses `actions-cool/maintain-one-comment@v3` (in the "Update status comment" step), which was [blocked by GitHub for a TOS violation](https://github.com/tos) on 2026-05-19
- This is why Netlify previews are not being published — the blocked action kills the entire job at setup before any step runs, including the Netlify deploy
- Same fix as #3113: replace with `marocchino/sticky-pull-request-comment@v2`

## Context
Same root cause as #3113. All runs of this workflow have failed since 2026-05-19.

## Test plan
- [ ] After merge, push a commit to an open PR and verify the Netlify preview deploys
- [ ] Verify the sticky comment is updated with the preview URL

Related: [CRW-11078](https://redhat.atlassian.net/browse/CRW-11078)

🤖 Generated with [Claude Code](https://claude.com/claude-code)