### PR TITLE
fix: Remove overview duplication to restore JTBD navigation flow

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -5,7 +5,6 @@ version: next
 prerelease: true
 start_page: overview:introduction-to-eclipse-che.adoc
 nav:
-  - modules/overview/nav.adoc
   - modules/discover/nav.adoc
   - modules/install/nav.adoc
   - modules/end-user-guide/nav.adoc


### PR DESCRIPTION
## Problem

After merging PRs #3098 and #3102, the navigation has duplication where Introduction appears both:
- As a top-level Overview section
- Inside the Discover section (via cross-reference)

This violates the established JTBD methodology documented in CLAUDE.md.

## Solution

Remove `modules/overview/nav.adoc` from main navigation to restore proper JTBD flow where:
- **Discover is first** and includes Introduction + Hosted Che content via cross-references
- **Install is second** per SME feedback  
- No duplication in navigation

## JTBD Navigation Flow

```yaml
nav:
  - modules/discover/nav.adoc      # 🔍 FIRST - includes intro content
  - modules/install/nav.adoc       # ⚙️ SECOND - per SME feedback
  - modules/end-user-guide/nav.adoc
  - modules/administration-guide/nav.adoc
  - modules/extensions/nav.adoc
  - modules/glossary/nav.adoc
```

This follows the documented JTBD user journey: **Discover → Install → Use → Administer**

## Testing

- ✅ Introduction content still accessible via Discover section
- ✅ Start page still works (`start_page: overview:introduction-to-eclipse-che.adoc`)
- ✅ No broken links
- ✅ Proper user journey flow