### PR TITLE
docs: Document operator-managed network policies

### DIFF
--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -1,108 +1,14 @@
-:_content-type: CONCEPT
+:_content-type: ASSEMBLY
 :description: Configuring network policies
-:keywords: administration guide, configuring, namespace, network policy, network policies, multitenant isolation
+:keywords: administration guide, configuring, namespace, network policy, network policies, multitenant isolation, openshift
 :navtitle: Configuring network policies
 :page-aliases: installation-guide:configuring-network-policies.adoc
 
-[id="configuring-networking-policies"]
+[id="configuring-network-policies"]
 = Configuring network policies
 
-By default, all Pods in a {orch-name} cluster can communicate with each other even if they are in different namespaces.
-In the context of {prod-short}, this makes it possible for a workspace Pod in one user {orch-namespace} to send traffic to another workspace Pod in a different user {orch-namespace}.
+include::partial$con_network-policies.adoc[leveloffset=+1]
 
-For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
-However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in user {orch-namespace}s.
+include::partial$proc_enabling-operator-managed-network-policies.adoc[leveloffset=+1]
 
-.Prerequisites
-* The {orch-name} cluster has network restrictions such as multitenant isolation.
-
-.Procedure
-* Apply the `allow-from-{prod-namespace}` NetworkPolicy to each user {orch-namespace}.
-The `allow-from-{prod-namespace}` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
-+
-.`allow-from-{prod-namespace}.yaml`
-====
-[source,yaml,subs="+quotes,attributes"]
-----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-    name: allow-from-{prod-namespace}
-spec:
-    ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-                kubernetes.io/metadata.name: {prod-namespace}   <1>
-    podSelector: {}   <2>
-    policyTypes:
-    - Ingress
-----
-<1> The {prod-short} namespace.
-The default is `{prod-namespace}`.
-<2> The empty `podSelector` selects all Pods in the {orch-namespace}.
-====
-+
-* OPTIONAL: In case you applied link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/network_security/network-policy#multitenant-network-policy[Configuring multitenant isolation with network policy], you also must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`.
-The `allow-from-openshift-apiserver` NetworkPolicy allows incoming traffic from `openshift-apiserver` namespace to the `devworkspace-webhook-server` enabling webhooks.
-The `allow-from-workspaces-namespaces` NetworkPolicy allows incoming traffic from each user project to `che-gateway` pod.
-+
-.`allow-from-openshift-apiserver.yaml`
-====
-[source,yaml,subs="+quotes,attributes"]
-----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-from-openshift-apiserver
-  namespace: {prod-namespace}   <1>
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: devworkspace-webhook-server   <2>
-  ingress:
-    - from:
-        - podSelector: {}
-          namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: openshift-apiserver
-  policyTypes:
-    - Ingress
-----
-<1> The {prod-short} namespace.
-The default is `{prod-namespace}`.
-<2> The `podSelector` only selects devworkspace-webhook-server pods
-====
-+
-.`allow-from-workspaces-namespaces.yaml`
-====
-[source,yaml,subs="+quotes,attributes"]
-----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-from-workspaces-namespaces
-  namespace: {prod-namespace}   <1>
-spec:
-  podSelector: {}   <2>
-  ingress:
-    - from:
-        - podSelector: {}
-          namespaceSelector:
-            matchLabels:
-              app.kubernetes.io/component: workspaces-namespace
-  policyTypes:
-    - Ingress
-----
-<1> The {prod-short} namespace.
-The default is `{prod-namespace}`.
-<2> The empty `podSelector` selects all pods in the {prod-short} namespace.
-====
-+
-
-.Additional resources
-* xref:configuring-namespace-provisioning.adoc[]
-
-* link:https://kubernetes.io/docs/concepts/security/multi-tenancy/#network-isolation[Network isolation]
-
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/network_security/network-policy#multitenant-network-policy[Configuring multitenant isolation with network policy]
+include::partial$proc_configuring-network-policies-manually.adoc[leveloffset=+1]

--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -1,11 +1,13 @@
 :_content-type: ASSEMBLY
 :description: Configuring network policies
 :keywords: administration guide, configuring, namespace, network policy, network policies, multitenant isolation, openshift
-:navtitle: Configuring network policies
+:navtitle: Configure network policies
 :page-aliases: installation-guide:configuring-network-policies.adoc
 
 [id="configuring-network-policies"]
-= Configuring network policies
+= Configure network policies
+
+Network policies control Pod-to-Pod communication in a {orch-name} cluster. On OpenShift, the {prod-short} Operator can manage NetworkPolicy resources automatically. Alternatively, you can create them manually.
 
 include::partial$con_network-policies.adoc[leveloffset=+1]
 

--- a/modules/administration-guide/partials/con_network-policies.adoc
+++ b/modules/administration-guide/partials/con_network-policies.adoc
@@ -1,5 +1,3 @@
-// configuring-network-policies
-
 [id="network-policies"]
 = Network policies
 
@@ -7,3 +5,7 @@ By default, all Pods in a {orch-name} cluster can communicate with each other ev
 In the context of {prod-short}, this makes it possible for a workspace Pod in one user {orch-namespace} to send traffic to another workspace Pod in a different user {orch-namespace}.
 
 Network policies restrict network traffic to only the flows required by {prod-short} components and workspaces.
+
+On OpenShift, the {prod-short} Operator can automatically create and manage the required NetworkPolicy resources. This is the recommended approach because the operator keeps policies synchronized as namespaces are created and deleted.
+
+Alternatively, if the operator-managed policies do not fit your requirements, or if you are running {prod-short} on {kubernetes}, you can create NetworkPolicy resources manually.

--- a/modules/administration-guide/partials/con_network-policies.adoc
+++ b/modules/administration-guide/partials/con_network-policies.adoc
@@ -1,0 +1,9 @@
+// configuring-network-policies
+
+[id="network-policies"]
+= Network policies
+
+By default, all Pods in a {orch-name} cluster can communicate with each other even if they are in different namespaces.
+In the context of {prod-short}, this makes it possible for a workspace Pod in one user {orch-namespace} to send traffic to another workspace Pod in a different user {orch-namespace}.
+
+Network policies restrict network traffic to only the flows required by {prod-short} components and workspaces.

--- a/modules/administration-guide/partials/proc_configuring-network-policies-manually.adoc
+++ b/modules/administration-guide/partials/proc_configuring-network-policies-manually.adoc
@@ -1,0 +1,102 @@
+// configuring-network-policies
+
+[id="configuring-network-policies-manually"]
+= Configuring network policies manually
+
+If the operator-managed network policies do not fit your requirements, or if you are running {prod-short} on {kubernetes}, you can create NetworkPolicy resources manually.
+
+For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
+However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in user {orch-namespace}s.
+
+.Prerequisites
+* The {orch-name} cluster has network restrictions such as multitenant isolation.
+
+.Procedure
+* Apply the `allow-from-{prod-namespace}` NetworkPolicy to each user {orch-namespace}.
+The `allow-from-{prod-namespace}` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
++
+.`allow-from-{prod-namespace}.yaml`
+====
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+    name: allow-from-{prod-namespace}
+spec:
+    ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+                kubernetes.io/metadata.name: {prod-namespace}   <1>
+    podSelector: {}   <2>
+    policyTypes:
+    - Ingress
+----
+<1> The {prod-short} namespace.
+The default is `{prod-namespace}`.
+<2> The empty `podSelector` selects all Pods in the {orch-namespace}.
+====
++
+* OPTIONAL: In case you applied link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/network_security/network-policy#multitenant-network-policy[Configuring multitenant isolation with network policy], you also must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`.
+The `allow-from-openshift-apiserver` NetworkPolicy allows incoming traffic from `openshift-apiserver` namespace to the `devworkspace-webhook-server` enabling webhooks.
+The `allow-from-workspaces-namespaces` NetworkPolicy allows incoming traffic from each user project to `che-gateway` pod.
++
+.`allow-from-openshift-apiserver.yaml`
+====
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-apiserver
+  namespace: {prod-namespace}   <1>
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: devworkspace-webhook-server   <2>
+  ingress:
+    - from:
+        - podSelector: {}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-apiserver
+  policyTypes:
+    - Ingress
+----
+<1> The {prod-short} namespace.
+The default is `{prod-namespace}`.
+<2> The `podSelector` only selects devworkspace-webhook-server pods
+====
++
+.`allow-from-workspaces-namespaces.yaml`
+====
+[source,yaml,subs="+quotes,attributes"]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-workspaces-namespaces
+  namespace: {prod-namespace}   <1>
+spec:
+  podSelector: {}   <2>
+  ingress:
+    - from:
+        - podSelector: {}
+          namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/component: workspaces-namespace
+  policyTypes:
+    - Ingress
+----
+<1> The {prod-short} namespace.
+The default is `{prod-namespace}`.
+<2> The empty `podSelector` selects all pods in the {prod-short} namespace.
+====
+
+.Additional resources
+* xref:configuring-namespace-provisioning.adoc[]
+
+* link:https://kubernetes.io/docs/concepts/security/multi-tenancy/#network-isolation[Network isolation]
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/network_security/network-policy#multitenant-network-policy[Configuring multitenant isolation with network policy]

--- a/modules/administration-guide/partials/proc_configuring-network-policies-manually.adoc
+++ b/modules/administration-guide/partials/proc_configuring-network-policies-manually.adoc
@@ -1,18 +1,16 @@
-// configuring-network-policies
-
 [id="configuring-network-policies-manually"]
-= Configuring network policies manually
+= Configure network policies manually
 
 If the operator-managed network policies do not fit your requirements, or if you are running {prod-short} on {kubernetes}, you can create NetworkPolicy resources manually.
 
-For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
+For security, configure multitenant isolation by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
 However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in user {orch-namespace}s.
 
 .Prerequisites
 * The {orch-name} cluster has network restrictions such as multitenant isolation.
 
 .Procedure
-* Apply the `allow-from-{prod-namespace}` NetworkPolicy to each user {orch-namespace}.
+. Apply the `allow-from-{prod-namespace}` NetworkPolicy to each user {orch-namespace}.
 The `allow-from-{prod-namespace}` NetworkPolicy allows incoming traffic from the {prod-short} namespace to all Pods in the user {orch-namespace}.
 +
 .`allow-from-{prod-namespace}.yaml`
@@ -38,7 +36,7 @@ The default is `{prod-namespace}`.
 <2> The empty `podSelector` selects all Pods in the {orch-namespace}.
 ====
 +
-* OPTIONAL: In case you applied link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/network_security/network-policy#multitenant-network-policy[Configuring multitenant isolation with network policy], you also must apply `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`.
+. Optional: If you configured link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp4-ver}/html/network_security/network-policy#multitenant-network-policy[multitenant isolation with network policy], apply the `allow-from-openshift-apiserver` and `allow-from-workspaces-namespaces` NetworkPolicies to `{prod-namespace}`.
 The `allow-from-openshift-apiserver` NetworkPolicy allows incoming traffic from `openshift-apiserver` namespace to the `devworkspace-webhook-server` enabling webhooks.
 The `allow-from-workspaces-namespaces` NetworkPolicy allows incoming traffic from each user project to `che-gateway` pod.
 +

--- a/modules/administration-guide/partials/proc_enabling-operator-managed-network-policies.adoc
+++ b/modules/administration-guide/partials/proc_enabling-operator-managed-network-policies.adoc
@@ -1,0 +1,87 @@
+// configuring-network-policies
+
+[id="enabling-operator-managed-network-policies"]
+= Enabling operator-managed network policies
+
+On OpenShift, the {prod-short} Operator can automatically create and manage NetworkPolicy resources for both the {prod-short} {orch-namespace} and user workspace {orch-namespace}s.
+This feature is controlled by the `spec.networking.networkPolicy.enabled` field in the CheCluster custom resource and is disabled by default.
+
+When enabled, the operator creates the following NetworkPolicy resources:
+
+.NetworkPolicy resources in the {prod-short} {orch-namespace}
+[cols="1,2", options="header"]
+|===
+| Name | Description
+
+| `allow-from-same-namespace`
+| Allows ingress traffic between {prod-short} Pods in the same {orch-namespace}.
+
+| `allow-from-workspaces`
+| Allows ingress traffic from user workspace {orch-namespace}s.
+
+| `allow-from-openshift-ingress`
+| Allows ingress traffic from the OpenShift ingress {orch-namespace}.
+
+| `allow-from-openshift-monitoring`
+| Allows ingress traffic from the OpenShift monitoring {orch-namespace}.
+
+| `allow-from-{prod-id-short}-operator`
+| Allows ingress traffic from the operator Pod to {prod-short} components.
+
+| `allow-all-egress`
+| Allows all egress traffic from {prod-short} Pods.
+|===
+
+.NetworkPolicy resources in each user workspace {orch-namespace}
+[cols="1,2", options="header"]
+|===
+| Name | Description
+
+| `allow-from-same-namespace`
+| Allows ingress traffic between Pods in the same {orch-namespace}.
+
+| `allow-from-{prod-namespace}`
+| Allows ingress traffic from the {prod-short} {orch-namespace}.
+
+| `allow-from-devworkspace-operator`
+| Allows ingress traffic from the {devworkspace} operator.
+
+| `allow-from-openshift-monitoring`
+| Allows ingress traffic from the OpenShift monitoring {orch-namespace}.
+
+| `allow-from-openshift-ingress`
+| Allows ingress traffic from the OpenShift ingress {orch-namespace}.
+
+| `allow-all-egress`
+| Allows all egress traffic from workspace Pods.
+|===
+
+.Prerequisites
+* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
+* An instance of {prod-short} running on OpenShift.
+
+.Procedure
+. Enable operator-managed network policies:
++
+[source,shell,subs="+quotes,+attributes"]
+----
+{orch-cli} patch checluster/{prod-checluster} \
+  --namespace {prod-namespace} \
+  --type merge \
+  --patch '{"spec":{"networking":{"networkPolicy":{"enabled":true}}}}'
+----
+
+.Verification
+. Verify that the NetworkPolicy resources are created in the {prod-short} {orch-namespace}:
++
+[source,shell,subs="+quotes,+attributes"]
+----
+{orch-cli} get networkpolicies -n {prod-namespace}
+----
++
+. Start a workspace and verify that the NetworkPolicy resources are created in the user {orch-namespace}:
++
+[source,shell,subs="+quotes,+attributes"]
+----
+{orch-cli} get networkpolicies -n __<user_namespace>__
+----

--- a/modules/administration-guide/partials/proc_enabling-operator-managed-network-policies.adoc
+++ b/modules/administration-guide/partials/proc_enabling-operator-managed-network-policies.adoc
@@ -1,12 +1,40 @@
-// configuring-network-policies
-
 [id="enabling-operator-managed-network-policies"]
-= Enabling operator-managed network policies
+= Enable operator-managed network policies
 
 On OpenShift, the {prod-short} Operator can automatically create and manage NetworkPolicy resources for both the {prod-short} {orch-namespace} and user workspace {orch-namespace}s.
 This feature is controlled by the `spec.networking.networkPolicy.enabled` field in the CheCluster custom resource and is disabled by default.
 
-When enabled, the operator creates the following NetworkPolicy resources:
+.Prerequisites
+* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
+* An instance of {prod-short} running on OpenShift.
+
+.Procedure
+. Enable operator-managed network policies:
++
+[source,shell,subs="+quotes,+attributes"]
+----
+{orch-cli} patch checluster/{prod-checluster} \
+  --namespace {prod-namespace} \
+  --type merge \
+  --patch '{"spec":{"networking":{"networkPolicy":{"enabled":true}}}}'
+----
+
+.Verification
+. Verify that the NetworkPolicy resources are created in the {prod-short} {orch-namespace}:
++
+[source,shell,subs="+quotes,+attributes"]
+----
+{orch-cli} get networkpolicies -n {prod-namespace}
+----
++
+. Start a workspace and verify that the NetworkPolicy resources are created in the user {orch-namespace}:
++
+[source,shell,subs="+quotes,+attributes"]
+----
+{orch-cli} get networkpolicies -n __<user_namespace>__
+----
+
+After enabling, the operator creates the following resources:
 
 .NetworkPolicy resources in the {prod-short} {orch-namespace}
 [cols="1,2", options="header"]
@@ -56,32 +84,5 @@ When enabled, the operator creates the following NetworkPolicy resources:
 | Allows all egress traffic from workspace Pods.
 |===
 
-.Prerequisites
-* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
-* An instance of {prod-short} running on OpenShift.
-
-.Procedure
-. Enable operator-managed network policies:
-+
-[source,shell,subs="+quotes,+attributes"]
-----
-{orch-cli} patch checluster/{prod-checluster} \
-  --namespace {prod-namespace} \
-  --type merge \
-  --patch '{"spec":{"networking":{"networkPolicy":{"enabled":true}}}}'
-----
-
-.Verification
-. Verify that the NetworkPolicy resources are created in the {prod-short} {orch-namespace}:
-+
-[source,shell,subs="+quotes,+attributes"]
-----
-{orch-cli} get networkpolicies -n {prod-namespace}
-----
-+
-. Start a workspace and verify that the NetworkPolicy resources are created in the user {orch-namespace}:
-+
-[source,shell,subs="+quotes,+attributes"]
-----
-{orch-cli} get networkpolicies -n __<user_namespace>__
-----
+.Additional resources
+* link:https://kubernetes.io/docs/concepts/services-networking/network-policies/[Kubernetes network policies]

--- a/modules/secure/pages/security-best-practices.adoc
+++ b/modules/secure/pages/security-best-practices.adoc
@@ -206,7 +206,7 @@ Implementing network policies allows you to:
 * Control ingress and egress traffic to and from workspace pods
 * Limit the attack surface by denying unauthorized network access
 
-When configuring network policies for {prod}, ensure that pods in the {prod-short} namespace can still communicate with pods in user namespaces. This communication is required for proper functionality. For detailed instructions on configuring network policies, see Additional resources.
+On OpenShift, the {prod-short} Operator can automatically manage NetworkPolicy resources for the {prod-short} namespace and user workspace namespaces. For detailed instructions on configuring network policies, see Additional resources.
 
 == Security in disconnected and air-gapped deployments
 


### PR DESCRIPTION
## What does this pull request change?

Updates the "Configuring network policies" article to document the new operator-managed NetworkPolicy feature introduced in [che-operator#2169](https://github.com/eclipse-che/che-operator/pull/2169).

## What issues does this pull request fix or reference?

- https://github.com/eclipse-che/che-operator/pull/2169

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.