### PR TITLE
fix: cherry-pick #3129 to 7.119.x — che callback url

### DIFF
--- a/modules/install/pages/proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc
+++ b/modules/install/pages/proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc
@@ -41,9 +41,8 @@ NOTE: Run the following command to obtain the `{prod}` redirect URL:
 [source,bash,subs="+quotes,+attributes"]
 ----
 echo "$(
-  {orch-cli} get checluster {prod-checluster} \
-    -n {prod-namespace} \
-    -o jsonpath='{.status.cheURL}'
+  oc whoami --show-console |
+  sed 's|console-openshift-console|{prod-id}|g'
 )/oauth/callback"
 ----
 


### PR DESCRIPTION
## What does this pull request change?

Cherry-pick of #3129 to the `7.119.x` release branch.

Fixes how to determine the Che callback URL for external IDP configuration: replaces the `checluster` status query with `oc whoami --show-console` + `sed`, which works before the cluster is fully deployed.

## What issues does this pull request fix or reference?

Backport of #3129.

## Specify the version of the product this pull request applies to

7.119.x

## Pull Request checklist

- [x] Successfully tested (same change as #3129, already tested by author).
- [x] the *`Validate language on files added or modified`* step reports no vale warnings.

Made with [Cursor](https://cursor.com)