### PR TITLE
fix: update vale to 3.17.1 from GitHub releases

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,8 +35,6 @@ LABEL \
 
 # Install system packages
 RUN set -x \
-    && dnf install --assumeyes --quiet dnf-plugins-core \
-    && dnf copr enable --assumeyes --quiet mczernek/vale fedora-42-x86_64 \
     && dnf install --assumeyes --quiet \
     ShellCheck \
     bash \
@@ -57,12 +55,18 @@ RUN set -x \
     tox \
     tree \
     unzip \
-    vale \
     wget \
     which \
     && dnf clean all --quiet \
     && dot -v \
-    && node --version \
+    && node --version
+
+# Install vale from GitHub releases (the COPR repo lags behind upstream)
+ENV VALE_VERSION=3.17.1
+RUN set -x \
+    && wget -q "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" -O /tmp/vale.tar.gz \
+    && tar -xzf /tmp/vale.tar.gz -C /usr/local/bin vale \
+    && rm /tmp/vale.tar.gz \
     && vale --version
 
 # Install Python packages


### PR DESCRIPTION
## Problem

CI fails on the "Count Vale alerts" step with:

```
E100: script 'actions/NoGerundsInTitles.tengo' not found
```

See: https://github.com/eclipse-che/che-docs/actions/runs/31170910918

## Root cause

The `RedHat` Vale style package **v674** (released Aug 6, 2026) added a new rule (`NoGerundsInTitles.yml`) that uses a Tengo script in an `actions/` subdirectory. This is a new Vale feature that requires **vale ≥ 3.16.0**.

The CI container (`quay.io/eclipse/che-docs:next`) installs vale from the Fedora COPR repo (`mczernek/vale`), which ships **vale 3.15.1**. Vale 3.15.1 cannot resolve `actions/NoGerundsInTitles.tengo` and fails with E100.

Timeline:
- **Jul 16, 2026**: RedHat style v673 added `NoGerundsInTitles.yml` with the action block *commented out*
- **Aug 6, 2026**: RedHat style v674 *uncommented* the action block and added `actions/NoGerundsInTitles.tengo`
- **Aug 7, 2026**: CI pulls `latest` RedHat style (v674), vale 3.15.1 fails to find the script

## Fix

Replace the COPR-based vale install with a direct download from GitHub releases, pinned to **vale 3.17.1**.

Benefits:
- No dependency on COPR repo update cycle
- Version pinned for reproducible builds
- Easy to update: change `VALE_VERSION=3.17.1` in the Containerfile

## Changes

- Removed `dnf-plugins-core` and COPR repo setup
- Removed `vale` from the dnf package list
- Added a separate `RUN` step that downloads vale from GitHub releases
- Pinned to vale 3.17.1 (latest stable)

## Verification

Tested locally with vale 3.16.0 — `NoGerundsInTitles` rule works correctly with the `actions/` subdirectory path.

```
$ vale --version
vale version 3.16.0
$ vale sync
SUCCESS  Synced 2 package(s)
$ vale modules/administration-guide/
# NoGerundsInTitles suggestions appear correctly, no E100 errors
```


Made with [Cursor](https://cursor.com)