### PR TITLE
docs: update dashboard Swagger UI route path

### DIFF
--- a/modules/administration-guide/pages/managing-workloads-using-the-che-server-api.adoc
+++ b/modules/administration-guide/pages/managing-workloads-using-the-che-server-api.adoc
@@ -13,7 +13,7 @@ To manage {prod-short} server and {prod-short} dashboard workloads, use the Swag
 
 * Navigate to the Swagger API web user interface:
  - `pass:c,a,q[{prod-url}]/swagger`   ({prod-short} server)
- - `pass:c,a,q[{prod-url}]/dashboard/api/swagger`   ({prod-short} dashboard)
+ - `pass:c,a,q[{prod-url}]/dashboard/swagger`   ({prod-short} dashboard)
 
 IMPORTANT: DevWorkspace is a k8s object and manipulations should happen on the Kubernetes API level - xref:end-user-guide:managing-workspaces-with-apis.adoc[]
 


### PR DESCRIPTION
## What does this pull request change?

Updates the dashboard Swagger UI route documentation from `/dashboard/api/swagger` to `/dashboard/swagger`.

This reflects the route change implemented in eclipse-che/che-dashboard#1579, which separates API documentation from API endpoints for better organization and consistency.

## What issues does this pull request fix or reference?

- https://github.com/eclipse-che/che-dashboard/pull/1579
- https://github.com/eclipse-che/che/issues/23894

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.