### PR TITLE
fix: disable broken RedHat.NoGerundsInTitles Vale rule

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -32,6 +32,9 @@ SkippedScopes = script, style, pre, figure, code, tt, blockquote, listingblock, 
 # IBM Style Guide (IBM)
 # Generic (Vale)
 BasedOnStyles = CheDocs,RedHat
+# Disabled: upstream packaging bug — RedHat.zip v664+ ships the rule but not
+# the Tengo script it depends on. See: https://github.com/redhat-documentation/vale-at-red-hat/pull/1046
+RedHat.NoGerundsInTitles = NO
 
 # Ignore attributes definition, id statements
 TokenIgnores = (:[^\n]+: [^\n]+), (\[id=[^\n]+)


### PR DESCRIPTION
## Problem

The CI pipeline (`Build and validate`) is failing on `main` with:

```
E100: script 'NoGerundsInTitles.tengo' not found
```

This started after [RedHat Vale style v664](https://github.com/redhat-documentation/vale-at-red-hat/releases/tag/v664) was released on Jul 13, 2026. The new `NoGerundsInTitles.yml` rule references a Tengo action script (`NoGerundsInTitles.tengo`) that is not included in the `RedHat.zip` package — the script lives at `.vale/styles/config/actions/` in the upstream repo but the release workflow only zips the `RedHat/` directory.

## Fix

Disable `RedHat.NoGerundsInTitles` in `.vale.ini` until the upstream packaging bug is fixed.

## Upstream fix

https://github.com/redhat-documentation/vale-at-red-hat/pull/1046

Once the upstream fix is released, this workaround can be reverted and the rule re-enabled.


Made with [Cursor](https://cursor.com)