### PR TITLE
docs: Add cluster login step to Open VSX deployment procedures

### DIFF
--- a/modules/administration-guide/pages/proc_deploy-open-vsx-from-workspace.adoc
+++ b/modules/administration-guide/pages/proc_deploy-open-vsx-from-workspace.adoc
@@ -29,6 +29,9 @@ The link:https://github.com/eclipse-openvsx/openvsx/blob/master/.devfile.yaml[.d
 The environment, including all necessary commands, is defined in the `.devfile.yaml` file.
 ====
 
+. Login to the cluster from the workspace terminal:
+.. Navigate to *Terminal* -> *New Terminal*
+.. Execute: `$ oc login --token=<USER_TOKEN> --server=<CLUSTER_API_URL>`
 . Create a new project for Open VSX.
 +
 Run the `2.1. Create Namespace for OpenVSX` task in the workspace:

--- a/modules/administration-guide/pages/proc_deploy-open-vsx-from-workspace.adoc
+++ b/modules/administration-guide/pages/proc_deploy-open-vsx-from-workspace.adoc
@@ -29,7 +29,7 @@ The link:https://github.com/eclipse-openvsx/openvsx/blob/master/.devfile.yaml[.d
 The environment, including all necessary commands, is defined in the `.devfile.yaml` file.
 ====
 
-. Login to the cluster from the workspace terminal:
+. Login to the cluster as a cluster administrator from the workspace terminal:
 .. Navigate to *Terminal* -> *New Terminal*
 .. Execute: `$ oc login --token=<USER_TOKEN> --server=<CLUSTER_API_URL>`
 . Create a new project for Open VSX.

--- a/modules/administration-guide/partials/proc_adding-or-removing-extensions-in-a-workspace.adoc
+++ b/modules/administration-guide/partials/proc_adding-or-removing-extensions-in-a-workspace.adoc
@@ -13,8 +13,8 @@ The embedded plugin registry is deprecated. Setting up an internal, on-premises 
 
 .Prerequisites
 
-* You are logged in to your {prod-short} instance as an administrator.
 * You have started a workspace using the link:{plugin-registry-repo-url}[plugin registry repository].
+* You are logged in to the cluster as a cluster administrator from the workspace terminal: `$ oc login --token=<USER_TOKEN> --server=<CLUSTER_API_URL>`
 * You have created a link:https://access.redhat.com/terms-based-registry/[Red Hat Registry Service Account] and have the username and token available.
 * For IBM Power (`ppc64le`) and IBM Z (`s390x`) architectures, you must build the custom plugin registry locally on the corresponding hardware.
 * (Optional) You can rebuild the container based on the latest tag or SHA to get the latest security fixes after a {prod-short} update.


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Add explicit cluster login instructions to ensure users are authenticated before running Open VSX deployment tasks. This clarifies the authentication prerequisite and prevents common setup errors.

## What issues does this pull request fix or reference?
https://redhat.atlassian.net/browse/CRW-10980
## Specify the version of the product this pull request applies to

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
