### PR TITLE
docs: Document automatic DevWorkspace Operator TLS certificate configuration

### DIFF
--- a/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
+++ b/modules/administration-guide/pages/importing-untrusted-tls-certificates.adoc
@@ -14,6 +14,7 @@ Therefore, you must import into {prod-short} all untrusted CA chains in use by a
 * A proxy
 * An identity provider (OIDC)
 * A source code repositories provider (Git)
+* A parent devfile referenced via URI with untrusted TLS
 
 {prod-short} uses labeled ConfigMaps in {prod-short} {orch-namespace} as sources for TLS certificates.
 The ConfigMaps can have an arbitrary amount of keys with an arbitrary amount of certificates each.
@@ -39,6 +40,9 @@ spec:
 ====
 On OpenShift cluster, {prod-short} operator automatically adds Red Hat Enterprise Linux CoreOS (RHCOS) trust bundle into mounted certificates.
 ====
+
+When certificates are imported, the {prod-short} operator automatically configures the {devworkspace} Operator to trust these certificates by setting the `tlsCertificateConfigmapRef` field in the {devworkspace} Operator configuration to reference the `ca-certs-merged` ConfigMap.
+This enables the {devworkspace} Operator to trust the certificates when resolving parent devfile references via URI that use untrusted TLS certificates.
 
 .Prerequisites
 * An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster.
@@ -111,6 +115,24 @@ This command returns {prod-short} CA bundle certificates in PEM format:
 {orch-cli} get configmap ca-certs-merged \
     --namespace=__<workspace_namespace>__ \
     --output='jsonpath={.data.tls-ca-bundle\.pem}'
+----
+
+. Verify that the {devworkspace} Operator is configured to trust the imported certificates.
+This command returns the TLS certificate ConfigMap reference in the {devworkspace} Operator configuration:
++
+[subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
+----
+{orch-cli} get devworkspaceoperatorconfig \
+    --namespace={prod-namespace} \
+    devworkspace-config \
+    --output='jsonpath={.config.routing.tlsCertificateConfigmapRef}'
+----
++
+The output should show the reference to the `ca-certs-merged` ConfigMap:
++
+[subs="+attributes,+quotes",options="nowrap",role=white-space-pre]
+----
+{"name":"ca-certs-merged","namespace":"__<prod-namespace>__"}
 ----
 
 . Verify that the workspace pod mounts the `ca-certs-merged` ConfigMap:


### PR DESCRIPTION
## What does this pull request change?

Updates the "Importing untrusted TLS certificates" article to document that the Che operator automatically configures the DevWorkspace Operator to trust imported certificates. When certificates are imported via labeled ConfigMaps, the Che operator now automatically sets the `tlsCertificateConfigmapRef` field in the DevWorkspace Operator routing configuration to reference the `ca-certs-merged` ConfigMap. This enables the DevWorkspace Operator to resolve parent devfile references via URI that use untrusted TLS certificates.

**Changes made:**
- Added parent devfile URI with untrusted TLS to the list of external services requiring certificate import
- Added explanation of automatic DevWorkspace Operator configuration
- Added verification step to check the DevWorkspace Operator configuration

**Source PR:** https://github.com/eclipse-che/che-operator/pull/2137

## What issues does this pull request fix or reference?

- https://github.com/eclipse-che/che-operator/pull/2137
- https://github.com/eclipse-che/che/issues/23870

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.