### PR TITLE
fix: update stale xref to observe module after #3152 merge

### DIFF
--- a/modules/optimize/pages/what-you-can-optimize.adoc
+++ b/modules/optimize/pages/what-you-can-optimize.adoc
@@ -47,4 +47,4 @@ Consider optimization when you observe:
 
 * xref:caching-images-for-faster-workspace-start.adoc[]
 * xref:configuring-autoscaling.adoc[]
-* xref:administration-guide:monitoring-che.adoc[]
+* xref:observe:monitoring-che.adoc[]


### PR DESCRIPTION
The Observe promotion PR #3152 moved `monitoring-che.adoc` from `administration-guide` to `observe`, but one cross-module xref in `modules/optimize/pages/what-you-can-optimize.adoc` was not updated.

This caused the Antora build to fail:
```
ERROR (asciidoctor): target of xref not found: administration-guide:monitoring-che.adoc
    file: modules/optimize/pages/what-you-can-optimize.adoc:50
```

**Fix:** `administration-guide:monitoring-che.adoc` → `observe:monitoring-che.adoc`

Made with [Cursor](https://cursor.com)