### PR TITLE
fix: che callback url

### DIFF
--- a/modules/install/pages/proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc
+++ b/modules/install/pages/proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc
@@ -41,9 +41,8 @@ NOTE: Run the following command to obtain the `{prod}` redirect URL:
 [source,bash,subs="+quotes,+attributes"]
 ----
 echo "$(
-  {orch-cli} get checluster {prod-checluster} \
-    -n {prod-namespace} \
-    -o jsonpath='{.status.cheURL}'
+  oc whoami --show-console |
+  sed 's|console-openshift-console|{prod-id}|g'
 )/oauth/callback"
 ----
 


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/main/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Fixing how to figure out che callback url for external IDP

## What issues does this pull request fix or reference?
N/A

## Specify the version of the product this pull request applies to
main, 7.119.x

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [x] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
