### PR TITLE
procedures: Add CLI Activity Tracker configuration documentation

### DIFF
--- a/modules/administration-guide/nav.adoc
+++ b/modules/administration-guide/nav.adoc
@@ -20,6 +20,7 @@
 *** xref:configuring-workspaces-nodeselector.adoc[]
 *** xref:configuring-allowed-urls-for-cloud-development-environments.adoc[]
 *** xref:enabling-container-run-capabilities.adoc[]
+*** xref:configuring-cli-activity-tracker.adoc[]
 ** xref:configuring-networking.adoc[]
 *** xref:configuring-network-policies.adoc[]
 *** xref:configuring-che-hostname.adoc[]

--- a/modules/administration-guide/pages/configuring-cli-activity-tracker.adoc
+++ b/modules/administration-guide/pages/configuring-cli-activity-tracker.adoc
@@ -1,0 +1,100 @@
+:_content-type: PROCEDURE
+:description: Configuring the CLI Activity Tracker to prevent workspace idling during active CLI processes.
+:keywords: administration-guide, cli-activity-tracker, workspace, idling, idle, timeout
+:navtitle: Configuring the CLI Activity Tracker
+:page-aliases:
+
+[id="configuring-cli-activity-tracker"]
+= Configuring the CLI Activity Tracker
+
+The CLI Activity Tracker monitors running CLI processes in workspace containers and prevents workspace idling while those processes are active. As an administrator, you can enable and configure this feature cluster-wide through the `CheCluster` custom resource. The operator propagates these settings as environment variables to all workspace containers.
+
+When the CLI Activity Tracker is enabled, it periodically scans for active CLI processes. If it detects a watched process, it resets the workspace idle timer, preventing the workspace from stopping while unattended tasks such as builds, deployments, or long-running scripts are in progress.
+
+All timing fields are optional. When omitted, the CLI Activity Tracker calculates defaults dynamically based on the workspace idle timeout.
+
+.Prerequisites
+
+* An active `{orch-cli}` session with administrative permissions to the destination {orch-name} cluster. See {orch-cli-link}.
+
+.Procedure
+
+. Enable the CLI Activity Tracker:
++
+[source,shell,subs="+quotes,+attributes,+macros"]
+----
+{orch-cli} patch checluster {prod-checluster} \
+  --namespace {prod-namespace} \
+  --type merge \
+  --patch '{
+    "spec": {
+      "devEnvironments": {
+        "cliActivityTracker": {
+          "enabled": true
+        }
+      }
+    }
+  }'
+----
+
+. Optional: Configure timing parameters to fine-tune the CLI Activity Tracker behavior:
++
+[source,shell,subs="+quotes,+attributes,+macros"]
+----
+{orch-cli} patch checluster {prod-checluster} \
+  --namespace {prod-namespace} \
+  --type merge \
+  --patch '{
+    "spec": {
+      "devEnvironments": {
+        "cliActivityTracker": {
+          "enabled": true,
+          "secondsOfCheckPeriod": __<check_period>__,
+          "secondsOfActivityWindow": __<activity_window>__,
+          "secondsOfGracePeriod": __<grace_period>__,
+          "secondsOfMaxProcessAge": __<max_process_age>__
+        }
+      }
+    }
+  }'
+----
++
+.CLI Activity Tracker timing parameters
+[cols="1,2", options="header"]
+|===
+| Parameter | Description
+
+| `secondsOfCheckPeriod`
+| How often (in seconds) to scan for active CLI processes.
+
+| `secondsOfActivityWindow`
+| How long (in seconds) to wait for input from interactive processes before considering them idle.
+
+| `secondsOfGracePeriod`
+| Duration (in seconds) during which newly started processes unconditionally prevent idling.
+
+| `secondsOfMaxProcessAge`
+| Safety limit (in seconds). Processes older than this value stop preventing idling.
+|===
+
+. To disable the CLI Activity Tracker, remove the `cliActivityTracker` section or set `enabled` to `false`:
++
+[source,shell,subs="+quotes,+attributes,+macros"]
+----
+{orch-cli} patch checluster {prod-checluster} \
+  --namespace {prod-namespace} \
+  --type merge \
+  --patch '{
+    "spec": {
+      "devEnvironments": {
+        "cliActivityTracker": {
+          "enabled": false
+        }
+      }
+    }
+  }'
+----
+
+.Additional resources
+
+* xref:end-user-guide:proc_preventing-workspace-idling-for-long-running-commands.adoc[]

--- a/modules/end-user-guide/pages/proc_preventing-workspace-idling-for-long-running-commands.adoc
+++ b/modules/end-user-guide/pages/proc_preventing-workspace-idling-for-long-running-commands.adoc
@@ -10,7 +10,9 @@
 [role="_abstract"]
 Prevent a workspace from stopping while long-running CLI tools such as `helm`, `odo`, or `sleep` are active, so that unattended tasks can complete without interruption.
 
-The CLI Watcher periodically checks for running processes that match the commands you specify. When it detects an active watched command, it resets the workspace idle timer. This configuration works entirely in user space and does not require administrator privileges.
+The CLI Activity Tracker periodically checks for running processes that match the commands you specify. When it detects an active watched command, it resets the workspace idle timer. This configuration works entirely in user space and does not require administrator privileges.
+
+NOTE: An administrator can enable and configure the CLI Activity Tracker at the cluster level. See xref:administration-guide:configuring-cli-activity-tracker.adoc[].
 
 .Prerequisites
 


### PR DESCRIPTION
## What does this pull request change?

Adds a new administration guide article documenting how to configure the CLI Activity Tracker at the cluster level via the CheCluster custom resource. The CLI Activity Tracker monitors running CLI processes in workspace containers and prevents workspace idling while those processes are active.

The new article covers:
- Enabling the CLI Activity Tracker via `spec.devEnvironments.cliActivityTracker`
- Configuring optional timing parameters (`secondsOfCheckPeriod`, `secondsOfActivityWindow`, `secondsOfGracePeriod`, `secondsOfMaxProcessAge`)
- Disabling the feature

Also updates the existing end-user guide article ("Prevent workspace idling for long-running commands") to cross-reference the new admin-level configuration.

Source PR: https://github.com/eclipse-che/che-operator/pull/2170
Related: https://github.com/eclipse-che/che-machine-exec/pull/376

## What issues does this pull request fix or reference?

- https://github.com/eclipse-che/che-operator/pull/2170
- https://issues.redhat.com/browse/CRW-11940

## Specify the version of the product this pull request applies to

next

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.