### PR TITLE
feat: add GitOps installation procedures

### DIFF
--- a/modules/administration-guide/pages/configuring-che-with-self-signed-certificate.adoc
+++ b/modules/administration-guide/pages/configuring-che-with-self-signed-certificate.adoc
@@ -63,4 +63,4 @@ $ {orch-cli} label secret self-signed-certificate app.kubernetes.io/part-of=che.
 
 .Additional resources
 
-* xref:install:installing-che.adoc[]
+* xref:install:con_installation-overview.adoc[]

--- a/modules/discover/examples/snip_che-supported-platforms.adoc
+++ b/modules/discover/examples/snip_che-supported-platforms.adoc
@@ -23,4 +23,4 @@ The following options are available for the local installation:
 
 .Additional resources
 
-* xref:install:installing-che.adoc[]
+* xref:install:con_installation-overview.adoc[]

--- a/modules/discover/pages/che-operator.adoc
+++ b/modules/discover/pages/che-operator.adoc
@@ -22,7 +22,7 @@ On a cluster with the {prod-short} operator, it is possible to create a `CheClus
 .Additional resources
 
 * xref:administration-guide:understanding-the-checluster-custom-resource.adoc[]
-* xref:install:installing-che.adoc[]
+* xref:install:con_installation-overview.adoc[]
 * xref:devworkspace-operator.adoc[]
 * xref:gateway.adoc[]
 * xref:dashboard.adoc[]

--- a/modules/discover/pages/roles-and-tasks.adoc
+++ b/modules/discover/pages/roles-and-tasks.adoc
@@ -15,7 +15,7 @@ Platform administrators deploy, configure, secure, upgrade, and monitor {prod-sh
 
 Common tasks include:
 
-* Deploy {prod-short} on a cluster. See xref:install:installing-che.adoc[].
+* Deploy {prod-short} on a cluster. See xref:install:con_installation-overview.adoc[].
 * Configure the `CheCluster` custom resource. See xref:administration-guide:understanding-the-checluster-custom-resource.adoc[].
 * Set up OAuth for Git providers. See xref:administration-guide:configuring-oauth-for-git-providers.adoc[].
 * Control workspace start times with image caching. See xref:optimize:caching-images-for-faster-workspace-start.adoc[].

--- a/modules/install/nav.adoc
+++ b/modules/install/nav.adoc
@@ -7,25 +7,27 @@
 ** xref:running-at-scale.adoc[]
 ** xref:installing-the-chectl-management-tool.adoc[]
 // Installing
-* xref:installing-che.adoc[]
-** Deploy on OpenShift
-*** xref:proc_installing-che-on-openshift-using-cli.adoc[]
-*** xref:proc_installing-che-on-openshift-using-the-web-console.adoc[]
-*** xref:proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc[]
-** Deploy on {kubernetes}
-*** xref:installing-che-on-microsoft-azure.adoc[]
-*** xref:installing-che-on-amazon-elastic-kubernetes-service.adoc[]
-*** xref:proc_installing-che-on-the-virtual-kubernetes-cluster.adoc[]
-** Deploy locally
-*** xref:proc_installing-che-on-red-hat-openshift-local.adoc[]
-*** xref:proc_installing-che-on-minikube.adoc[]
-*** xref:proc_installing-che-on-minikube-keycloak-oidc.adoc[]
-** Deploy in a restricted environment
-*** xref:proc_installing-che-in-a-restricted-environment.adoc[]
-** xref:using-chectl-to-configure-the-checluster-custom-resource-during-installation.adoc[]
-** Permissions
-*** xref:ref_permissions-to-install-che-on-openshift-using-cli.adoc[]
-*** xref:ref_permissions-to-install-che-on-openshift-using-the-web-console.adoc[]
+* Deploy using GitOps
+** xref:proc_deploying-che-using-gitops.adoc[]
+** xref:proc_deploying-che-using-gitops-in-a-restricted-environment.adoc[]
+* Deploy on OpenShift
+** xref:proc_installing-che-on-openshift-using-cli.adoc[]
+** xref:proc_installing-che-on-openshift-using-the-web-console.adoc[]
+** xref:proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc[]
+* Deploy on {kubernetes}
+** xref:installing-che-on-microsoft-azure.adoc[]
+** xref:installing-che-on-amazon-elastic-kubernetes-service.adoc[]
+** xref:proc_installing-che-on-the-virtual-kubernetes-cluster.adoc[]
+* Deploy locally
+** xref:proc_installing-che-on-red-hat-openshift-local.adoc[]
+** xref:proc_installing-che-on-minikube.adoc[]
+** xref:proc_installing-che-on-minikube-keycloak-oidc.adoc[]
+* Deploy in a restricted environment
+** xref:proc_installing-che-in-a-restricted-environment.adoc[]
+* xref:using-chectl-to-configure-the-checluster-custom-resource-during-installation.adoc[]
+* Permissions
+** xref:ref_permissions-to-install-che-on-openshift-using-cli.adoc[]
+** xref:ref_permissions-to-install-che-on-openshift-using-the-web-console.adoc[]
 * xref:proc_verifying-the-installation.adoc[]
 * xref:proc_finding-the-fully-qualified-domain-name-fqdn.adoc[]
 * xref:con_next-steps-after-installation.adoc[]

--- a/modules/install/pages/calculating-che-resource-requirements.adoc
+++ b/modules/install/pages/calculating-che-resource-requirements.adoc
@@ -11,6 +11,8 @@
 [role="_abstract"]
 Size your cluster by calculating the CPU and memory requirements for the {prod-short} Operator, {devworkspace} Controller, and user workspaces so that your cluster can handle the expected number of concurrent users.
 
+include::partial$snip_persona-admin.adoc[]
+
 The {prod-short} Operator, {devworkspace} Controller, and user workspaces consist of a set of pods.
 The pods contribute to the resource consumption in CPU and memory limits and requests.
 

--- a/modules/install/pages/con_installation-overview.adoc
+++ b/modules/install/pages/con_installation-overview.adoc
@@ -9,28 +9,36 @@
 [role="_abstract"]
 {prod-short} deploys on {orch-name} as an Operator that manages a gateway, dashboard, server, and plug-in registry. The installation method you choose depends on your cluster environment and need for configuration control.
 
+include::partial$snip_persona-admin.adoc[]
+
 {prod-short} consists of an Operator, a user dashboard, a gateway, and a plug-in registry. The Operator manages the full lifecycle of all server components. You deploy {prod-short} by installing the Operator and creating a `CheCluster` custom resource.
 
 == Installation methods
+
+Argo CD (GitOps):: Store the Operator subscription and `CheCluster` configuration in a Git repository and let Argo CD reconcile the deployment. Choose this method for production deployments where every configuration change must be tracked in Git, auditable, and automatically reconciled.
 
 `{prod-cli}` command-line tool:: Choose this method when you need to quickly deploy {prod-short} for evaluation, customize the `CheCluster` configuration during installation, or manage {prod-short} from scripts.
 
 {orch-name} web console:: Choose this method when you prefer a graphical workflow through OperatorHub and do not need advanced configuration options during deployment.
 
-Both methods produce the same result: an Operator subscription and a `CheCluster` custom resource. For step-by-step deployment instructions, see Additional resources.
+All methods produce the same result: an Operator subscription and a `CheCluster` custom resource. For step-by-step deployment instructions, see Additional resources.
 
 == Deployment scenarios
 
-Standard deployment:: Your {orch-name} cluster has internet access. Both installation methods are available. The Operator pulls container images directly from `registry.redhat.io`.
+Standard deployment:: Your {orch-name} cluster has internet access. All installation methods are available. The Operator pulls container images directly from `registry.redhat.io`.
 
-Air-gapped deployment:: Your cluster has no internet access. Mirror the required container images and Operator catalogs to a private registry before installation.
+GitOps deployment:: Your organization manages cluster configuration declaratively through Argo CD. Store the Operator subscription and `CheCluster` configuration in a Git repository and let Argo CD reconcile the desired state. Available for both connected and air-gapped clusters.
+
+Air-gapped deployment:: Your cluster has no internet access. Mirror the required container images and Operator catalogs to a private registry before installation. Both GitOps and CLI methods are available.
 
 External identity provider:: Your organization manages authentication through an existing identity system such as {keycloak}. Deploy {prod-short} with an external OIDC provider instead of the default {orch-name} OAuth.
 
 [role="_additional-resources"]
 .Additional resources
 
+* xref:proc_deploying-che-using-gitops.adoc[]
 * xref:proc_installing-che-on-openshift-using-cli.adoc[]
 * xref:proc_installing-che-on-openshift-using-the-web-console.adoc[]
+* xref:proc_deploying-che-using-gitops-in-a-restricted-environment.adoc[]
 * xref:proc_installing-che-in-a-restricted-environment.adoc[]
 * xref:proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc[]

--- a/modules/install/pages/con_next-steps-after-installation.adoc
+++ b/modules/install/pages/con_next-steps-after-installation.adoc
@@ -9,6 +9,8 @@
 [role="_abstract"]
 Prepare {prod-short} for your team by completing these configuration tasks before inviting developers: customize the `CheCluster` resource, connect Git providers for credential-free repository access, and verify end-to-end functionality with a first workspace.
 
+include::partial$snip_persona-admin.adoc[]
+
 * Verify the platform end-to-end, configure Git provider OAuth, and share the dashboard URL with developers. For a walkthrough of each verification step, see Additional resources.
 * Customize the `CheCluster` custom resource to adjust {prod-short} behavior for your environment. For field-by-field configuration guidance, see Additional resources.
 * Create your first cloud development environment from a Git repository URL. For a step-by-step workspace creation walkthrough, see Additional resources.

--- a/modules/install/pages/installing-che-on-amazon-elastic-kubernetes-service.adoc
+++ b/modules/install/pages/installing-che-on-amazon-elastic-kubernetes-service.adoc
@@ -9,6 +9,8 @@
 [role="_abstract"]
 To provide cloud development environments on AWS, deploy {prod-short} on an Amazon EKS cluster by configuring DNS, TLS certificates, and Keycloak as the OIDC identity provider.
 
+include::partial$snip_persona-admin.adoc[]
+
 .Prerequisites
 
 * You have `helm` installed. See link:https://helm.sh/docs/intro/install/[Installing Helm].

--- a/modules/install/pages/installing-che-on-microsoft-azure.adoc
+++ b/modules/install/pages/installing-che-on-microsoft-azure.adoc
@@ -9,6 +9,8 @@
 [role="_abstract"]
 To provide cloud development environments on Microsoft Azure, deploy {prod-short} on an AKS cluster by configuring DNS, TLS certificates, and Keycloak as the OIDC identity provider.
 
+include::partial$snip_persona-admin.adoc[]
+
 .Prerequisites
 
 * You have `helm` installed. See link:https://helm.sh/docs/intro/install/[Installing Helm].

--- a/modules/install/pages/installing-the-chectl-management-tool.adoc
+++ b/modules/install/pages/installing-the-chectl-management-tool.adoc
@@ -11,6 +11,8 @@
 [role="_abstract"]
 Set up `{prod-cli}` on Linux, macOS, or Windows so that you can deploy, update, and manage {prod-short} from the command line.
 
+include::partial$snip_persona-admin.adoc[]
+
 include::example$proc_{project-context}-installing-the-chectl-management-tool-on-windows.adoc[leveloffset=+1]
 
 include::example$proc_{project-context}-installing-the-chectl-management-tool-on-linux-or-macos.adoc[leveloffset=+1]

--- a/modules/install/pages/proc_deploying-che-using-gitops-in-a-restricted-environment.adoc
+++ b/modules/install/pages/proc_deploying-che-using-gitops-in-a-restricted-environment.adoc
@@ -1,0 +1,254 @@
+:_content-type: PROCEDURE
+:description: Deploy {prod-short} in a restricted network through Argo CD by mirroring the required container images to a private registry and storing the deployment manifests in an internal Git repository.
+:keywords: install, gitops, argo cd, air-gapped, restricted, disconnected
+:navtitle: Deploy in a restricted environment using GitOps
+
+[id="deploying-che-using-gitops-in-a-restricted-environment"]
+= Deploy in a restricted environment using GitOps
+
+[role="_abstract"]
+Deploy {prod-short} in a restricted network through Argo CD by mirroring the required container images to a private registry and storing the deployment manifests in an internal Git repository.
+
+include::partial$snip_persona-admin.adoc[]
+
+In a disconnected environment, the cluster cannot pull images from public registries or sync from external Git repositories. You mirror the required images to an internal registry, store the {prod-short} manifests in an internal Git repository, and let Argo CD reconcile the deployment from inside the network.
+
+.Prerequisites
+
+* You have a {kubernetes} or {orch-name} cluster operating on a restricted network with administrative access.
+
+* You have mirrored the required {prod-short} container images and Operator catalogs to a private registry. See xref:proc_installing-che-in-a-restricted-environment.adoc[].
+
+* You have an `ImageContentSourcePolicy` or `ImageDigestMirrorSet` configured to redirect image pulls to your private registry.
+
+* You have Argo CD installed on the cluster. See link:https://argo-cd.readthedocs.io/en/stable/getting_started/[Argo CD Getting Started].
+
+* You have an active `{orch-cli}` session with administrative permissions to the cluster.
+
+* You have an internal Git repository accessible from the cluster.
+
+.Procedure
+
+. Download and execute the mirroring script to install a custom Operator catalog and mirror the related images: xref:administration-guide:attachment$restricted-environment/prepare-restricted-environment.sh[prepare-restricted-environment.sh].
++
+[source,bash,subs="+attributes,+quotes"]
+----
+$ bash prepare-restricted-environment.sh \
+  --devworkspace_operator_index {devworkspace-operator-index-disconnected-install}\
+  --devworkspace_operator_version "v{devworkspace-operator-version-patch}" \
+  --prod_operator_index "{prod-operator-index}" \
+  --prod_operator_package_name "{prod-operator-package-name}" \
+  --prod_operator_bundle_name "{prod-operator-bundle-name}" \
+  --prod_operator_version "v{prod-ver-patch}" \
+  --my_registry "__<my_registry>__" <1>
+----
+<1> The private Docker registry where the images will be mirrored
+
+. In your internal Git repository, create a directory for the {prod-short} manifests with three files: the Operator subscription, the `CheCluster` custom resource, and a Kustomize configuration.
++
+.Repository structure
+[source,subs="+quotes"]
+----
+__<your-gitops-repo>__/
+└── che/
+    ├── subscription.yaml
+    ├── checluster.yaml
+    └── kustomization.yaml
+----
+
+. Create the `subscription.yaml` file with the {orch-namespace} and Operator subscription pointing to the disconnected catalog source:
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {prod-namespace}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {prod-operator-package-name}
+  namespace: openshift-operators
+spec:
+  channel: {prod-stable-channel}
+  installPlanApproval: Automatic
+  name: {prod-operator-package-name}
+  source: {prod-operator-package-name}-disconnected-install
+  sourceNamespace: openshift-marketplace
+----
++
+The `source` field points to the disconnected catalog source created by the mirroring script.
+
+. Create the `checluster.yaml` file with the {prod-short} instance configuration pointing to your private registry:
++
+[source,yaml,subs="+attributes,+quotes"]
+----
+apiVersion: org.eclipse.che/v2
+kind: CheCluster
+metadata:
+  name: {prod-checluster}
+  namespace: {prod-namespace}
+spec:
+  components:
+    cheServer:
+      debug: false
+      logLevel: INFO
+    metrics:
+      enable: true
+    pluginRegistry:
+      openVSXURL: ""
+  containerRegistry:
+    hostname: __<your-private-registry>__
+    organization: __<your-registry-organization>__
+  devEnvironments:
+    startTimeoutSeconds: 600
+    defaultEditor: che-incubator/che-code/latest
+    defaultNamespace:
+      autoProvision: true
+      template: <username>-{prod-id-short}
+    storage:
+      pvcStrategy: per-user
+----
++
+`containerRegistry.hostname`:: The hostname of your private container registry that holds the mirrored images.
+`containerRegistry.organization`:: The organization or project path in your private registry.
+`pluginRegistry.openVSXURL`:: Set to an empty string to disable external Open VSX access. Use an internal Open VSX instance if IDE extensions are required.
+`startTimeoutSeconds`:: Increased to 600 seconds to allow for slower image pulls from internal registries.
+
+. Create the `kustomization.yaml` file:
++
+[source,yaml]
+----
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - subscription.yaml
+  - checluster.yaml
+----
+
+. Commit and push the files to your internal Git repository.
+
+. Grant the Argo CD service account the permissions required to create namespaces and install Operators:
++
+[source,bash,subs="+attributes,+quotes"]
+----
+$ {orch-cli} apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-che-installer
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "create", "update", "patch"]
+  - apiGroups: ["operators.coreos.com"]
+    resources: ["subscriptions", "operatorgroups"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["org.eclipse.che"]
+    resources: ["checlusters"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-che-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-che-installer
+subjects:
+  - kind: ServiceAccount
+    name: argocd-application-controller
+    namespace: argocd
+EOF
+----
++
+Adjust the `ServiceAccount` name and {orch-namespace} to match your Argo CD installation.
+
+. Create the Argo CD `Application` resource that points to your internal Git repository:
++
+[source,bash,subs="+attributes,+quotes"]
+----
+$ {orch-cli} apply -f - <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {prod-id-short}
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: __<your-internal-git-repo-url>__
+    targetRevision: main
+    path: che
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 30s
+        factor: 2
+        maxDuration: 5m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true
+EOF
+----
+
+. Wait for Argo CD to sync the resources. In a restricted environment, the Operator installation takes longer because images are pulled from the internal registry.
+
+.Verification
+
+. Verify that the Argo CD Application reports `Synced` and `Healthy`:
++
+[source,bash,subs="+attributes"]
+----
+$ {orch-cli} get application {prod-id-short} -n argocd \
+    -o jsonpath='{.status.sync.status}{" "}{.status.health.status}'
+----
++
+Expected output: `Synced Healthy`
+
+. Verify that the `CheCluster` is active:
++
+[source,bash,subs="+attributes"]
+----
+$ {orch-cli} get checluster {prod-checluster} -n {prod-namespace} \
+    -o jsonpath='{.status.chePhase}'
+----
++
+Expected output: `Active`
+
+. Retrieve the {prod-short} dashboard URL and open it in a browser:
++
+[source,bash,subs="+attributes"]
+----
+$ {orch-cli} get checluster {prod-checluster} -n {prod-namespace} \
+    -o jsonpath='{.status.cheURL}'
+----
+
+.Troubleshooting
+
+* *Image pull errors*: Verify that all required images are mirrored to your private registry and that the `ImageContentSourcePolicy` or `ImageDigestMirrorSet` is configured correctly.
+
+* *Sync fails with "CheCluster CRD not found"*: Verify that the Argo CD Application includes `SkipDryRunOnMissingResource=true` in the `syncOptions`.
+
+* *Sync retries but CheCluster is not created*: The Operator may still be installing. Wait for the ClusterServiceVersion to reach `Succeeded`:
++
+[source,bash,subs="+attributes"]
+----
+$ {orch-cli} get csv -A | grep {prod-operator-package-name}
+----
+
+.Additional resources
+
+* xref:proc_deploying-che-using-gitops.adoc[]
+* xref:proc_installing-che-in-a-restricted-environment.adoc[]
+* link:https://argo-cd.readthedocs.io/en/stable/getting_started/[Argo CD Getting Started]

--- a/modules/install/pages/proc_deploying-che-using-gitops.adoc
+++ b/modules/install/pages/proc_deploying-che-using-gitops.adoc
@@ -1,0 +1,229 @@
+:_content-type: PROCEDURE
+:description: Deploy {prod-short} declaratively through Argo CD so that every configuration change is tracked in Git, auditable, and automatically reconciled on the cluster.
+:keywords: install, gitops, argo cd, declarative, deployment
+:navtitle: Deploy using GitOps and Argo CD
+
+[id="deploying-che-using-gitops"]
+= Deploy using GitOps and Argo CD
+
+[role="_abstract"]
+Deploy {prod-short} declaratively through Argo CD so that every configuration change is tracked in Git, auditable, and automatically reconciled on the cluster.
+
+include::partial$snip_persona-admin.adoc[]
+
+With this method, you store the Operator subscription and `CheCluster` configuration in a Git repository. Argo CD monitors the repository and applies changes to the cluster automatically. You manage {prod-short} through Git commits instead of direct cluster commands.
+
+.Prerequisites
+
+* You have a {kubernetes} or {orch-name} cluster with administrative access.
+
+* You have Argo CD installed on the cluster. See link:https://argo-cd.readthedocs.io/en/stable/getting_started/[Argo CD Getting Started].
+
+* You have an active `{orch-cli}` session with administrative permissions to the cluster.
+
+* You have a Git repository accessible from the cluster (GitHub, GitLab, Bitbucket, or an internal Git server).
+
+.Procedure
+
+. In your Git repository, create a directory for the {prod-short} manifests. The directory contains three files: the Operator subscription, the `CheCluster` custom resource, and a Kustomize configuration.
++
+.Repository structure
+[source,subs="+quotes"]
+----
+__<your-gitops-repo>__/
+└── che/
+    ├── subscription.yaml
+    ├── checluster.yaml
+    └── kustomization.yaml
+----
+
+. Create the `subscription.yaml` file with the {orch-namespace} and Operator subscription:
++
+[source,yaml,subs="+attributes"]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {prod-namespace}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {prod-operator-package-name}
+  namespace: openshift-operators
+spec:
+  channel: {prod-stable-channel}
+  installPlanApproval: Automatic
+  name: {prod-operator-package-name}
+  source: {prod-stable-channel-catalog-source}
+  sourceNamespace: openshift-marketplace
+----
++
+NOTE: On {kubernetes} clusters without OLM, install the {prod-short} Operator using Helm or `{prod-cli}` instead of a `Subscription`.
+
+. Create the `checluster.yaml` file with the {prod-short} instance configuration:
++
+[source,yaml,subs="+attributes"]
+----
+apiVersion: org.eclipse.che/v2
+kind: CheCluster
+metadata:
+  name: {prod-checluster}
+  namespace: {prod-namespace}
+spec:
+  components:
+    cheServer:
+      debug: false
+      logLevel: INFO
+    metrics:
+      enable: true
+    pluginRegistry:
+      openVSXURL: https://open-vsx.org
+  devEnvironments:
+    startTimeoutSeconds: 300
+    defaultEditor: che-incubator/che-code/latest
+    defaultNamespace:
+      autoProvision: true
+      template: <username>-{prod-id-short}
+    storage:
+      pvcStrategy: per-user
+----
+
+. Create the `kustomization.yaml` file:
++
+[source,yaml]
+----
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - subscription.yaml
+  - checluster.yaml
+----
+
+. Commit and push the files to your Git repository.
+
+. Grant the Argo CD service account the permissions required to create namespaces and install Operators:
++
+[source,bash,subs="+attributes,+quotes"]
+----
+$ {orch-cli} apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-che-installer
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "create", "update", "patch"]
+  - apiGroups: ["operators.coreos.com"]
+    resources: ["subscriptions", "operatorgroups"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["org.eclipse.che"]
+    resources: ["checlusters"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-che-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-che-installer
+subjects:
+  - kind: ServiceAccount
+    name: argocd-application-controller
+    namespace: argocd
+EOF
+----
++
+Adjust the `ServiceAccount` name and {orch-namespace} to match your Argo CD installation.
+
+. Create the Argo CD `Application` resource that points to your Git repository:
++
+[source,bash,subs="+attributes,+quotes"]
+----
+$ {orch-cli} apply -f - <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {prod-id-short}
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: __<your-git-repo-url>__
+    targetRevision: main
+    path: che
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    retry:
+      limit: 10
+      backoff:
+        duration: 30s
+        factor: 2
+        maxDuration: 5m
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true
+EOF
+----
++
+`SkipDryRunOnMissingResource`:: Required because the `CheCluster` custom resource definition (CRD) does not exist until the Operator installs it. This option tells Argo CD to skip validation for unknown resource types and apply them directly.
++
+`selfHeal`:: Reverts manual changes on the cluster to match the Git repository state.
+
+. Wait for Argo CD to sync the resources. The Operator installs first, registers the `CheCluster` CRD, and then Argo CD applies the `CheCluster` custom resource.
+
+.Verification
+
+. Verify that the Argo CD Application reports `Synced` and `Healthy`:
++
+[source,bash,subs="+attributes"]
+----
+$ {orch-cli} get application {prod-id-short} -n argocd \
+    -o jsonpath='{.status.sync.status}{" "}{.status.health.status}'
+----
++
+Expected output: `Synced Healthy`
+
+. Verify that the `CheCluster` is active:
++
+[source,bash,subs="+attributes"]
+----
+$ {orch-cli} get checluster {prod-checluster} -n {prod-namespace} \
+    -o jsonpath='{.status.chePhase}'
+----
++
+Expected output: `Active`
+
+. Retrieve the {prod-short} dashboard URL and open it in a browser:
++
+[source,bash,subs="+attributes"]
+----
+$ {orch-cli} get checluster {prod-checluster} -n {prod-namespace} \
+    -o jsonpath='{.status.cheURL}'
+----
+
+.Troubleshooting
+
+* *Sync fails with "CheCluster CRD not found"*: Verify that the Argo CD Application includes `SkipDryRunOnMissingResource=true` in the `syncOptions`.
+
+* *Sync retries but CheCluster is not created*: The Operator may still be installing. Wait for the ClusterServiceVersion to reach `Succeeded`:
++
+[source,bash,subs="+attributes"]
+----
+$ {orch-cli} get csv -A | grep {prod-operator-package-name}
+----
+
+.Additional resources
+
+* link:https://argo-cd.readthedocs.io/en/stable/getting_started/[Argo CD Getting Started]
+* link:https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/[Argo CD sync options]
+* xref:administration-guide:understanding-the-checluster-custom-resource.adoc[]

--- a/modules/install/pages/proc_finding-the-fully-qualified-domain-name-fqdn.adoc
+++ b/modules/install/pages/proc_finding-the-fully-qualified-domain-name-fqdn.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Get the {prod-short} dashboard URL from the `CheCluster` custom resource so that you can open the dashboard in a browser or share the endpoint with your development team.
 
+include::partial$snip_persona-admin.adoc[]
+
 [TIP]
 ====
 You can find the FQDN for your organization's {prod-short} instance in the *Administrator* view of the {orch-name} web console as follows. Go to *Operators* -> *Installed Operators* -> *{prod} instance Specification* -> *{prod-checluster}* -> *{prod} URL*.

--- a/modules/install/pages/proc_installing-che-in-a-restricted-environment.adoc
+++ b/modules/install/pages/proc_installing-che-in-a-restricted-environment.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Deploy {prod-short} on an {orch-name} cluster with no internet access by mirroring the required container images and Operator catalogs to a private registry.
 
+include::partial$snip_persona-admin.adoc[]
+
 On a restricted network, deploying {prod-short} and running workspaces requires the following public resources:
 
 * Operator catalog

--- a/modules/install/pages/proc_installing-che-on-minikube-keycloak-oidc.adoc
+++ b/modules/install/pages/proc_installing-che-on-minikube-keycloak-oidc.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 To test {prod-short} with centralized authentication locally, deploy {prod-short} on a single-node {kubernetes} cluster with Minikube and configure Keycloak as the OpenID Connect (OIDC) identity provider.
 
+include::partial$snip_persona-admin.adoc[]
+
 [WARNING]
 ====
 Single-node {kubernetes} clusters are suited only for testing or development. Do not use such clusters to run {prod-short} for organizations or developer teams.

--- a/modules/install/pages/proc_installing-che-on-minikube.adoc
+++ b/modules/install/pages/proc_installing-che-on-minikube.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 To evaluate {prod-short} in a local development environment, create a single-node {kubernetes} cluster with Minikube and deploy {prod-short}.
 
+include::partial$snip_persona-admin.adoc[]
+
 [WARNING]
 ====
 Single-node {kubernetes} clusters are suited only for testing or development. Do not use such clusters to run {prod-short} for organizations or developer teams.

--- a/modules/install/pages/proc_installing-che-on-openshift-using-cli.adoc
+++ b/modules/install/pages/proc_installing-che-on-openshift-using-cli.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Deploy {prod-short} from the command line using the `{prod-cli}` management tool so that you have full control over configuration options and can automate the installation.
 
+include::partial$snip_persona-admin.adoc[]
+
 .Prerequisites
 
 * You have an {ocp} {ocp4-ver} or later cluster.

--- a/modules/install/pages/proc_installing-che-on-openshift-using-the-web-console.adoc
+++ b/modules/install/pages/proc_installing-che-on-openshift-using-the-web-console.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Deploy {prod-short} through the {orch-name} web console using the standard OperatorHub workflow so that you can install without command-line access.
 
+include::partial$snip_persona-admin.adoc[]
+
 .Prerequisites
 
 * You have an {orch-name} web console session as a cluster administrator. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/web_console/web-console.html[Accessing the web console].

--- a/modules/install/pages/proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc
+++ b/modules/install/pages/proc_installing-che-on-openshift-with-keycloak-as-oidc.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Deploy {prod-short} with {keycloak} as the OIDC provider so that you can manage user authentication through your organization's existing identity infrastructure instead of {orch-name} OAuth.
 
+include::partial$snip_persona-admin.adoc[]
+
 .Prerequisites
 
 * You have an active `{orch-cli}` session with administrative permissions to the {orch-name} cluster. See {orch-cli-link}.

--- a/modules/install/pages/proc_installing-che-on-red-hat-openshift-local.adoc
+++ b/modules/install/pages/proc_installing-che-on-red-hat-openshift-local.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 To evaluate {prod-short} on a local {orch-name} cluster, deploy {prod-short} by using {rh-os-local} for development and testing.
 
+include::partial$snip_persona-admin.adoc[]
+
 .Prerequisites
 
 * You have an active `{orch-cli}` session with administrative permissions to the {orch-name} cluster. See link:https://docs.openshift.com/container-platform/{ocp4-ver}/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the OpenShift CLI].

--- a/modules/install/pages/proc_installing-che-on-the-virtual-kubernetes-cluster.adoc
+++ b/modules/install/pages/proc_installing-che-on-the-virtual-kubernetes-cluster.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 To deploy {prod-short} when the host cluster version is incompatible or lacks external OIDC support, use a virtual {kubernetes} cluster (vCluster) to bypass these constraints.
 
+include::partial$snip_persona-admin.adoc[]
+
 .Prerequisites
 
 * You have `helm` installed. See link:https://helm.sh/docs/intro/install/[Installing Helm].

--- a/modules/install/pages/proc_uninstalling-che.adoc
+++ b/modules/install/pages/proc_uninstalling-che.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Remove {prod-short} and all related user data from your {orch-name} cluster when you no longer need the platform or want to perform a clean reinstallation.
 
+include::partial$snip_persona-admin.adoc[]
+
 [WARNING]
 ====
 Uninstalling {prod-short} removes all {prod-short}-related user data.

--- a/modules/install/pages/proc_verifying-the-installation.adoc
+++ b/modules/install/pages/proc_verifying-the-installation.adoc
@@ -9,6 +9,8 @@
 [role="_abstract"]
 Confirm that {prod-short} is operational before onboarding users by checking the Operator pod, the `CheCluster` status, and the dashboard URL.
 
+include::partial$snip_persona-admin.adoc[]
+
 .Prerequisites
 
 * You have installed {prod-short} on an {orch-name} cluster.

--- a/modules/install/pages/ref_permissions-to-install-che-on-openshift-using-cli.adoc
+++ b/modules/install/pages/ref_permissions-to-install-che-on-openshift-using-cli.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Apply this `ClusterRole` to the service account or user to grant the minimum permissions required for a `{prod-cli}`-based installation of {prod-short}.
 
+include::partial$snip_persona-admin.adoc[]
+
 [source,yaml,subs="+quotes,+attributes"]
 ----
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/install/pages/ref_permissions-to-install-che-on-openshift-using-the-web-console.adoc
+++ b/modules/install/pages/ref_permissions-to-install-che-on-openshift-using-the-web-console.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Apply this `ClusterRole` to the service account or user to grant the minimum permissions required for installing {prod-short} through the {orch-name} web console.
 
+include::partial$snip_persona-admin.adoc[]
+
 [source,yaml,subs="+quotes,+attributes"]
 ----
 apiVersion: rbac.authorization.k8s.io/v1

--- a/modules/install/pages/running-at-scale.adoc
+++ b/modules/install/pages/running-at-scale.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Scaling cloud development environments (CDEs) to thousands of concurrent workspaces imposes high infrastructure demands on etcd storage, Operator memory, and worker node capacity. This topic covers the bottlenecks, tested maximums, and architectural patterns, including multi-cluster deployments, that address these challenges.
 
+include::partial$snip_persona-admin.adoc[]
+
 Such a scale imposes high infrastructure demands and introduces potential bottlenecks that can impact performance and stability. Addressing these challenges requires meticulous planning, strategic architectural choices, monitoring, and continuous optimization.
 
 CDE workloads are particularly complex to scale. The underlying IDE solutions, such as Visual Studio Code - Open Source ("Code - OSS") or JetBrains Gateway, are designed as single-user applications, not as multitenant services.

--- a/modules/install/pages/using-chectl-to-configure-the-checluster-custom-resource-during-installation.adoc
+++ b/modules/install/pages/using-chectl-to-configure-the-checluster-custom-resource-during-installation.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Customize the `CheCluster` Custom Resource during installation so that {prod-short} deploys with your organization's specific settings instead of Operator defaults.
 
+include::partial$snip_persona-admin.adoc[]
+
 
 .Prerequisites
 

--- a/modules/install/partials/snip_persona-admin.adoc
+++ b/modules/install/partials/snip_persona-admin.adoc
@@ -1,0 +1,1 @@
+This page is for platform administrators who install, configure, and manage {prod-short} on {orch-name} clusters. To learn more about common roles and example tasks referenced in {prod-short} documentation, see xref:discover:roles-and-tasks.adoc[].


### PR DESCRIPTION
## Summary

- Add two new procedures for deploying Che using Argo CD (GitOps)
- Update installation overview to include GitOps as a deployment method
- Add "Deploy using GitOps" section to nav (before OpenShift deploy methods)

## What changed

| Action | File |
|--------|------|
| Created | `modules/install/pages/proc_deploying-che-using-gitops.adoc` |
| Created | `modules/install/pages/proc_deploying-che-using-gitops-in-a-restricted-environment.adoc` |
| Modified | `modules/install/pages/con_installation-overview.adoc` |
| Modified | `modules/install/nav.adoc` |

## Why

SME feedback: production deployments use GitOps (Argo CD), not CLI or web console. The GitOps procedure should be the primary installation method.

Two procedures cover:
1. **Connected clusters**: Argo CD pulling from an external Git repo
2. **Air-gapped clusters**: Argo CD pulling from an internal Git repo + mirrored registry

## Cluster testing

Tested end-to-end on OCP 4.21 ROSA cluster (Jul 2, 2026):
- Single Argo CD Application with `SkipDryRunOnMissingResource=true` works
- Operator installs via OLM, CheCluster CR applied after CRD is registered
- Dashboard comes up, Phase: Active

## Downstream alignment

Content body is identical to downstream `devspaces-documentation` procedures on the `gitops-install-procedures` branch. Only metadata wrappers differ (`:_content-type:` vs `:_mod-docs-content-type:`, no `_{context}` suffixes, Antora xrefs vs `link:` macros).

## Test plan

- [ ] Antora build succeeds
- [ ] nav renders with "Deploy using GitOps" section
- [ ] Vale passes on new files

Made with [Cursor](https://cursor.com)