### PR TITLE
fix: pin GitHub Actions to commit SHAs in publication-builder

### DIFF
--- a/.github/workflows/publication-builder.yaml
+++ b/.github/workflows/publication-builder.yaml
@@ -30,7 +30,7 @@ jobs:
     container: "quay.io/eclipse/che-docs:next"
     steps:
       - name: Checkout publication-builder branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: publication-builder
 
@@ -47,7 +47,7 @@ jobs:
         shell: bash
 
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         env:
           cache-name: cache
         with:
@@ -59,7 +59,7 @@ jobs:
         run: tools/publication-builder.sh
 
       - name: Commit artifact to publication branch
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d # v3
         with:
           commit_message: "Publication at ${{ steps.get-date.outputs.timestamp }}"
           force_orphan: true # publish branch with only the latest commit


### PR DESCRIPTION
## Summary

Pin the 3 GitHub Actions references in `publication-builder.yaml` to immutable commit SHAs. This is a companion to #3186 (which covers the `main` branch).

This workflow is higher-risk because it uses `CHE_BOT_GITHUB_TOKEN` (a long-lived bot token with repo write access).

| Action | Old ref | New pinned ref |
|--------|---------|---------------|
| `actions/checkout` | `@v3` | SHA `# v4` |
| `actions/cache` | `@v3` | SHA `# v4` |
| `peaceiris/actions-gh-pages` | `@v3` | SHA `# v3` |

**Ref:** https://gitlab.eclipse.org/security/vulnerability-reports/-/work_items/273

## Test plan

- [ ] Publication builder workflow runs successfully after merge

Made with [Cursor](https://cursor.com)