### PR TITLE
fix: convert ARM64 gateway override from NOTE to conditional step

### DIFF
--- a/modules/install/examples/snip_che-arm64-openshift-gateway-images.adoc
+++ b/modules/install/examples/snip_che-arm64-openshift-gateway-images.adoc
@@ -1,11 +1,9 @@
 :_content-type: SNIPPET
 
-[NOTE]
-====
-On ARM64 (AArch64) OpenShift clusters, you must override the gateway sidecar images after installing the {prod} Operator, because the default images are not available for ARM64.
-
-To patch the {prod} Operator subscription, run the following commands:
-
+. If you are deploying on an ARM64 (AArch64) cluster, override the gateway sidecar images by patching the {prod} Operator subscription:
++
+The default gateway sidecar images are not available for ARM64.
++
 [source,shell,subs="+quotes,+attributes"]
 ----
 ECLIPSE_CHE_SUBSCRIPTION=$(
@@ -40,4 +38,3 @@ ECLIPSE_CHE_SUBSCRIPTION_NAMESPACE=$(
     }
   }'
 ----
-====

--- a/modules/install/pages/proc_installing-che-on-openshift-using-cli.adoc
+++ b/modules/install/pages/proc_installing-che-on-openshift-using-cli.adoc
@@ -34,6 +34,8 @@ $ {prod-cli} server:delete
 $ {prod-cli} server:deploy --platform openshift
 ----
 
+include::example$snip_che-arm64-openshift-gateway-images.adoc[]
+
 .Verification
 
 . Verify the {prod-short} instance status:

--- a/modules/install/pages/proc_installing-che-on-openshift-using-the-web-console.adoc
+++ b/modules/install/pages/proc_installing-che-on-openshift-using-the-web-console.adoc
@@ -57,6 +57,8 @@ If you want to onboard link:https://docs.openshift.com/container-platform/{ocp4-
 See link:https://docs.openshift.com/container-platform/{ocp4-ver}/operators/user/olm-creating-apps-from-installed-operators.html[Creating applications from installed Operators].
 ====
 
+include::example$snip_che-arm64-openshift-gateway-images.adoc[]
+
 .Verification
 
 . In *{prod} instance Specification*, go to *{prod-checluster}*, landing on the *Details* tab.


### PR DESCRIPTION
## Problem

The ARM64 gateway sidecar override was formatted as a `[NOTE]` block in `snip_che-arm64-openshift-gateway-images.adoc`. However, it contains imperative actions (commands users must run on ARM64 clusters), making it a procedure step rather than supplementary information.

Additionally, the snippet was orphaned in `modules/administration-guide/examples/` — it was not included in any page.

## Solution

- **Converted** the snippet from a `[NOTE]` block to a numbered conditional step: "If you are deploying on an ARM64 (AArch64) cluster, override the gateway sidecar images..."
- **Moved** the snippet from `administration-guide/examples/` to `install/examples/`
- **Added** the include in both install procedures:
  - `proc_installing-che-on-openshift-using-cli.adoc`
  - `proc_installing-che-on-openshift-using-the-web-console.adoc`
- **Placed** in the Procedure section (after deploy step, before Verification)

## Why

Notes should contain supplementary information. Content with imperative commands ("you must override", "run the following commands") is a procedure step. This change:
- Fixes DITA/AEM conversion: maps to `<step importance="optional">` instead of `<note>` inside `<result>`
- Ensures the ARM64 override is visible in the numbered step list
- Restores the orphaned snippet to actual use

## Files changed

| File | Change |
|------|--------|
| `modules/install/examples/snip_che-arm64-openshift-gateway-images.adoc` | Moved from admin-guide, converted to step format |
| `modules/install/pages/proc_installing-che-on-openshift-using-cli.adoc` | Added include |
| `modules/install/pages/proc_installing-che-on-openshift-using-the-web-console.adoc` | Added include |

Signed-off-by: Geetika Trivedi <gtrivedi@redhat.com>

Made with [Cursor](https://cursor.com)