### PR TITLE
fix: remove @antora/pdf-extension to unblock CI

### DIFF
--- a/antora-playbook-for-development.yml
+++ b/antora-playbook-for-development.yml
@@ -20,7 +20,6 @@ antora:
             snippet_length: 142
         -   require: '@antora/collector-extension' # Single-source content from engineering repositories, see https://gitlab.com/antora/antora-collector-extension
         -   require: ./extensions/htmltest.js # Test links in HTML, see https://docs.antora.org/antora/latest/extend/extension-tutorial/
-        -   require: '@antora/pdf-extension' # Generate monolithic AsciiDoc files, see  https://gitlab.com/antora/antora-assembler
 
 asciidoc:
     sourcemap: true


### PR DESCRIPTION
## Summary

- Remove `@antora/pdf-extension` from `antora-playbook-for-development.yml`

## Why

The `@antora/pdf-extension` requires `asciidoctor-pdf` (Ruby gem) to convert assembled AsciiDoc to PDF. This gem was never installed in the container. After the base image (`quay.io/podman/stable:latest`) updated, the extension started crashing with:

```
FATAL (antora): ENOENT: no such file or directory, open
  'build/assembler-pdf/docs/next/_exports/discover.pdf'
```

This breaks **all PR checks** — both "Build and validate pull request" and "Build and verify container".

PDFs are not served on the live site. The extension comment confirms it was used for "monolithic AsciiDoc files", not actual PDFs. The npm packages (`@antora/assembler`, `@antora/pdf-extension`) remain in the Containerfile for potential future use.

## Test plan

- [ ] "Build and validate pull request" check passes
- [ ] "Build and verify container" check passes
- [ ] Live site preview renders correctly on Netlify

Made with [Cursor](https://cursor.com)