### PR TITLE
docs: document operator-managed network policies

### DIFF
--- a/modules/administration-guide/pages/configuring-network-policies.adoc
+++ b/modules/administration-guide/pages/configuring-network-policies.adoc
@@ -1,4 +1,4 @@
-:_content-type: CONCEPT
+:_content-type: PROCEDURE
 :description: Configuring network policies
 :keywords: administration guide, configuring, namespace, network policy, network policies, multitenant isolation
 :navtitle: Configuring network policies
@@ -12,6 +12,108 @@ In the context of {prod-short}, this makes it possible for a workspace Pod in on
 
 For security, multitenant isolation could be configured by using NetworkPolicy objects to restrict all incoming communication to Pods in a user {orch-namespace}.
 However, Pods in the {prod-short} {orch-namespace} must be able to communicate with Pods in user {orch-namespace}s.
+
+[id="operator-managed-network-policies"]
+== Operator-managed network policies
+
+On OpenShift clusters, {prod-short} can automatically create and manage NetworkPolicy resources for the {prod-short} {orch-namespace} and user workspace {orch-namespace}s. This feature is disabled by default.
+
+When enabled, the operator creates the following fine-grained NetworkPolicy resources:
+
+.NetworkPolicy resources in the {prod-short} {orch-namespace}
+[cols="1,2",options="header"]
+|===
+|Policy name |Description
+
+|`allow-from-same-namespace`
+|Allows ingress traffic between {prod-short} pods in the same {orch-namespace}.
+
+|`allow-from-workspaces`
+|Allows ingress traffic from user workspace {orch-namespace}s.
+
+|`allow-from-openshift-ingress`
+|Allows ingress traffic from the OpenShift ingress {orch-namespace}.
+
+|`allow-from-openshift-monitoring`
+|Allows ingress traffic from the OpenShift monitoring {orch-namespace}.
+
+|`allow-from-{prod-id-short}-operator`
+|Allows ingress traffic from the operator pod to {prod-short} components.
+
+|`allow-all-egress`
+|Allows all egress traffic from {prod-short} pods.
+|===
+
+.NetworkPolicy resources in each user workspace {orch-namespace}
+[cols="1,2",options="header"]
+|===
+|Policy name |Description
+
+|`allow-from-{prod-namespace}`
+|Allows ingress traffic from the {prod-short} {orch-namespace}.
+
+|`allow-from-same-namespace`
+|Allows ingress traffic between pods in the same {orch-namespace}.
+
+|`allow-from-devworkspace-operator`
+|Allows ingress traffic from the {devworkspace} operator.
+
+|`allow-from-openshift-monitoring`
+|Allows ingress traffic from the OpenShift monitoring {orch-namespace}.
+
+|`allow-from-openshift-ingress`
+|Allows ingress traffic from the OpenShift ingress {orch-namespace}.
+
+|`allow-all-egress`
+|Allows all egress traffic from workspace pods.
+|===
+
+.Prerequisites
+
+* An active `{orch-cli}` session with administrative permissions to the destination OpenShift cluster. See {orch-cli-link}.
+
+* An instance of {prod-short} running in OpenShift.
+
+.Procedure
+
+. Enable operator-managed network policies:
++
+[source,subs="+quotes,attributes"]
+----
+{orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} \
+  --type='merge' -p \
+  '{"spec":{"networking":{"networkPolicy":{"enabled":true}}}}'
+----
+
+.Verification
+
+. Verify NetworkPolicy resources are created in the {prod-short} {orch-namespace}:
++
+[source,subs="+quotes,attributes"]
+----
+{orch-cli} get networkpolicies -n {prod-namespace}
+----
+
+. Start a workspace and verify NetworkPolicy resources are created in the user {orch-namespace}:
++
+[source,subs="+quotes,attributes"]
+----
+{orch-cli} get networkpolicies -n __<user_namespace>__
+----
+
+To disable operator-managed network policies and remove all managed NetworkPolicy resources:
+
+[source,subs="+quotes,attributes"]
+----
+{orch-cli} patch checluster/{prod-checluster} -n {prod-namespace} \
+  --type='merge' -p \
+  '{"spec":{"networking":{"networkPolicy":{"enabled":false}}}}'
+----
+
+[id="manually-configuring-network-policies"]
+== Manually configuring network policies
+
+If you do not use operator-managed network policies, you can manually create NetworkPolicy objects to restrict incoming communication to Pods in a user {orch-namespace}.
 
 .Prerequisites
 * The {orch-name} cluster has network restrictions such as multitenant isolation.

--- a/modules/secure/pages/security-best-practices.adoc
+++ b/modules/secure/pages/security-best-practices.adoc
@@ -33,7 +33,7 @@ For Git OAuth setup and for restricting platform access, see Additional resource
 
 These additional measures strengthen your security posture but are not required:
 
-* *Network policies.* Control ingress and egress traffic between workspace pods to limit the attack surface.
+* *Network policies.* Enable operator-managed network policies on OpenShift to restrict ingress and egress traffic, or manually configure NetworkPolicy objects to limit the attack surface.
 * *Resource quotas and limit ranges.* Prevent resource abuse by setting per-project consumption constraints.
 * *Extension management.* Restrict IDE extensions to trusted sources, especially in air-gapped environments.
 * *Self-signed certificates.* Import custom TLS certificates if your Git server or artifact repositories use internal certificate authorities.
@@ -206,7 +206,7 @@ Implementing network policies allows you to:
 * Control ingress and egress traffic to and from workspace pods
 * Limit the attack surface by denying unauthorized network access
 
-When configuring network policies for {prod}, ensure that pods in the {prod-short} namespace can still communicate with pods in user namespaces. This communication is required for proper functionality. For detailed instructions on configuring network policies, see Additional resources.
+On OpenShift, you can enable operator-managed network policies by setting `spec.networking.networkPolicy.enabled` to `true` in the CheCluster custom resource. The operator then creates fine-grained ingress and egress NetworkPolicy resources in both the {prod-short} namespace and user workspace namespaces. When configuring network policies for {prod} manually, ensure that pods in the {prod-short} namespace can still communicate with pods in user namespaces. This communication is required for proper functionality. For detailed instructions on configuring network policies, see Additional resources.
 
 == Security in disconnected and air-gapped deployments
 


### PR DESCRIPTION
## Summary

- Documents the new `spec.networking.networkPolicy.enabled` CheCluster field introduced in [che-operator#2169](https://github.com/eclipse-che/che-operator/pull/2169)
- Adds an "Operator-managed network policies" section to the configuring-network-policies page with reference tables listing all created NetworkPolicy resources
- Includes procedures for enabling, verifying, and disabling operator-managed network policies
- Updates the security best practices page to reference the new operator-managed approach

## Test plan

- [ ] Verify AsciiDoc renders correctly via Antora preview
- [ ] Verify attribute substitutions (`{prod-short}`, `{orch-namespace}`, etc.) resolve correctly
- [ ] Review that the policy names in the tables match the actual operator implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)