### PR TITLE
fix: restore Vale control directives to HTML passthrough format

### DIFF
--- a/modules/install/pages/proc_installing-che-on-openshift-using-the-web-console.adoc
+++ b/modules/install/pages/proc_installing-che-on-openshift-using-the-web-console.adoc
@@ -59,11 +59,7 @@ See link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/user
 
 .Verification
 
-// vale RedHat.Spelling = NO
-
 . In *{prod} instance Specification*, go to *{prod-checluster}*, landing on the *Details* tab.
-
-// vale RedHat.Spelling = YES
 
 . Under *Message*, check that there is *None*, which means no errors.
 


### PR DESCRIPTION
## Summary

- Removes Vale control directives (`// vale RedHat.Spelling = NO/YES`) that trigger `RedHat.Spacing` errors in CI
- The `{prod-checluster}` attribute these directives were suppressing only produces a spelling warning (not an error), so the directives are unnecessary

## Root cause

The `RedHat.Spacing` rule catches the text "RedHat.Spelling" inside the Vale control directive itself, interpreting it as two improperly joined words. This happens in both formats:
- `// vale RedHat.Spelling = NO` (AsciiDoc comment -- not recognized as a Vale directive)
- `pass:[<!-- vale RedHat.Spelling = NO -->]` (HTML passthrough -- the rule fires before the directive is parsed)

Removing the directives entirely resolves the circular problem. The underlying `{prod-checluster}` text only triggers a warning, which does not fail the build.

## Test plan

- [ ] Publication builder CI passes (0 errors)
- [ ] Vale linting workflow passes
- [ ] "Build and validate pull request" workflow passes