### PR TITLE
fix: escape shell variables in cluster-roles source blocks

### DIFF
--- a/modules/administration-guide/examples/snip_che-configuring-cluster-roles-for-users.adoc
+++ b/modules/administration-guide/examples/snip_che-configuring-cluster-roles-for-users.adoc
@@ -32,7 +32,7 @@ $ {orch-cli} apply -f - <<EOF
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: ${USER_ROLES}
+  name: $\{USER_ROLES}
   labels:
     app.kubernetes.io/part-of: che.eclipse.org
 rules:
@@ -56,17 +56,17 @@ $ {orch-cli} apply -f - <<EOF
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: ${USER_ROLES}-operator
+  name: $\{USER_ROLES}-operator
   labels:
     app.kubernetes.io/part-of: che.eclipse.org
 subjects:
   - kind: ServiceAccount
     name: che-operator
-    namespace: ${OPERATOR_NAMESPACE}
+    namespace: $\{OPERATOR_NAMESPACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ${USER_ROLES}
+  name: $\{USER_ROLES}
 EOF
 
 ----
@@ -76,7 +76,7 @@ EOF
 [source,bash,subs="+quotes,+macros,+attributes"]
 ----
 $ {orch-cli} patch checluster eclipse-che \
-  --patch '{"spec": {"components": {"cheServer": {"clusterRoles": ["'${USER_ROLES}'"]}}}}' \
+  --patch '{"spec": {"components": {"cheServer": {"clusterRoles": ["'$\{USER_ROLES}'"]}}}}' \
   --type=merge -n eclipse-che
 ----
 
@@ -85,7 +85,7 @@ $ {orch-cli} patch checluster eclipse-che \
 [source,bash,subs="+quotes,+macros,+attributes"]
 ----
 $ {orch-cli} patch checluster eclipse-che \
-  --patch '{"spec": {"devEnvironments": {"user": {"clusterRoles": ["'${USER_ROLES}'"]}}}}' \
+  --patch '{"spec": {"devEnvironments": {"user": {"clusterRoles": ["'$\{USER_ROLES}'"]}}}}' \
   --type=merge -n eclipse-che
 ----
 
@@ -99,7 +99,7 @@ $ {orch-cli} patch checluster eclipse-che \
 +
 [source,bash,subs="+quotes,+macros,+attributes"]
 ----
-$ {orch-cli} get clusterrole ${USER_ROLES}
+$ {orch-cli} get clusterrole $\{USER_ROLES}
 ----
 
 [role="_additional-resources"]


### PR DESCRIPTION
## Summary

- Escape shell variables `${USER_ROLES}` and `${OPERATOR_NAMESPACE}` in cluster-roles source blocks to prevent Asciidoctor from resolving them as AsciiDoc attributes

## Root cause

PR #3159 added `+attributes` to source blocks that contain shell variables. This was needed so `{orch-cli}` resolves correctly (replacing hardcoded `kubectl`). But it also caused Asciidoctor to try resolving `${USER_ROLES}` and `${OPERATOR_NAMESPACE}` as attributes, producing "missing attribute" warnings that fail the publication builder.

## Fix

Escape with backslash (`$\{USER_ROLES}`, `$\{OPERATOR_NAMESPACE}`) so Asciidoctor renders them literally while still resolving `{orch-cli}` and `{prod-operator}`.


Made with [Cursor](https://cursor.com)