### PR TITLE
fix: remove Vale control directives that trigger RedHat.Spacing errors

### DIFF
--- a/modules/install/pages/proc_installing-che-on-openshift-using-the-web-console.adoc
+++ b/modules/install/pages/proc_installing-che-on-openshift-using-the-web-console.adoc
@@ -59,11 +59,7 @@ See link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/user
 
 .Verification
 
-pass:[<!-- vale RedHat.Spelling = NO -->]
-
 . In *{prod} instance Specification*, go to *{prod-checluster}*, landing on the *Details* tab.
-
-pass:[<!-- vale RedHat.Spelling = YES -->]
 
 . Under *Message*, check that there is *None*, which means no errors.
 


### PR DESCRIPTION
## Summary

Backport of #3167 to `7.120.x`.

Removes `pass:[<!-- vale RedHat.Spelling = NO/YES -->]` lines that cause the publication builder to fail.

## Why the publication builder fails on 7.120.x

1. `tools/validate_language_changes.sh` diffs against `origin/main`
2. After #3167 merged to `main` (removing these directives), the file on `7.120.x` now differs from `main`
3. Vale lints the file, sees "RedHat.Spelling" text inside the directives, and `RedHat.Spacing` flags it as an error
4. 2 errors → exit code 1 → build fails

## Why this fix works

- Removing the directives eliminates the 2 errors
- The `{prod-checluster}` text these directives were suppressing only produces a spelling **warning**, not an error
- Vale exits 0 when only warnings are present → build passes

## Test plan

- [ ] Publication builder CI passes on `7.120.x` (0 errors)


Made with [Cursor](https://cursor.com)