### PR TITLE
docs: Document DevWorkspace Operator version requirements and validation

### DIFF
--- a/modules/administration-guide/pages/devworkspace-operator.adoc
+++ b/modules/administration-guide/pages/devworkspace-operator.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
-:description: {devworkspace} operator
-:keywords: administration-guide, workspace operator, devworkspace
+:description: {devworkspace} operator overview, version requirements, and validation
+:keywords: administration-guide, workspace operator, devworkspace, version requirements, validation
 :navtitle: {devworkspace} operator
 :page-aliases: .:devworkspace-operator.adoc
 
@@ -22,6 +22,37 @@ When creating a workspace with {prod-short} with a devfile, the {devworkspace} C
 A `DevWorkspaceTemplate` is a custom resource that defines a reusable `spec.template` for {devworkspace}s.
 
 When a workspace is started, DWO reads the corresponding {devworkspace} CR and creates the necessary resources such as deployments, secrets, configmaps, routes such that at the end a workspace pod representing the development environment defined in the devfile is created.
+
+== {devworkspace} Operator version requirements
+
+{prod-short} requires a minimum version of the {devworkspace} Operator to function correctly. The operator enforces this requirement through two validation gates:
+
+.Validation gates
+[cols="1,2,2",options="header"]
+|===
+| Gate | When it occurs | Behavior
+
+| Webhook validation
+| CheCluster CR creation
+| Prevents CheCluster creation if the {devworkspace} Operator is not installed. Returns error: `DevWorkspace Operator is not installed. Please install it before creating a CheCluster instance`
+
+| Reconciler version validation
+| CheCluster reconciliation
+| Blocks reconciliation if the installed {devworkspace} Operator version is below the minimum required version. Logs error and updates CheCluster status with message: `DevWorkspace Operator version <installed-version> is installed, but Eclipse Che requires version <minimum-version> or higher. Please upgrade the DevWorkspace Operator`
+|===
+
+IMPORTANT: The current minimum required {devworkspace} Operator version is 0.38.0. This requirement is validated at runtime rather than through package manager dependencies.
+
+.Verification
+
+To verify the installed {devworkspace} Operator version on OpenShift:
+
+[source,bash,subs="+quotes,+attributes"]
+----
+{orch-cli} get subscription -A -o json | jq -r '.items[] | select(.spec.package=="devworkspace-operator") | .status.installedCSV'
+----
+
+The output shows the installed Cluster Service Version (CSV), for example: `devworkspace-operator.v0.40.0`.
 
 .Custom Resources overview
 

--- a/modules/administration-guide/pages/proc_installing-che-on-openshift-using-the-web-console.adoc
+++ b/modules/administration-guide/pages/proc_installing-che-on-openshift-using-the-web-console.adoc
@@ -32,6 +32,8 @@ See link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/admi
 [IMPORTANT]
 ====
 The {prod} Operator depends on the {devworkspace} Operator. If you install the {prod} Operator manually to a non-default namespace, ensure that the {devworkspace} Operator is also installed in the same namespace. The Operator Lifecycle Manager installs the {devworkspace} Operator as a dependency within the {prod} Operator namespace. If the {devworkspace} Operator is already installed in a different namespace, two conflicting installations can result.
+
+{prod-short} requires {devworkspace} Operator version 0.38.0 or higher. The {prod-short} Operator validates this requirement at runtime and blocks CheCluster creation or reconciliation if the requirement is not met.
 ====
 +
 [IMPORTANT]


### PR DESCRIPTION
## What does this pull request change?

This PR documents the runtime version validation mechanism for the DevWorkspace Operator introduced in eclipse-che/che-operator#2076.

The following documentation updates are included:

- **New section in `devworkspace-operator.adoc`**: Explains the two-gate validation system (webhook and reconciler) that enforces DevWorkspace Operator installation and version requirements
- **Minimum version requirement**: Documents the requirement for DevWorkspace Operator version 0.38.0 or higher
- **Error messages**: Documents the specific error messages users will encounter when validation fails
- **Verification steps**: Provides commands for checking the installed DevWorkspace Operator version
- **Updated installation procedure**: Adds a note in `proc_installing-che-on-openshift-using-the-web-console.adoc` mentioning the version requirement

## What issues does this pull request fix or reference?

- eclipse-che/che-operator#2076

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *\`Validate language on files added or modified\`* step reports no vale warnings.