### PR TITLE
fix: resolve Vale error in configuring-ai-providers

### DIFF
--- a/modules/administration-guide/pages/configuring-ai-providers.adoc
+++ b/modules/administration-guide/pages/configuring-ai-providers.adoc
@@ -120,7 +120,7 @@ See link:https://github.com/che-incubator/che-ai-tool-images[che-incubator/che-a
 <7> Environment variable name for the API key. The dashboard creates a {kubernetes} Secret using this name as the data key.
 <8> Optional. Provider IDs pre-selected in the AI Selector widget for new workspaces.
 
-. Create the `ConfigMap` in the `{prod-namespace}` namespace with the required labels:
+. Create the `ConfigMap` in the `{prod-namespace}` with the required labels:
 +
 [subs="+quotes,+attributes"]
 ----


### PR DESCRIPTION
## Summary

Remove redundant word "namespace" after `{prod-namespace}` attribute to fix the `CheDocs.Attributes` Vale error that is breaking the publication builder.

**Before:** `. Create the \`ConfigMap\` in the \`{prod-namespace}\` namespace with the required labels:`

**After:** `. Create the \`ConfigMap\` in the \`{prod-namespace}\` with the required labels:`

The attribute `{prod-namespace}` already resolves to the namespace name (e.g. `openshift-devspaces`), so the word "namespace" after it is redundant and triggers Vale rule `CheDocs.Attributes`.

This error has been causing the `publication-builder` and `call-publication-builder` workflows to fail since Aug 14, 2026.

## Test plan

- [ ] Publication builder workflow passes after merge

Made with [Cursor](https://cursor.com)