### PR TITLE
fix: update start_page after Discover module promotion

### DIFF
--- a/publication-builder-antora-playbook.yml
+++ b/publication-builder-antora-playbook.yml
@@ -13,7 +13,7 @@ site:
   title: Eclipse Che Documentation
   # The url property is mandatory to generate the 404 and sitemap files.
   url: https://www.eclipse.org/che
-  start_page: docs:overview:introduction-to-eclipse-che.adoc
+  start_page: docs:discover:what-is-che.adoc
   keys:
     google_analytics: "UA-37306001-2"
 content:


### PR DESCRIPTION
## Summary

- The JTBD Discover work (PR #3131) moved `introduction-to-eclipse-che.adoc` from the `overview` module to the `discover` module as `what-is-che.adoc`.
- Both `main` and `7.120.x` branches already have `start_page: discover:what-is-che.adoc` in their `antora.yml`, but the publication-builder playbook was not updated.
- The stale `start_page: docs:overview:introduction-to-eclipse-che.adoc` generates a WARN, which `failure_level: warn` promotes to exit code 1, breaking the publication builder on every push to `main`.

## Test plan

- [ ] Verify the publication-builder CI passes after merge


Made with [Cursor](https://cursor.com)