### PR TITLE
fix: install asciidoctor-pdf gem for PDF generation in CI

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -72,6 +72,11 @@ RUN set -x \
     yq \
     && yq --version
 
+# Install asciidoctor-pdf (required by @antora/pdf-extension to generate PDFs)
+RUN set -x \
+    && gem install asciidoctor-pdf \
+    && asciidoctor-pdf --version
+
 # WORKDIR is a Node.js prerequisite
 WORKDIR /tmp
 # Avoid error: Local gulp not found in /projects


### PR DESCRIPTION
## Summary

- Install `asciidoctor-pdf` Ruby gem in the Containerfile

## Why

The `@antora/pdf-extension` (installed at `1.0.0-beta.14`) shells out to `asciidoctor-pdf` to convert assembled AsciiDoc files to PDF. This Ruby gem was never installed in the container, causing all PR checks to fail with:

```
FATAL (antora): ENOENT: no such file or directory, open
  'build/assembler-pdf/docs/next/_exports/discover.pdf'
```

This has been breaking all PR checks since the Discover module was added in #3098.

## What changed

| File | Change |
|------|--------|
| `Containerfile` | Added `gem install asciidoctor-pdf` after the Python packages step |

## Test plan

- [ ] Container builds successfully with the new gem
- [ ] `antora generate` produces PDF files in `build/assembler-pdf/`
- [ ] PR checks pass (Build and validate, Build and verify container)

Made with [Cursor](https://cursor.com)