### PR TITLE
fix: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-and-validate-on-pr.yaml
+++ b/.github/workflows/build-and-validate-on-pr.yaml
@@ -20,7 +20,7 @@ jobs:
     container: "quay.io/eclipse/che-docs:next"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0 # Necessary for git diff in vale step
 
@@ -37,7 +37,7 @@ jobs:
         shell: bash
 
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         env:
           cache-name: cache
         with:
@@ -54,7 +54,7 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > PR_SHA
 
       - name: Upload artifact doc-content
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: doc-content
           path: |

--- a/.github/workflows/build-and-validate-on-push.yaml
+++ b/.github/workflows/build-and-validate-on-push.yaml
@@ -22,7 +22,7 @@ jobs:
     container: "quay.io/eclipse/che-docs:next"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
         run: echo "YEAR_WEEK=$(/bin/date -u +%Y%U)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         env:
           cache-name: cache
         with:
@@ -50,7 +50,7 @@ jobs:
         run: CI=true antora generate antora-playbook-for-development.yml --stacktrace --log-failure-level=error
 
       - name: Upload artifact doc-content
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: doc-content
           path: build/site

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/container-on-pull-request.yml
+++ b/.github/workflows/container-on-pull-request.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0 # Necessary for git diff in vale step
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Build and verify the container
         run: tools/build-and-verify-container.sh

--- a/.github/workflows/preview-sticky-comment.yml
+++ b/.github/workflows/preview-sticky-comment.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: create
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: |

--- a/.github/workflows/publish-netlify.yml
+++ b/.github/workflows/publish-netlify.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download doc-content artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@07ab29fd4a977ae4d2b275087cf67563dfdf0295 # v9
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           name: doc-content
@@ -38,7 +38,7 @@ jobs:
           echo "pr_sha=$(<content/PR_SHA)" >> $GITHUB_OUTPUT
 
       - name: Publish preview netlify
-        uses: netlify/actions/cli@master
+        uses: netlify/actions/cli@3185065f4ab2f6df6f2ef41ee013626e1c02a426 # master
         id: netlify-publish
         with:
           args: deploy --dir=content/build/site --functions=functions
@@ -47,7 +47,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
       - name: Update status comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ steps.vars.outputs.pr_number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
       - name: Check existing tags
@@ -43,7 +43,7 @@ jobs:
             fi
           fi
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.9
       - name: Set up yq
@@ -51,11 +51,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install yq
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/try-in-web-ide.yaml
+++ b/.github/workflows/try-in-web-ide.yaml
@@ -20,14 +20,14 @@ jobs:
     steps:
       - name: Try in Web IDE
         id: try-in-web-ide
-        uses: redhat-actions/try-in-web-ide@main
+        uses: redhat-actions/try-in-web-ide@f8e7861005a44bc2af3c9bb333a696906a86ee4e # main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add_comment: true
           add_status: false
       - name: Try in Web IDE - development version
         id: try-in-web-ide-next
-        uses: redhat-actions/try-in-web-ide@main
+        uses: redhat-actions/try-in-web-ide@f8e7861005a44bc2af3c9bb333a696906a86ee4e # main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           add_comment: true

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Install Asciidoctor
         run: sudo apt-get install -y asciidoctor
       - name: Vale Linter
-        uses: errata-ai/vale-action@reviewdog
+        uses: errata-ai/vale-action@518a9136acc6e6668ce7c00d367051e0941e87ff # reviewdog
         with:
           vale_flags: "--minAlertLevel=error"
           fail_on_error: true


### PR DESCRIPTION
## Summary

Pin every GitHub Actions reference to an immutable commit SHA to mitigate supply chain attacks like the [tj-actions/changed-files compromise (CVE-2025-30066)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-github-action-cve-2025-30066).

**Before:** All action references used mutable version tags (`@v3`, `@v4`) or branch names (`@main`, `@master`, `@reviewdog`), which can be retroactively modified by attackers.

**After:** Every `uses:` line references a specific commit SHA with a version comment for readability:
```yaml
# Before
uses: actions/checkout@v3

# After
uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
```

### Changes across 9 workflow files (26 action references):

| Action | Old ref | New pinned ref |
|--------|---------|---------------|
| `actions/checkout` | `@v3` | SHA `# v4` |
| `actions/cache` | `@v3` | SHA `# v4` |
| `actions/upload-artifact` | `@v4` | SHA `# v4` |
| `actions/setup-python` | `@v4` | SHA `# v5` |
| `docker/setup-qemu-action` | `@v2` | SHA `# v3` |
| `docker/setup-buildx-action` | `@v2` | SHA `# v3` |
| `docker/login-action` | `@v2` | SHA `# v3` |
| `marocchino/sticky-pull-request-comment` | `@v2` | SHA `# v2` |
| `dawidd6/action-download-artifact` | `@v2` | SHA `# v9` |
| `netlify/actions/cli` | `@master` | SHA `# master` |
| `errata-ai/vale-action` | `@reviewdog` | SHA `# reviewdog` |
| `redhat-actions/try-in-web-ide` | `@main` | SHA `# main` |

Existing Dependabot configuration will manage future SHA updates automatically.

**Ref:** https://gitlab.eclipse.org/security/vulnerability-reports/-/work_items/273

## Test plan

- [ ] CI workflows pass on this PR
- [ ] Verify Dependabot can process SHA-pinned action references

Made with [Cursor](https://cursor.com)