### PR TITLE
fix: backport DOMAIN__SUFFIX YAML formatting fix to 7.120.x

### DIFF
--- a/modules/administration-guide/pages/configuring-workspaces-endpoints-base-domain.adoc
+++ b/modules/administration-guide/pages/configuring-workspaces-endpoints-base-domain.adoc
@@ -9,7 +9,7 @@
 
 Learn how to configure the base domain for workspace endpoints.
 By default, {prod-short} Operator automatically detects the base domain. To change it, you need to configure the `CHE_INFRA_OPENSHIFT_ROUTE_HOST_DOMAIN__SUFFIX` property in the `CheCluster` Custom Resource.
-[source,yaml,subs="+quotes"]
+[source,yaml]
 ----
 spec:
   components:


### PR DESCRIPTION
Cherry-pick of #3161 to the 7.120.x release branch.

Removes `+quotes` from the YAML source block so that `__` in `CHE_INFRA_OPENSHIFT_ROUTE_HOST_DOMAIN__SUFFIX` is not interpreted as AsciiDoc italic markers. Uses a callout instead for the placeholder value.


Made with [Cursor](https://cursor.com)